### PR TITLE
fix #465: tsm-writer now write the input datablock directly

### DIFF
--- a/tskv/src/compaction/compact.rs
+++ b/tskv/src/compaction/compact.rs
@@ -372,7 +372,7 @@ mod test {
         },
     };
 
-    use models::FieldId;
+    use models::{FieldId, Timestamp};
     use utils::BloomFilter;
 
     use crate::{

--- a/tskv/src/main.rs
+++ b/tskv/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
     }
 
     if let Some(p) = tsm_path {
-        print!("Path: {}", p);
+        println!("Path: {}", p);
         tskv::print_tsm_statistics(p);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #465 .

 # Rationale for this change

# What changes are included in this PR?
1. Fix bugs in #465 
2. The tsm-writer now write the input datablock directly.

# Are there any user-facing changes?
No.
