### PR TITLE
fix(protos): build.rs will panic properly when command call 'flatc ..…

### DIFF
--- a/protos/build.rs
+++ b/protos/build.rs
@@ -1,3 +1,4 @@
+use core::panic;
 use prost_build;
 use std::io::Write;
 use std::ops::Deref;
@@ -100,7 +101,7 @@ mod flatbuffers_generated;
             flatbuffers_generated_mod_rs_file.write_all(b";\n")?;
             flatbuffers_generated_mod_rs_file.flush()?;
 
-            Command::new("flatc")
+            let output = Command::new("flatc")
                 .arg("-o")
                 .arg(&output_dir_final)
                 .arg("--rust")
@@ -114,6 +115,10 @@ mod flatbuffers_generated;
                     "Failed to generate file by flatbuffers {}.",
                     output_file_name
                 ));
+
+            if !output.status.success() {
+                panic!("{}", String::from_utf8(output.stderr).unwrap());
+            }
 
             let output_file_path = output_dir_final.join(output_file_name);
             println!("fbs_file: {}", output_file_path.to_str().unwrap());

--- a/protos/proto/models.fbs
+++ b/protos/proto/models.fbs
@@ -29,14 +29,14 @@ table Row {
     fields: [RowField];
 }
 
-enum WALEntryType: ubyte {
+enum WALEntryType: byte {
     Write = 1,
     Delete,
     DeleteRange,
 }
 
 table WriteWALEntry {
-    Rows: [Row];
+    rows: [Row];
 }
 
 struct DeleteWALEntryItems {
@@ -61,7 +61,7 @@ union WALEntryUnion {
 }
 
 table WALEntry {
-    type: WALEntryType;
+    type: WALEntryType = Write;
     series_id: uint64;
     value: WALEntryUnion;
 }

--- a/protos/src/lib.rs
+++ b/protos/src/lib.rs
@@ -1,4 +1,3 @@
 #[allow(unused_imports)]
-
 mod generated;
 pub use generated::*;


### PR DESCRIPTION
….' and  return_code is 1

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)