### PR TITLE
feat(cli) #482: GlobalConfig now use path to init.

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [dependencies]
 trace = {path = "../trace" }
 
-lazy_static = "1.4.0"
+once_cell = "1.10"
 serde = "1.0.138"
 toml = "0.5.9"

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,10 +1,9 @@
 #[gloable-config]
-max_memcache_size = 134217728 # 128 * 1024 * 1024
-max_summary_size = 134217728 # 128 * 1024 * 1024
-max_immemcache_num =  4
+tsfamily_num = 1
 # DBOption
 front_cpu = 2
 back_cpu = 2
+max_summary_size = 134217728 # 128 * 1024 * 1024
 create_if_missing = false
 db_path = "dev/db"
 db_name =  "db"
@@ -20,12 +19,9 @@ compact_trigger = 4
 max_compact_size = 2147483648 # 2 * 1024 * 1024 * 1024
 tsm_dir = "db/tsm/"
 delta_dir = "db/delta/"
-#MemCacheOpt
-tf_id = 0
-seq_no = 0
+max_memcache_size = 134217728 # 128 * 1024 * 1024
+max_immemcache_num =  4
 #SchemaStoreConfig
 schema_store_config_dir = "dev/schema"
-#tsfamily num
-tsfamily_num = 1
 #forward index config
 forward_index_path = "/tmp/test/tskv.fidx"

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1,17 +1,16 @@
 use std::{fs::File, io::prelude::Read};
 
