### PR TITLE
fix(bug): docker-stop takes a long time.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -320,7 +320,7 @@ func (s *Server) initTSDBStore() error {
 	}
 
 	for _, service := range s.services {
-		fmt.Println("shit service")
+
 		if err := service.Open(); err != nil {
 			return fmt.Errorf("open service: %s", err)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -163,7 +163,7 @@ func (s *Server) Close() {
 		_ = s.listener.Close()
 	}
 
-	//service is no use,It's nil.
+	//services is no use,It's nil.
 	for _, service := range s.services {
 		_ = service.Close()
 	}
@@ -318,7 +318,7 @@ func (s *Server) initTSDBStore() error {
 	if err := s.subscriber.Open(); err != nil {
 		return fmt.Errorf("open subscriber: %s", err)
 	}
-	fmt.Println("3612783628163215")
+
 	for _, service := range s.services {
 		fmt.Println("shit service")
 		if err := service.Open(); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -80,6 +80,7 @@ type Server struct {
 	coordinatorService *coordinator.Service
 	snapshotterService *snapshotter.Service
 
+	//this field is nil.We don't append services to it.
 	services []interface {
 		WithLogger(log *zap.Logger)
 		Open() error
@@ -157,6 +158,12 @@ func (s *Server) Open() error {
 }
 
 func (s *Server) Close() {
+
+	if s.listener != nil {
+		_ = s.listener.Close()
+	}
+
+	//service is no use,It's nil.
 	for _, service := range s.services {
 		_ = service.Close()
 	}
@@ -184,6 +191,26 @@ func (s *Server) Close() {
 	if s.continuousQuerierService != nil {
 		_ = s.continuousQuerierService.Close()
 	}
+
+	if s.hintedHandoff != nil {
+		_ = s.hintedHandoff.Close()
+	}
+
+	if s.monitor != nil {
+		_ = s.monitor.Close()
+	}
+
+	//if s.snapshotterService != nil {
+	//	_ = s.snapshotterService.Close()
+	//}
+
+	//_ = s.tcpListener.Close()
+	//s.tcpMux.Close()
+	//
+	//_ = s.httpListener.Close()
+	//s.httpMux.Close()
+	//
+	//_ = s.httpServer.Close()
 
 	close(s.closing)
 }
@@ -291,8 +318,9 @@ func (s *Server) initTSDBStore() error {
 	if err := s.subscriber.Open(); err != nil {
 		return fmt.Errorf("open subscriber: %s", err)
 	}
-
+	fmt.Println("3612783628163215")
 	for _, service := range s.services {
+		fmt.Println("shit service")
 		if err := service.Open(); err != nil {
 			return fmt.Errorf("open service: %s", err)
 		}
@@ -418,7 +446,7 @@ func (s *Server) startHTTPServer() {
 	}, nil)
 
 	if err := s.httpMux.Serve(); err != nil {
-		s.Logger.Info("start http/tcp server stop", zap.Error(err))
+		s.Logger.Info("start to stop http/tcp server", zap.Error(err))
 	}
 }
 


### PR DESCRIPTION
Closes #226 

This PR could test in this way.
first use `docker build -t . [imageName]` to build a image locally.
then use `docker run` to start the image.
finally use `docker stop` to stop it. 

