### PR TITLE
feat(compaction) #433: fixs bugs when compact tsm_files with tombstones

### DIFF
--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -242,7 +242,7 @@ impl TsKv {
                                                                          .map(|f| f.field_id())
                                                                          .collect();
                                 let mut tombstone =
-                                    TsmTombstone::with_tsm_file_id(&path, column_file.file_id())?;
+                                    TsmTombstone::open_for_write(&path, column_file.file_id())?;
                                 tombstone.add_range(&field_ids, min, max)?;
                                 tombstone.flush()?;
                             }

--- a/tskv/src/main.rs
+++ b/tskv/src/main.rs
@@ -1,30 +1,42 @@
 use std::env;
 
-use tskv;
-
 const ARG_PRINT: &str = "print";
 const ARG_TSM: &str = "--tsm";
+const ARG_TOMBSTONE: &str = "--tombstone";
 
 /// # Example
-/// tskv print --tsm <tsm_path>
+/// tskv print [--tsm <tsm_path>] [--tombstone]
+///
+/// - --tsm <tsm_path> print statistics for .tsm file at <tsm_path> .
+/// - --tombstone also print tombstone for every field_id in .tsm file.
 fn main() {
-    let mut args = env::args();
+    let mut args = env::args().peekable();
     let mut tsm_path: Option<String> = None;
+    let mut show_tombstone = false;
 
-    while let Some(arg) = args.next() {
+    while let Some(arg) = args.peek() {
         // --print [--tsm <path>]
-        if &arg == ARG_PRINT {
-            match args.next() {
-                Some(a) if &a == ARG_TSM => {
-                    tsm_path = args.next();
-                },
-                _ => break,
+        if arg.as_str() == ARG_PRINT {
+            while let Some(print_arg) = args.next() {
+                match print_arg.as_str() {
+                    ARG_TSM => {
+                        tsm_path = args.next();
+                        if tsm_path.is_none() {
+                            println!("Invalid arguments: --tsm <tsm_path>");
+                        }
+                    },
+                    ARG_TOMBSTONE => {
+                        show_tombstone = true;
+                    },
+                    _ => {},
+                }
             }
         }
+        args.next();
     }
 
     if let Some(p) = tsm_path {
-        println!("Path: {}", p);
-        tskv::print_tsm_statistics(p);
+        println!("Path: {}, ShowTombstone: {}", p, show_tombstone);
+        tskv::print_tsm_statistics(p, show_tombstone);
     }
 }

--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -28,7 +28,7 @@ use crate::{
     kv_option::{TseriesFamDesc, TseriesFamOpt},
     memcache::{DataType, MemCache},
     summary::{CompactMeta, VersionEdit},
-    tsm::{ColumnReader, IndexReader, TsmTombstone},
+    tsm::{ColumnReader, IndexReader, TsmReader, TsmTombstone},
     ColumnFileId, TseriesFamilyId, VersionId,
 };
 
@@ -36,10 +36,10 @@ lazy_static! {
     pub static ref FLUSH_REQ: Arc<Mutex<Vec<FlushReq>>> = Arc::new(Mutex::new(vec![]));
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct TimeRange {
-    pub max_ts: i64,
     pub min_ts: i64,
+    pub max_ts: i64,
 }
 
 impl TimeRange {
@@ -47,8 +47,26 @@ impl TimeRange {
         Self { max_ts, min_ts }
     }
 
+    #[inline(always)]
     pub fn overlaps(&self, range: &TimeRange) -> bool {
         !(self.min_ts > range.max_ts || self.max_ts < range.min_ts)
+    }
+
+    #[inline(always)]
+    pub fn includes(&self, other: &TimeRange) -> bool {
+        self.min_ts <= other.min_ts && self.max_ts >= other.max_ts
+    }
+}
+
+impl From<(Timestamp, Timestamp)> for TimeRange {
+    fn from(time_range: (Timestamp, Timestamp)) -> Self {
+        Self { min_ts: time_range.0, max_ts: time_range.1 }
+    }
+}
+
+impl Into<(Timestamp, Timestamp)> for TimeRange {
+    fn into(self) -> (Timestamp, Timestamp) {
+        (self.min_ts, self.max_ts)
     }
 }
 
@@ -182,55 +200,17 @@ impl LevelInfo {
                 continue;
             }
 
-            let mut tomb = HashMap::new();
-            if let Ok(mut tombstone) =
-                TsmTombstone::with_tsm_file_id(GLOBAL_CONFIG.db_path.clone(), file.file_id)
-            {
-                match tombstone.load() {
-                    Ok(_) => {},
-                    Err(e) => {
-                        error!("failed to load tombstone, in case {:?}", e);
-                    },
-                };
-                for i in tombstone.tombstones() {
-                    tomb.insert(i.field_id, TimeRange { min_ts: i.min_ts, max_ts: i.max_ts });
-                }
-            }
-
-            let file = match file_manager::open_file(file.file_path(self.tsf_opt.clone(), tf_id)) {
-                Ok(v) => v,
+            let tsm_reader = match TsmReader::open(file.file_path(self.tsf_opt.clone(), tf_id)) {
+                Ok(tr) => tr,
                 Err(e) => {
-                    error!("failed to get file, path : {:?}, in case {:?}",
-                           file.file_path(self.tsf_opt.clone(), tf_id),
-                           e);
+                    error!("failed to load tombstone, in case {:?}", e);
                     return;
                 },
             };
-            let file = Arc::new(file);
-
-            let index = match IndexReader::open(file.clone()) {
-                Ok(v) => v,
-                Err(e) => {
-                    error!("failed get index reader : {:?}", e);
-                    return;
-                },
-            };
-            for idx in index.iter_opt(field_id) {
-                for blk in idx.block_iterator() {
-                    if blk.min_ts() <= time_range.max_ts && blk.max_ts() >= time_range.min_ts {
-                        let mut cr = ColumnReader::new(file.clone(),
-                                                       idx.block_iterator_opt(time_range.min_ts,
-                                                                              time_range.max_ts));
-                        while let Some(blk_ret) = cr.next() {
-                            if let Ok(mut blk) = blk_ret {
-                                if let Some(del_time_range) = tomb.get(&field_id) {
-                                    // we need to remove greater equal than min_ts and less than
-                                    // min_ts + 1
-                                    blk.exclude(del_time_range.min_ts, del_time_range.max_ts + 1)
-                                }
-                                println!("{:?}", &blk);
-                            }
-                        }
+            for idx in tsm_reader.index_iterator_opt(field_id) {
+                for blk in idx.block_iterator_opt(time_range) {
+                    if let Ok(blk) = tsm_reader.get_data_block(&blk) {
+                        println!("{:?}", &blk);
                     }
                 }
             }
@@ -682,7 +662,7 @@ mod test {
         let file = version.levels_info[1].files[0].clone();
 
         let mut tombstone =
-            TsmTombstone::with_tsm_file_id("dev/db".to_string(), file.file_id).unwrap();
+            TsmTombstone::open_for_write("dev/db".to_string(), file.file_id).unwrap();
         tombstone.add_range(&[0], 0, 0).unwrap();
         tombstone.flush().unwrap();
         tombstone.load().unwrap();

--- a/tskv/src/tsm/writer.rs
+++ b/tskv/src/tsm/writer.rs
@@ -132,7 +132,7 @@ impl IndexBuf {
 
         let mut buf = vec![0_u8; BLOCK_META_SIZE];
         for (_, idx) in self.buf.iter() {
-            idx.encode(&mut buf[..INDEX_META_SIZE]);
+            idx.encode(&mut buf[..INDEX_META_SIZE])?;
             writer.write(&buf[..INDEX_META_SIZE]).context(IOSnafu)?;
             size += 11;
             for blk in idx.blocks.iter() {

--- a/utils/src/bloom_filter.rs
+++ b/utils/src/bloom_filter.rs
@@ -12,8 +12,7 @@ impl BloomFilter {
     pub fn new(m: u64) -> Self {
         let m = Self::pow2(m);
         let l = m as usize >> 3;
-        let mut b: Vec<u8> = Vec::with_capacity(l);
-        b.resize(l, 0);
+        let b: Vec<u8> = vec![0; l];
         Self { b, mask: m - 1 }
     }
 
@@ -43,6 +42,10 @@ impl BloomFilter {
 
     pub fn len(&self) -> usize {
         self.b.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.b.is_empty()
     }
 
     pub fn bytes(&self) -> &[u8] {


### PR DESCRIPTION
# Which issue does this PR close?

Nothing.

 # Rationale for this change

## Refactor

1. Change some `min_ts, max_ts` to `TimeRange`.
2. Some Clippy suggested refactors.

## Fix bugs

When I added some test cases, I find these bugs and fixed them.

```
# When compact files with tombstone
cargo test --package tskv --lib -- compaction::compact::test::test_compaction_4
# In method index_iterator_opt() and block_iterator_opt()
cargo test --package tskv --lib -- tsm::reader::test::test_tsm_reader_2
# When excludes a TimeRange( m, m + 1) in a DataBlock (0, n), n > m > 0.
cargo test --package tskv --lib -- tsm::block
```

# What changes are included in this PR?

## New features

1. Add new argument `--tombstone` for task::main for debug.

# Are there any user-facing changes?

1. TsmTombstone now use `open_for_read()` and `open_for_write()` to get an instance, instead of `with_tsm_file_id`.
2. Tombstone now have a TimeRange field, min_ts & max_ts are removed.
