### PR TITLE
fix(clippy): tseries_family.rs

### DIFF
--- a/query/tests/datafusion.rs
+++ b/query/tests/datafusion.rs
@@ -17,8 +17,8 @@ use datafusion::{
     },
     physical_expr::{planner, PhysicalSortExpr},
     physical_plan::{
-        filter::FilterExec, planner::ExtensionPlanner, ExecutionPlan, Partitioning,
-        PhysicalPlanner, RecordBatchStream, SendableRecordBatchStream, Statistics,
+        filter::FilterExec, ExecutionPlan, Partitioning, RecordBatchStream,
+        SendableRecordBatchStream, Statistics,
     },
     prelude::*,
     scalar::ScalarValue,

--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -20,6 +20,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use trace::{debug, error, info, warn};
 use utils::BloomFilter;
 
+use crate::memcache::MemRaw;
 use crate::{
     compaction::FlushReq,
     direct_io::{File, FileCursor},
@@ -67,9 +68,9 @@ impl From<(Timestamp, Timestamp)> for TimeRange {
     }
 }
 
-impl Into<(Timestamp, Timestamp)> for TimeRange {
-    fn into(self) -> (Timestamp, Timestamp) {
-        (self.min_ts, self.max_ts)
+impl From<TimeRange> for (Timestamp, Timestamp) {
+    fn from(t: TimeRange) -> Self {
+        (t.min_ts, t.max_ts)
     }
 }
 
@@ -275,12 +276,16 @@ impl Version {
     }
 }
 
-pub struct SuperVersion {
-    pub id: u32,
+pub struct CacheGroup {
     pub delta_mut_cache: Arc<RwLock<MemCache>>,
     pub delta_immut_cache: Vec<Arc<RwLock<MemCache>>>,
     pub mut_cache: Arc<RwLock<MemCache>>,
     pub immut_cache: Vec<Arc<RwLock<MemCache>>>,
+}
+
+pub struct SuperVersion {
+    pub id: u32,
+    pub caches: CacheGroup,
     pub cur_version: Arc<RwLock<Version>>,
     pub opt: Arc<TseriesFamOpt>,
     pub version_id: u64,
@@ -289,20 +294,14 @@ pub struct SuperVersion {
 impl SuperVersion {
     pub fn new(
         id: u32,
-        delta_mut_cache: Arc<RwLock<MemCache>>,
-        delta_immut_cache: Vec<Arc<RwLock<MemCache>>>,
-        mut_cache: Arc<RwLock<MemCache>>,
-        immut_cache: Vec<Arc<RwLock<MemCache>>>,
+        caches: CacheGroup,
         cur_version: Arc<RwLock<Version>>,
         opt: Arc<TseriesFamOpt>,
         version_id: u64,
     ) -> Self {
         Self {
             id,
-            delta_mut_cache,
-            delta_immut_cache,
-            mut_cache,
-            immut_cache,
+            caches,
             cur_version,
             opt,
             version_id,
@@ -354,10 +353,12 @@ impl TseriesFamily {
             immut_cache: Default::default(),
             super_version: Arc::new(SuperVersion::new(
                 tf_id,
-                delta_mm,
-                Default::default(),
-                mm,
-                Default::default(),
+                CacheGroup {
+                    delta_mut_cache: delta_mm,
+                    delta_immut_cache: Default::default(),
+                    mut_cache: mm,
+                    immut_cache: Default::default(),
+                },
                 version.clone(),
                 tsf_opt.clone(),
                 0,
@@ -371,25 +372,38 @@ impl TseriesFamily {
     }
 
     pub async fn switch_memcache(&mut self, cache: Arc<RwLock<MemCache>>) {
-        self.super_version.mut_cache.write().switch_to_immutable();
+        self.super_version
+            .caches
+            .mut_cache
+            .write()
+            .switch_to_immutable();
         self.immut_cache.push(self.mut_cache.clone());
-        self.super_version_id.fetch_add(1, Ordering::SeqCst);
-        let vers = SuperVersion::new(
-            self.tf_id,
-            self.delta_mut_cache.clone(),
-            self.delta_immut_cache.clone(),
-            cache.clone(),
-            self.immut_cache.clone(),
-            self.version.clone(),
-            self.opts.clone(),
-            self.super_version_id.load(Ordering::SeqCst),
-        );
-        self.super_version = Arc::new(vers);
+        self.new_super_version();
         self.mut_cache = cache;
     }
 
+    fn new_super_version(&mut self) {
+        self.super_version_id.fetch_add(1, Ordering::SeqCst);
+        self.super_version = Arc::new(SuperVersion::new(
+            self.tf_id,
+            CacheGroup {
+                delta_mut_cache: self.delta_mut_cache.clone(),
+                delta_immut_cache: self.delta_immut_cache.clone(),
+                mut_cache: self.mut_cache.clone(),
+                immut_cache: self.immut_cache.clone(),
+            },
+            self.version.clone(),
+            self.opts.clone(),
+            self.super_version_id.load(Ordering::SeqCst),
+        ))
+    }
+
     pub async fn switch_to_immutable(&mut self) {
-        self.super_version.mut_cache.write().switch_to_immutable();
+        self.super_version
+            .caches
+            .mut_cache
+            .write()
+            .switch_to_immutable();
 
         self.immut_cache.push(self.mut_cache.clone());
         self.mut_cache = Arc::from(RwLock::new(MemCache::new(
@@ -398,18 +412,7 @@ impl TseriesFamily {
             self.seq_no,
             false,
         )));
-        self.super_version_id.fetch_add(1, Ordering::SeqCst);
-        let vers = SuperVersion::new(
-            self.tf_id,
-            self.delta_mut_cache.clone(),
-            self.delta_immut_cache.clone(),
-            self.mut_cache.clone(),
-            self.immut_cache.clone(),
-            self.version.clone(),
-            self.opts.clone(),
-            self.super_version_id.load(Ordering::SeqCst),
-        );
-        self.super_version = Arc::new(vers);
+        self.new_super_version()
     }
 
     pub async fn switch_to_delta_immutable(&mut self) {
@@ -421,18 +424,7 @@ impl TseriesFamily {
             self.seq_no,
             true,
         )));
-        self.super_version_id.fetch_add(1, Ordering::SeqCst);
-        let vers = SuperVersion::new(
-            self.tf_id,
-            self.delta_mut_cache.clone(),
-            self.delta_immut_cache.clone(),
-            self.mut_cache.clone(),
-            self.immut_cache.clone(),
-            self.version.clone(),
-            self.opts.clone(),
-            self.super_version_id.load(Ordering::SeqCst),
-        );
-        self.super_version = Arc::new(vers);
+        self.new_super_version()
     }
 
     async fn wrap_delta_flush_req(&mut self, sender: UnboundedSender<Arc<Mutex<Vec<FlushReq>>>>) {
@@ -443,27 +435,16 @@ impl TseriesFamily {
         info!("delta memcache full or other,switch to immutable");
         self.switch_to_delta_immutable().await;
         let len = self.delta_immut_cache.len();
-        let mut imut = vec![];
+        let mut immut = vec![];
         for i in self.delta_immut_cache.iter() {
             if !i.read().flushed {
-                imut.push(i.clone());
+                immut.push(i.clone());
             }
         }
-        self.delta_immut_cache = imut;
+        self.delta_immut_cache = immut;
 
         if len != self.delta_immut_cache.len() {
-            self.super_version_id.fetch_add(1, Ordering::SeqCst);
-            let vers = SuperVersion::new(
-                self.tf_id,
-                self.delta_mut_cache.clone(),
-                self.delta_immut_cache.clone(),
-                self.mut_cache.clone(),
-                self.immut_cache.clone(),
-                self.version.clone(),
-                self.opts.clone(),
-                self.super_version_id.load(Ordering::SeqCst),
-            );
-            self.super_version = Arc::new(vers);
+            self.new_super_version()
         }
 
         let mut req_mem = vec![];
@@ -504,18 +485,7 @@ impl TseriesFamily {
         self.immut_cache = imut;
 
         if len != self.immut_cache.len() {
-            self.super_version_id.fetch_add(1, Ordering::SeqCst);
-            let vers = SuperVersion::new(
-                self.tf_id,
-                self.delta_mut_cache.clone(),
-                self.delta_immut_cache.clone(),
-                self.mut_cache.clone(),
-                self.immut_cache.clone(),
-                self.version.clone(),
-                self.opts.clone(),
-                self.super_version_id.load(Ordering::SeqCst),
-            );
-            self.super_version = Arc::new(vers);
+            self.new_super_version()
         }
 
         self.immut_ts_min = self.mut_ts_max;
@@ -555,28 +525,24 @@ impl TseriesFamily {
     // version_set when we insert each point
     pub async fn put_mutcache(
         &mut self,
-        fid: FieldId,
-        val: &[u8],
-        dtype: ValueType,
-        seq: u64,
-        ts: Timestamp,
+        raw: &mut MemRaw<'_>,
         sender: UnboundedSender<Arc<Mutex<Vec<FlushReq>>>>,
     ) {
         if self.immut_ts_min == i64::MIN {
-            self.immut_ts_min = ts;
+            self.immut_ts_min = raw.ts;
         }
-        if ts >= self.immut_ts_min {
-            if ts > self.mut_ts_max {
-                self.mut_ts_max = ts;
+        if raw.ts >= self.immut_ts_min {
+            if raw.ts > self.mut_ts_max {
+                self.mut_ts_max = raw.ts;
             }
-            let mut mem = self.super_version.mut_cache.write();
-            let _ = mem.insert_raw(seq, fid, ts, dtype, val);
+            let mut mem = self.super_version.caches.mut_cache.write();
+            let _ = mem.insert_raw(raw);
         } else {
-            let mut delta_mem = self.super_version.delta_mut_cache.write();
-            let _ = delta_mem.insert_raw(seq, fid, ts, dtype, val);
+            let mut delta_mem = self.super_version.caches.delta_mut_cache.write();
+            let _ = delta_mem.insert_raw(raw);
         }
 
-        if self.super_version.mut_cache.read().is_full() {
+        if self.super_version.caches.mut_cache.read().is_full() {
             info!("mut_cache full,switch to immutable");
             self.switch_to_immutable().await;
             if self.immut_cache.len() >= GLOBAL_CONFIG.max_immemcache_num {
@@ -584,7 +550,7 @@ impl TseriesFamily {
             }
         }
 
-        if self.super_version.delta_mut_cache.read().is_full() {
+        if self.super_version.caches.delta_mut_cache.read().is_full() {
             self.wrap_delta_flush_req(sender.clone()).await;
         }
     }
@@ -647,6 +613,7 @@ mod test {
     use tokio::sync::mpsc;
     use trace::info;
 
+    use crate::memcache::MemRaw;
     use crate::{
         compaction::{run_flush_memtable_job, FlushReq},
         context::GlobalContext,
@@ -670,11 +637,13 @@ mod test {
         );
         let (flush_task_sender, flush_task_receiver) = mpsc::unbounded_channel();
         tsf.put_mutcache(
-            0,
-            10_i32.to_be_bytes().as_slice(),
-            ValueType::Integer,
-            0,
-            0,
+            &mut MemRaw {
+                seq: 0,
+                ts: 0,
+                field_id: 0,
+                field_type: ValueType::Integer,
+                val: 10_i32.to_be_bytes().as_slice(),
+            },
             flush_task_sender,
         )
         .await;
@@ -706,11 +675,16 @@ mod test {
         }
 
         let mut mem = MemCache::new(0, 1000, 0, false);
-        mem.insert_raw(0, 0, 0, ValueType::Integer, 10_i64.to_be_bytes().as_slice())
-            .unwrap();
+        mem.insert_raw(&mut MemRaw {
+            seq: 0,
+            ts: 0,
+            field_id: 0,
+            field_type: ValueType::Integer,
+            val: 10_i64.to_be_bytes().as_slice(),
+        })
+        .unwrap();
         let mem = Arc::new(RwLock::new(mem));
-        let mut req_mem = vec![];
-        req_mem.push((0, mem));
+        let req_mem = vec![(0, mem)];
         let flush_seq = Arc::new(Mutex::new(vec![FlushReq {
             mems: req_mem,
             wait_req: 0,

--- a/tskv/src/wal.rs
+++ b/tskv/src/wal.rs
@@ -14,6 +14,7 @@ use tokio::sync::{mpsc::UnboundedSender, oneshot};
 use trace::{debug, error, info, warn};
 use walkdir::IntoIter;
 
+use crate::memcache::MemRaw;
 use crate::{
     byte_utils,
     compaction::FlushReq,
@@ -393,11 +394,13 @@ impl WalManager {
                                             };
                                             // todo: change fbs timestamp to i64
                                             tsf.put_mutcache(
-                                                fid,
-                                                val,
-                                                dtype,
-                                                e.seq,
-                                                p.timestamp() as i64,
+                                                &mut MemRaw {
+                                                    seq: e.seq,
+                                                    ts: p.timestamp() as i64,
+                                                    field_id: fid,
+                                                    field_type: dtype,
+                                                    val,
+                                                },
                                                 flush_task_sender.clone(),
                                             )
                                             .await

--- a/tskv/tests/test_kvcore_interface.rs
+++ b/tskv/tests/test_kvcore_interface.rs
@@ -212,9 +212,11 @@ mod tests {
         let mut fbb = flatbuffers::FlatBufferBuilder::new();
         let points = models_helper::create_random_points_with_delta(&mut fbb, 1);
         fbb.finish(points, None);
-        let points = fbb.finished_data();
-
-        tskv.insert_cache(1, points).await.unwrap();
+        let buf = fbb.finished_data();
+        let ps = flatbuffers::root::<fb_models::Points>(buf)
+            .context(error::InvalidFlatbufferSnafu)
+            .unwrap();
+        tskv.insert_cache(1, &ps).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
1. implement `From<tseries_family::TimeRange>`
2. SupperVersion::new() has too many arguments
3. TseriesFamily::put_mutcache() has too many arguments
4. Reduce duplicated code in kvcore.rs
