### PR TITLE
feat(compaction) #464: Improves LevelCompactionPicker.

### DIFF
--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -508,7 +508,7 @@ impl TseriesFamily {
             super_version_id: AtomicU64::new(0),
             version,
             opts: tsf_opt.clone(),
-            compact_picker: Arc::new(LevelCompactionPicker::new(tsf_opt.clone())),
+            compact_picker: Arc::new(LevelCompactionPicker::new()),
             immut_ts_min: max_level_ts,
             mut_ts_max: i64::MIN,
         }
@@ -727,8 +727,7 @@ impl TseriesFamily {
     }
 
     pub fn pick_compaction(&self) -> Option<CompactReq> {
-        self.compact_picker
-            .pick_compaction(self.tf_id, self.version.clone())
+        self.compact_picker.pick_compaction(self.version.clone())
     }
 
     pub fn tf_id(&self) -> TseriesFamilyId {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #464 #433 .

# Rationale for this change

Improved `LevelCompactionPicker` aims to pick `ColumnFiles` in Level-0 and Level-n(n>0) at the same time :

1. Selects a Level with the highest score.
2. Picks files in Level-n from lower timestamp to higher.
3. Picks files in Level-0 using the time range overlapped with file picked step-2.

# What changes are included in this PR?

1. Function `run_compaction_job()` now produces **one** VersionEdit.
2. Use `VersionEdit` generated by `run_compaction_job()` to check compacted files in unit tests.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
