### PR TITLE
feature(summary) #446: some refactor about summary.

### DIFF
--- a/tskv/src/compaction/mod.rs
+++ b/tskv/src/compaction/mod.rs
@@ -2,12 +2,15 @@ mod compact;
 mod flush;
 mod picker;
 
+use std::sync::Arc;
+
 pub use compact::*;
 pub use flush::*;
 use parking_lot::RwLock;
 pub use picker::*;
 
 use crate::{
+    kv_option::TseriesFamOpt,
     memcache::MemCache,
     summary::VersionEdit,
     tseries_family::{ColumnFile, Version},
@@ -18,16 +21,18 @@ use crate::{
 pub trait CompactionEngine: Clone + Sync + Send {
     async fn apply(&mut self, edits: Vec<VersionEdit>) -> crate::error::Result<()>;
 }
+
 pub struct CompactReq {
-    files: (LevelId, Vec<std::sync::Arc<ColumnFile>>),
-    version: std::sync::Arc<Version>,
-    tsf_id: TseriesFamilyId,
+    ts_family_id: TseriesFamilyId,
+    ts_family_opt: Arc<TseriesFamOpt>,
+
+    files: Vec<Arc<ColumnFile>>,
+    version: Arc<Version>,
     out_level: LevelId,
 }
 
 #[derive(Debug)]
 pub struct FlushReq {
-    //(tsf id,memcache)
     pub mems: Vec<(TseriesFamilyId, std::sync::Arc<RwLock<MemCache>>)>,
     pub wait_req: u64,
 }

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -21,7 +21,7 @@ use trace::{debug, error, info, trace, warn};
 
 use crate::memcache::MemRaw;
 use crate::{
-    compaction::{run_flush_memtable_job, FlushReq},
+    compaction::{self, run_flush_memtable_job, CompactReq, FlushReq},
     context::GlobalContext,
     error::{self, Result},
     file_manager::{self, FileManager},
@@ -32,12 +32,12 @@ use crate::{
     record_file::Reader,
     summary,
     summary::{Summary, SummaryProcessor, SummaryTask, VersionEdit},
-    tseries_family::{TimeRange, Version},
+    tseries_family::{SuperVersion, TimeRange, Version},
     tsm::TsmTombstone,
     version_set,
     version_set::VersionSet,
     wal::{self, WalEntryType, WalManager, WalTask},
-    Error, Task,
+    Error, Task, TseriesFamilyId,
 };
 
 pub struct Entry {
@@ -52,6 +52,7 @@ pub struct TsKv {
     forward_index: Arc<RwLock<ForwardIndex>>,
 
     flush_task_sender: UnboundedSender<Arc<Mutex<Vec<FlushReq>>>>,
+    compact_task_sender: UnboundedSender<TseriesFamilyId>,
     summary_task_sender: UnboundedSender<SummaryTask>,
 }
 
@@ -59,6 +60,7 @@ impl TsKv {
     pub async fn open(opt: Options) -> Result<Self> {
         let shared_options = Arc::new(opt);
         let (flush_task_sender, flush_task_receiver) = mpsc::unbounded_channel();
+        let (compact_task_sender, compact_task_receiver) = mpsc::unbounded_channel();
         let (version_set, summary) =
             Self::recover(shared_options.clone(), flush_task_sender.clone()).await;
         let mut fidx = ForwardIndex::new(&shared_options.forward_index_conf.path);
@@ -73,13 +75,21 @@ impl TsKv {
             version_set,
             wal_sender,
             flush_task_sender,
+            compact_task_sender: compact_task_sender.clone(),
             summary_task_sender: summary_task_sender.clone(),
         };
         core.run_wal_job(wal_receiver);
         core.run_flush_job(
             flush_task_receiver,
-            summary.global_context(),
-            summary.version_set(),
+            summary.global_context().clone(),
+            summary.version_set().clone(),
+            summary_task_sender.clone(),
+            compact_task_sender.clone(),
+        );
+        core.run_compact_job(
+            compact_task_receiver,
+            summary.global_context().clone(),
+            summary.version_set().clone(),
             summary_task_sender.clone(),
         );
         core.run_summary_job(summary, summary_task_receiver, summary_task_sender);
@@ -151,22 +161,30 @@ impl TsKv {
     }
 
     pub async fn read_point(&self, sid: SeriesId, time_range: &TimeRange, field_id: FieldId) {
-        let version_set = self.version_set.read();
-        if let Some(tsf) = version_set.get_tsfamily_immut(sid) {
+        let mut super_version: Option<Arc<SuperVersion>> = None;
+        {
+            let version_set = self.version_set.read();
+            if let Some(tsf) = version_set.get_tsfamily_immut(sid) {
+                super_version = Some(tsf.super_version());
+            } else {
+                warn!("ts_family with sid {} not found.", sid);
+            }
+        };
+        if let Some(sv) = super_version {
             // get data from memcache
-            if let Some(mem_entry) = tsf.cache().read().data_cache.get(&field_id) {
+            if let Some(mem_entry) = sv.caches.mut_cache.read().data_cache.get(&field_id) {
                 info!("memcache::{}::{}", sid.clone(), field_id);
                 mem_entry.read_cell(time_range);
             }
 
             // get data from delta_memcache
-            if let Some(mem_entry) = tsf.delta_cache().read().data_cache.get(&field_id) {
+            if let Some(mem_entry) = sv.caches.delta_mut_cache.read().data_cache.get(&field_id) {
                 info!("delta memcache::{}::{}", sid.clone(), field_id);
                 mem_entry.read_cell(time_range);
             }
 
             // get data from immut_delta_memcache
-            for mem_cache in tsf.delta_immut_cache().iter() {
+            for mem_cache in sv.caches.delta_immut_cache.iter() {
                 if mem_cache.read().flushed {
                     continue;
                 }
@@ -177,7 +195,7 @@ impl TsKv {
             }
 
             // get data from im_memcache
-            for mem_cache in tsf.im_cache().iter() {
+            for mem_cache in sv.caches.immut_cache.iter() {
                 if mem_cache.read().flushed {
                     continue;
                 }
@@ -188,22 +206,18 @@ impl TsKv {
             }
 
             // get data from levelinfo
-            for level_info in tsf.version().read().levels_info.iter() {
+            for level_info in sv.version.levels_info.iter() {
                 if level_info.level == 0 {
                     continue;
                 }
                 info!("levelinfo::{}::{}", sid.clone(), field_id);
-                level_info.read_columnfile(tsf.tf_id(), field_id, time_range);
+                level_info.read_column_file(sv.ts_family_id, field_id, time_range);
             }
 
             // get data from delta
-            let level_info = &tsf.version().read().levels_info;
-            if !level_info.is_empty() {
-                info!("delta::{}::{}", sid.clone(), field_id);
-                level_info[0].read_columnfile(tsf.tf_id(), field_id, time_range);
-            }
-        } else {
-            warn!("ts_family with sid {} not found.", sid);
+            let level_info = sv.version.levels_info();
+            info!("delta::{}::{}", sid.clone(), field_id);
+            level_info[0].read_column_file(sv.ts_family_id, field_id, time_range);
         }
     }
 
@@ -228,18 +242,24 @@ impl TsKv {
         };
         let path = self.options.db.db_path.clone();
         for series_info in series_infos {
-            let vs = self.version_set.read();
-            if let Some(tsf) = vs.get_tsfamily_immut(series_info.series_id()) {
-                tsf.delete_cache(&TimeRange {
-                    min_ts: min,
-                    max_ts: max,
-                })
-                .await;
-                let version = tsf.version().read();
-                for level in version.levels_info() {
-                    if level.ts_range.overlaps(&timerange) {
+            let mut super_version: Option<Arc<SuperVersion>> = None;
+            {
+                let vs = self.version_set.read();
+                if let Some(tsf) = vs.get_tsfamily_immut(series_info.series_id()) {
+                    tsf.delete_cache(&TimeRange {
+                        min_ts: min,
+                        max_ts: max,
+                    })
+                    .await;
+                    super_version = Some(tsf.super_version())
+                }
+            };
+
+            if let Some(sv) = super_version {
+                for level in sv.version.levels_info() {
+                    if level.time_range.overlaps(&timerange) {
                         for column_file in level.files.iter() {
-                            if column_file.range().overlaps(&timerange) {
+                            if column_file.time_range().overlaps(&timerange) {
                                 let field_ids: Vec<FieldId> = series_info
                                     .field_infos()
                                     .iter()
@@ -316,7 +336,8 @@ impl TsKv {
         mut receiver: UnboundedReceiver<Arc<Mutex<Vec<FlushReq>>>>,
         ctx: Arc<GlobalContext>,
         version_set: Arc<RwLock<VersionSet>>,
-        sender: UnboundedSender<SummaryTask>,
+        summary_task_sender: UnboundedSender<SummaryTask>,
+        compact_task_sender: UnboundedSender<TseriesFamilyId>,
     ) {
         let f = async move {
             while let Some(x) = receiver.recv().await {
@@ -325,7 +346,8 @@ impl TsKv {
                     ctx.clone(),
                     HashMap::new(),
                     version_set.clone(),
-                    sender.clone(),
+                    summary_task_sender.clone(),
+                    compact_task_sender.clone(),
                 )
                 .await
                 .unwrap();
@@ -333,6 +355,36 @@ impl TsKv {
         };
         tokio::spawn(f);
         warn!("Flush task handler started");
+    }
+
+    fn run_compact_job(
+        &self,
+        mut receiver: UnboundedReceiver<TseriesFamilyId>,
+        ctx: Arc<GlobalContext>,
+        version_set: Arc<RwLock<VersionSet>>,
+        summary_task_sender: UnboundedSender<SummaryTask>,
+    ) {
+        tokio::spawn(async move {
+            while let Some(ts_family_id) = receiver.recv().await {
+                if let Some(tsf) = version_set.read().get_tsfamily_by_tf_id(ts_family_id) {
+                    if let Some(compact_req) = tsf.pick_compaction() {
+                        match compaction::run_compaction_job(compact_req, ctx.clone()) {
+                            Ok(version_edits) => {
+                                let (summary_tx, summary_rx) = oneshot::channel();
+                                let ret = summary_task_sender.send(SummaryTask {
+                                    edits: version_edits,
+                                    cb: summary_tx,
+                                });
+                                // TODO Handle summary result using summary_rx.
+                            }
+                            Err(e) => {
+                                error!("Compaction job failed: {}", e);
+                            }
+                        }
+                    }
+                }
+            }
+        });
     }
 
     fn run_summary_job(

--- a/tskv/src/lib.rs
+++ b/tskv/src/lib.rs
@@ -36,7 +36,6 @@ use utils::BloomFilter;
 type ColumnFileId = u64;
 type TseriesFamilyId = u32;
 type LevelId = u32;
-type VersionId = u32;
 
 #[derive(Debug)]
 pub enum Task {

--- a/tskv/src/memcache.rs
+++ b/tskv/src/memcache.rs
@@ -129,6 +129,8 @@ pub struct MemCache {
     tf_id: u32,
     // wal seq number
     pub seq_no: u64,
+    // wal seq number when the MemCache been built
+    min_seq_no: u64,
     // max mem buffer size convert to immemcache
     max_buf_size: u64,
     // block <field_id, buffer>
@@ -151,6 +153,7 @@ impl MemCache {
             max_buf_size: max_size,
             data_cache: cache,
             seq_no: seq,
+            min_seq_no: seq,
             cache_size: 0,
             is_delta,
         }
@@ -201,6 +204,10 @@ impl MemCache {
 
     pub fn tf_id(&self) -> u32 {
         self.tf_id
+    }
+
+    pub fn min_seq_no(&self) -> u64 {
+        self.min_seq_no
     }
 
     pub fn max_buf_size(&self) -> u64 {

--- a/tskv/src/tsm/block.rs
+++ b/tskv/src/tsm/block.rs
@@ -256,8 +256,9 @@ impl DataBlock {
         }
     }
 
-    /// Merges many `DataBlock`s into one `DataBlock`, sorted by timestamp,
-    /// if many (timestamp, value) conflict with the same timestamp, use the last value.
+    /// Merges one or many `DataBlock`s into some `DataBlock` with fixed length,
+    /// sorted by timestamp, if many (timestamp, value) conflict with the same
+    /// timestamp, use the last value.
     pub fn merge_blocks(mut blocks: Vec<Self>, max_block_size: u32) -> Vec<Self> {
         if blocks.is_empty() {
             return vec![];

--- a/tskv/src/tsm/mod.rs
+++ b/tskv/src/tsm/mod.rs
@@ -13,7 +13,7 @@ pub use tombstone::{Tombstone, TsmTombstone};
 pub use writer::*;
 
 // MAX_BLOCK_VALUES is the maximum number of values a TSM block can store.
-const MAX_BLOCK_VALUES: usize = 1000;
+pub(crate) const MAX_BLOCK_VALUES: u32 = 1000;
 
 const INDEX_META_SIZE: usize = 11;
 const BLOCK_META_SIZE: usize = 44;

--- a/tskv/src/tsm/reader.rs
+++ b/tskv/src/tsm/reader.rs
@@ -385,7 +385,6 @@ impl BlockMetaIterator {
         while pos < sli.len() {
             self.block_meta_limit += 1;
             if max_ts < decode_be_i64(&sli[pos + 8..pos + 16]) {
-                // Last data block in time range
                 return;
             } else {
                 pos += BLOCK_META_SIZE;
@@ -580,7 +579,7 @@ pub fn decode_data_block(
     }
 
     // let crc_ts = &self.buf[..4];
-    let mut ts = Vec::with_capacity(MAX_BLOCK_VALUES);
+    let mut ts = Vec::with_capacity(MAX_BLOCK_VALUES as usize);
     timestamp::decode(&buf[4..val_off as usize], &mut ts).context(DecodeSnafu)?;
     // let crc_data = &self.buf[(val_offset - offset) as usize..4];
     let data = &buf[(val_off + 4) as usize..];

--- a/tskv/src/tsm/writer.rs
+++ b/tskv/src/tsm/writer.rs
@@ -483,21 +483,10 @@ mod test {
     #[test]
     fn test_tsm_write_fast() {
         let dir = Path::new(TEST_PATH);
+        #[rustfmt::skip]
         let data: HashMap<FieldId, DataBlock> = HashMap::from([
-            (
-                1,
-                DataBlock::U64 {
-                    ts: vec![2, 3, 4],
-                    val: vec![12, 13, 15],
-                },
-            ),
-            (
-                2,
-                DataBlock::U64 {
-                    ts: vec![2, 3, 4],
-                    val: vec![101, 102, 103],
-                },
-            ),
+            (1, DataBlock::U64 { ts: vec![2, 3, 4], val: vec![12, 13, 15] }),
+            (2, DataBlock::U64 { ts: vec![2, 3, 4], val: vec![101, 102, 103] }),
         ]);
 
         write_to_tsm(&dir, "tsm_write_fast.tsm", &data);
@@ -529,21 +518,10 @@ mod test {
         let file = file_manager::create_file(&tsm_path).unwrap().into_cursor();
         let mut writer = TsmWriter::open(file, 0, false, 0).unwrap();
 
+        #[rustfmt::skip]
         let data = vec![
-            (
-                1,
-                DataBlock::I64 {
-                    ts: ts_1,
-                    val: val_1,
-                },
-            ),
-            (
-                1,
-                DataBlock::I64 {
-                    ts: ts_2,
-                    val: val_2,
-                },
-            ),
+            (1, DataBlock::I64 { ts: ts_1, val: val_1 }),
+            (1, DataBlock::I64 { ts: ts_2, val: val_2 }),
         ];
         for (fid, blk) in data.iter() {
             writer.write_block(*fid, blk).unwrap();

--- a/tskv/src/wal.rs
+++ b/tskv/src/wal.rs
@@ -291,7 +291,7 @@ impl WalManager {
 
     async fn roll_wal_file(&mut self) -> Result<()> {
         if self.current_file.size > SEGMENT_SIZE {
-            let id = self.current_file.id;
+            let id = self.current_file.id + 1;
             let max_sequence = self.current_file.max_sequence;
 
             self.current_file.flush().await?;

--- a/tskv/tests/test_kvcore_interface.rs
+++ b/tskv/tests/test_kvcore_interface.rs
@@ -116,7 +116,7 @@ mod tests {
         fields_id = fields_id[0..l].to_owned();
         tskv.read(
             sids,
-            &TimeRange::new(Local::now().timestamp_millis() + 100, 0),
+            &TimeRange::new(0, Local::now().timestamp_millis() + 100),
             fields_id,
         )
         .await;
@@ -166,7 +166,7 @@ mod tests {
         fields_id = fields_id[0..l].to_owned();
         tskv.read(
             sids.clone(),
-            &TimeRange::new(Local::now().timestamp_millis() + 100, 0),
+            &TimeRange::new(0, Local::now().timestamp_millis() + 100),
             fields_id.clone(),
         )
         .await;
@@ -174,7 +174,7 @@ mod tests {
         tskv.delete_series(sids.clone(), 1, 1).await.unwrap();
         tskv.read(
             sids.clone(),
-            &TimeRange::new(Local::now().timestamp_millis() + 100, 0),
+            &TimeRange::new(0, Local::now().timestamp_millis() + 100),
             fields_id.clone(),
         )
         .await;


### PR DESCRIPTION
# Which issue does this PR close?

# Rationale for this change

## 1. Remove `RwLock` for `Version` and `SuperVersion`.

When a new file created by flush, we want to modify the `Version::levels_info`. When cache is needed in query, we read the `TsFamily::caches`. It's necessary to hold a  `RwLock` for `Version` or `VersionSet` now. #446 #519 

Since the `RwLock` is removed, `Version` and `SuperVersion` become readonly, a better way to modify them is by the **summary write job**. When a series of `VersionEdit` persisted by the **summary write job**,  a new `Version` is created by the old `Version` and `VersionEdit`s. Then replace olds with the news.

## 2. Exchange the two arguments for `TimeRange::new(max_ts, min_ts)`.

Now it's (max_ts, min_ts), different with rust slices(`&slice[min..max]`) and the number axis intervals(`[min, max)`), sometimes it makes puzzles.

# What changes are included in this PR?

## Summary

1. Add min_seq_no in `MemCache`, if it's smaller than Version::last_seq, we can safely remove it.
2. When call Summary::write_summary(), dispatch `VersionEdit`s for each TsFamily (maps TsFamilyId to `VersionEdit`s), then produce new `Version`s and `SuperVersion`s for them.
3. `Version` now can use a series of `VersionEdit` to generate a new `Version`.
4. TsFamily now has an `Arc<Version>` and an `Arc<dyn Picker>`, and some other refactors for pickers.
5. Reduce arguments for VersionEdit::add_file().
6. Implement the Default trait for `CompactMeta`.
7. Exchange the two arguments for TimeRange::new().

# Are there any user-facing changes?