-use lazy_static::lazy_static;
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use trace::debug;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GlobalConfig {
-    pub max_memcache_size: u64,
-    pub max_summary_size: u64,
-    pub max_immemcache_num: usize,
+    pub tsfamily_num: u32,
     // DBOption
     pub front_cpu: usize,
     pub back_cpu: usize,
+    pub max_summary_size: u64,
     pub create_if_missing: bool,
     pub db_path: String,
     pub db_name: String,
@@ -21,36 +20,28 @@ pub struct GlobalConfig {
     pub sync: bool,
     // TseriesFamOpt
     pub max_level: u32,
-    // pub base_file_size: u64,
     pub level_ratio: f64,
     pub base_file_size: u64,
     pub compact_trigger: u32,
     pub max_compact_size: u64,
     pub tsm_dir: String,
     pub delta_dir: String,
-    // MemCacheOpt
-    pub tf_id: u32,
-    pub seq_no: u64,
+    pub max_memcache_size: u64,
+    pub max_immemcache_num: u16,
     // SchemaStoreConfig
     pub schema_store_config_dir: String,
-    // tsfamily num
-    pub tsfamily_num: u32,
+    // ForwardIndex
     pub forward_index_path: String,
 }
 
-impl GlobalConfig {
-    pub const fn max_memcache_size(&self) -> &u64 {
-        &self.max_memcache_size
-    }
-}
-
-lazy_static! {
-    pub static ref GLOBAL_CONFIG: GlobalConfig = {
-        let mut file = File::open("../config/config.toml").unwrap();
+pub fn get_config(path: &str) -> &'static GlobalConfig {
+    static INSTANCE: OnceCell<GlobalConfig> = OnceCell::new();
+    INSTANCE.get_or_init(|| {
+        let mut file = File::open(path).unwrap();
         let mut content = String::new();
         file.read_to_string(&mut content).unwrap();
         let config: GlobalConfig = toml::from_str(&content).unwrap();
         debug!("{:#?}", config);
         config
-    };
+    })
 }

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+config = { path = "../config" }
 protos = { path = "../protos" }
 tskv = { path = "../tskv" }
 async-stream = "0.3"

--- a/tskv/benches/kvcore_bench.rs
+++ b/tskv/benches/kvcore_bench.rs
@@ -5,19 +5,15 @@ use parking_lot::Mutex;
 use snafu::ResultExt;
 use tokio::runtime::Runtime;
 
-use protos::{kv_service::WritePointsRpcRequest, models_helper};
-use tskv::{error, kv_option::WalConfig, TsKv};
+use protos::{kv_service::WritePointsRpcRequest, models as fb_models, models_helper};
+use tskv::{error, TsKv};
 
 async fn get_tskv() -> TsKv {
-    let opt = tskv::kv_option::Options {
-        wal: Arc::new(WalConfig {
-            dir: String::from("/tmp/test_bench/wal"),
-            ..Default::default()
-        }),
-        ..Default::default()
-    };
+    let mut global_config = (*config::get_config("../config/config.toml")).clone();
+    global_config.wal_config_dir = "/tmp/test_bench/wal".to_string();
+    let opt = tskv::kv_option::Options::from(&global_config);
 
-    TsKv::open(opt).await.unwrap()
+    TsKv::open(opt, global_config.tsfamily_num).await.unwrap()
 }
 
 fn test_write(tskv: Arc<Mutex<TsKv>>, request: WritePointsRpcRequest) {

--- a/tskv/src/compaction/flush.rs
+++ b/tskv/src/compaction/flush.rs
@@ -273,11 +273,7 @@ pub async fn run_flush_memtable_job(
         if let Some(tsf) = version_set.read().get_tsfamily_by_tf_id(*tsf_id) {
             if !memtables.is_empty() {
                 // todo: build path by vnode data
-                let cf_opt = tsf_config
-                    .get(&tsf_id)
-                    .cloned()
-                    .unwrap_or(Arc::new(TseriesFamOpt::default()));
-
+                let cf_opt = tsf.options();
                 let path_tsm = cf_opt.tsm_dir(*tsf_id);
                 let path_delta = cf_opt.delta_dir(*tsf_id);
                 let mut job = FlushTask::new(memtables.clone(), *tsf_id, path_tsm, path_delta);

--- a/tskv/src/compaction/picker.rs
+++ b/tskv/src/compaction/picker.rs
@@ -112,6 +112,14 @@ impl LevelCompatContext {
                 Ordering::Greater
             }
         });
+
+        println!("==========Debug(pick_level)1==========");
+        println!("Calculate level scores:");
+        for lvl_score in self.level_scores.iter() {
+            println!("Level-{} | {}", lvl_score.0, lvl_score.1);
+        }
+        println!("==========Debug(pick_level)2==========");
+
         let base_level = self.base_level;
         if let Some((level, score)) = self.level_scores.first() {
             return if *score < 1.0 {

--- a/tskv/src/index/forward_index.rs
+++ b/tskv/src/index/forward_index.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use config::GLOBAL_CONFIG;
+use config::GlobalConfig;
 use models::{FieldId, FieldInfo, SeriesId, SeriesInfo, ValueType};
 use num_traits::ToPrimitive;
 use trace::error;
@@ -263,10 +263,10 @@ pub struct ForwardIndexConfig {
     pub path: String,
 }
 
-impl Default for ForwardIndexConfig {
-    fn default() -> Self {
-        ForwardIndexConfig {
-            path: GLOBAL_CONFIG.forward_index_path.clone(),
+impl From<&GlobalConfig> for ForwardIndexConfig {
+    fn from(config: &GlobalConfig) -> Self {
+        Self {
+            path: config.forward_index_path.clone(),
         }
     }
 }

--- a/tskv/src/tsm/mod.rs
+++ b/tskv/src/tsm/mod.rs
@@ -15,6 +15,7 @@ pub use writer::*;
 // MAX_BLOCK_VALUES is the maximum number of values a TSM block can store.
 pub(crate) const MAX_BLOCK_VALUES: u32 = 1000;
 
+const HEADER_SIZE: usize = 5;
 const INDEX_META_SIZE: usize = 11;
 const BLOCK_META_SIZE: usize = 44;
 const BLOOM_FILTER_SIZE: usize = 64;

--- a/tskv/src/version_set.rs
+++ b/tskv/src/version_set.rs
@@ -3,7 +3,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use config::GLOBAL_CONFIG;
 use parking_lot::RwLock;
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 use trace::error;
@@ -33,9 +32,9 @@ impl VersionSet {
                     let tf = TseriesFamily::new(
                         id,
                         name.clone(),
-                        MemCache::new(id, GLOBAL_CONFIG.max_memcache_size, seq, false),
+                        MemCache::new(id, item.tsf_opt.max_memcache_size, seq, false),
                         ver.clone(),
-                        item.opt.clone(),
+                        item.tsf_opt.clone(),
                     );
                     ts_families.insert(id, tf);
                     ts_families_names.insert(name.clone(), id);
@@ -61,7 +60,7 @@ impl VersionSet {
             Some(tf) => {
                 let mem = Arc::new(RwLock::new(MemCache::new(
                     tf_id,
-                    GLOBAL_CONFIG.max_memcache_size,
+                    tf.options().max_memcache_size,
                     seq,
                     false,
                 )));
@@ -119,12 +118,13 @@ impl VersionSet {
         let tf = TseriesFamily::new(
             tsf_id,
             tsf_name.clone(),
-            MemCache::new(tsf_id, GLOBAL_CONFIG.max_memcache_size, seq_no, false),
+            MemCache::new(tsf_id, opt.max_memcache_size, seq_no, false),
             Arc::new(Version::new(
                 tsf_id,
-                file_id,
                 tsf_name.clone(),
-                LevelInfo::init_levels(),
+                opt.clone(),
+                file_id,
+                LevelInfo::init_levels(opt.clone()),
                 i64::MIN,
             )),
             opt,

--- a/tskv/tests/test_kvcore_interface.rs
+++ b/tskv/tests/test_kvcore_interface.rs
@@ -5,24 +5,21 @@ mod tests {
 
     use chrono::Local;
 
+    use config::get_config;
     use models::SeriesInfo;
     use protos::{kv_service, models as fb_models, models_helper};
     use serial_test::serial;
     use snafu::ResultExt;
     use tokio::sync::{mpsc, oneshot::channel};
     use trace::{debug, error, info, init_default_global_tracing, warn};
-    use tskv::{error, kv_option, kv_option::WalConfig, Task, TimeRange, TsKv};
+    use tskv::{error, kv_option, Task, TimeRange, TsKv};
 
     async fn get_tskv() -> TsKv {
-        let opt = kv_option::Options {
-            wal: Arc::new(WalConfig {
-                dir: String::from("/tmp/test/wal"),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
+        let mut global_config = (*get_config("../config/config.toml")).clone();
+        global_config.wal_config_dir = "/tmp/test/wal".to_string();
+        let opt = kv_option::Options::from(&global_config);
 
-        TsKv::open(opt).await.unwrap()
+        TsKv::open(opt, global_config.tsfamily_num).await.unwrap()
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #482.
Closes #437.

# Rationale for this change

There are a lot code change for for #482.

Changes in this PR make Options like `DBOptoins` can never be shared using `DBOptions::default()`, one alternative is `Arc<DBOptions>`, so #437 can be closed.

# What changes are included in this PR?

1. `GlobalConfig` use `OnceCell` to load the config-path parsed from the command line arguments lazily.
2. Options like `DBOptions` now have a `From<&GlobalConfig>` trait, remove their `Default` trait.
3. Merge `TseriesFamOpt` and `MemCacheOpt`, remove `MemCacheOpt`.4. 
4. Other changes to let their unit-tests run normally.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
