### PR TITLE
feat(server): add query handler

### DIFF
--- a/line_protocol/src/parser.rs
+++ b/line_protocol/src/parser.rs
@@ -1,5 +1,3 @@
-use core::time;
-
 use crate::{Error, Result};
 
 pub struct Parser {

--- a/main/src/http/handler.rs
+++ b/main/src/http/handler.rs
@@ -1,0 +1,177 @@
+use std::sync::Arc;
+
+use chrono::Local;
+use flatbuffers::FlatBufferBuilder;
+use futures::StreamExt;
+use hyper::{Body, Request, Response};
+use line_protocol::{line_protocol_to_lines, Line};
+use protos::kv_service::WritePointsRpcRequest;
+use protos::models::{self as fb_models, FieldBuilder, Point, PointArgs, TagBuilder};
+use query::db::Db;
+use snafu::ResultExt;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::oneshot;
+use trace::debug;
+
+use crate::http::{parse_query, ChannelSendSnafu, Error, HyperSnafu, ParseLineProtocolSnafu};
+
+pub(crate) async fn route(
+    req: Request<Body>,
+    db: Arc<Db>,
+    sender: UnboundedSender<tskv::Task>,
+) -> Result<Response<Body>, Error> {
+    match req.uri().path() {
+        "/write/line_protocol" => write_line_protocol(req, sender).await,
+        "/query/sql" => query_sql(req, db).await,
+        _ => message_404(req),
+    }
+}
+
+pub(crate) async fn write_line_protocol(
+    req: Request<Body>,
+    sender: UnboundedSender<tskv::Task>,
+) -> Result<Response<Body>, Error> {
+    let database: String;
+    if let Some(query) = req.uri().query() {
+        let query_params = parse_query(query);
+        database = query_params
+            .get("database")
+            .unwrap_or_else(|| &"")
+            .to_string();
+    } else {
+        return Err(Error::Syntax {
+            reason: format!("Need some request parameters."),
+        });
+    }
+
+    if database.is_empty() {
+        return Err(Error::Syntax {
+            reason: format!("Request has no parameter 'database'."),
+        });
+    }
+
+    let mut body = req.into_body();
+    let mut buffer: Vec<u8> = Vec::with_capacity(512);
+    let mut len = 0_usize;
+    while let Some(chunk) = body.next().await {
+        let chunk = chunk.context(HyperSnafu)?;
+        len += chunk.len();
+        if len > 102400 {
+            return Err(Error::BodyOversize { size: 102400 });
+        }
+        buffer.extend_from_slice(chunk.as_ref());
+    }
+    let lines = String::from_utf8(buffer).map_err(|_| Error::NotUtf8)?;
+    let line_protocol_lines = line_protocol_to_lines(&lines, Local::now().timestamp_millis())
+        .context(ParseLineProtocolSnafu)?;
+    debug!("Write request: {:?}", line_protocol_lines);
+    let points = parse_lines_to_points(&line_protocol_lines);
+
+    let req = WritePointsRpcRequest {
+        version: 1,
+        database,
+        points,
+    };
+
+    // Send Request to handler
+    let (tx, rx) = oneshot::channel();
+    let _ = sender
+        .send(tskv::Task::WritePoints { req, tx })
+        .context(ChannelSendSnafu)?;
+
+    // Receive Response from handler
+    let _ = match rx.await {
+        Ok(Ok(resp)) => resp,
+        Ok(Err(err)) => return Err(Error::Tskv { source: err }),
+        Err(err) => return Err(Error::ChannelReceive { source: err }),
+    };
+
+    let resp = http::Response::builder()
+        .body(Body::from("Write succeed."))
+        .unwrap();
+    Ok(resp)
+}
+
+pub(crate) async fn query_sql(req: Request<Body>, db: Arc<Db>) -> Result<Response<Body>, Error> {
+    let database: String;
+    if let Some(query) = req.uri().query() {
+        let query_params = parse_query(query);
+        database = query_params
+            .get("database")
+            .unwrap_or_else(|| &"")
+            .to_string();
+    } else {
+        return Err(Error::Syntax {
+            reason: format!("Need some request parameters."),
+        });
+    }
+
+    if database.is_empty() {
+        return Err(Error::Syntax {
+            reason: format!("Request has no parameter 'database'."),
+        });
+    }
+
+    let mut body = req.into_body();
+    let mut buffer: Vec<u8> = Vec::with_capacity(512);
+    let mut len = 0_usize;
+    while let Some(chunk) = body.next().await {
+        let chunk = chunk.context(HyperSnafu)?;
+        len += chunk.len();
+        if len > 102400 {
+            return Err(Error::BodyOversize { size: 102400 });
+        }
+        buffer.extend_from_slice(chunk.as_ref());
+    }
+    let sql = String::from_utf8(buffer).map_err(|_| Error::NotUtf8)?;
+
+    let ret = db.run_query(&sql).await;
+    dbg!(&ret);
+
+    let resp = http::Response::builder()
+        .body(Body::from("Write succeed."))
+        .unwrap();
+    Ok(resp)
+}
+
+fn parse_lines_to_points(lines: &[Line]) -> Vec<u8> {
+    let mut fbb = FlatBufferBuilder::new();
+    let mut point_offsets = Vec::with_capacity(lines.len());
+    for line in lines.iter() {
+        let mut tags = Vec::new();
+        for (k, v) in line.tags.iter() {
+            let fbk = fbb.create_vector(k.as_bytes());
+            let fbv = fbb.create_vector(v.as_bytes());
+            let mut tag_builder = TagBuilder::new(&mut fbb);
+            tag_builder.add_key(fbk);
+            tag_builder.add_value(fbv);
+            tags.push(tag_builder.finish());
+        }
+        let mut fields = Vec::new();
+        for (k, v) in line.fields.iter() {
+            let fbk = fbb.create_vector(k.as_bytes());
+            let fbv = fbb.create_vector(v.as_bytes());
+            let mut field_builder = FieldBuilder::new(&mut fbb);
+            field_builder.add_name(fbk);
+            field_builder.add_type_(fb_models::FieldType::Float);
+            field_builder.add_value(fbv);
+            fields.push(field_builder.finish());
+        }
+        let point_args = PointArgs {
+            tags: Some(fbb.create_vector(&tags)),
+            fields: Some(fbb.create_vector(&fields)),
+            timestamp: line.timestamp,
+        };
+        point_offsets.push(Point::create(&mut fbb, &point_args));
+    }
+    let points = fbb.create_vector(&point_offsets);
+    fbb.finish(points, None);
+    fbb.finished_data().to_vec()
+}
+
+fn message_404(req: Request<Body>) -> Result<Response<Body>, Error> {
+    Ok(Response::builder()
+        .status(404)
+        .body(Body::from(format!("URI not found: {}", req.uri().path())))
+        .unwrap())
+}

--- a/main/src/http/mod.rs
+++ b/main/src/http/mod.rs
@@ -1,22 +1,21 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
-use chrono::Local;
-use flatbuffers::FlatBufferBuilder;
-use futures::StreamExt;
 use hyper::server::conn::AddrStream;
 use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Request, Response, Server as HyperServer};
-use line_protocol::{line_protocol_to_lines, Line};
-use protos::kv_service::WritePointsRpcRequest;
-use protos::models::{self as fb_models, FieldBuilder, Point, PointArgs, TagBuilder};
+use hyper::Server as HyperServer;
+use query::db::Db;
 use snafu::{ResultExt, Snafu};
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::RecvError;
-use trace::{debug, info};
+use trace::info;
+
+use crate::http::handler::route;
+
+mod handler;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
@@ -46,88 +45,27 @@ pub enum Error {
     Syntax { reason: String },
 }
 
-pub async fn serve(addr: SocketAddr, sender: UnboundedSender<tskv::Task>) -> Result<(), Error> {
+pub async fn serve(
+    addr: SocketAddr,
+    db: Arc<Db>,
+    sender: UnboundedSender<tskv::Task>,
+) -> Result<(), Error> {
     let make_service = make_service_fn(move |conn: &AddrStream| {
+        let db = db.clone();
         let sender = sender.clone();
         let remote_addr = conn.remote_addr();
         info!("Remote IP: {}", remote_addr);
 
-        let service = service_fn(move |req| match req.uri().path() {
-            "/write/line_protocol" => write_line_protocol(sender.clone(), req),
-            _ => write_line_protocol(sender.clone(), req),
-        });
-
-        async move { Ok::<_, Infallible>(service) }
+        async move {
+            Ok::<_, Infallible>(service_fn(move |req| {
+                route(req, db.clone(), sender.clone())
+            }))
+        }
     });
 
     let server = HyperServer::bind(&addr).serve(make_service);
 
     server.await.context(HyperSnafu)
-}
-
-async fn write_line_protocol(
-    sender: UnboundedSender<tskv::Task>,
-    req: Request<Body>,
-) -> Result<Response<Body>, Error> {
-    let database;
-    if let Some(query) = req.uri().query() {
-        let query_params = parse_query(query);
-        database = query_params
-            .get("database")
-            .unwrap_or_else(|| &"")
-            .to_string();
-    } else {
-        return Err(Error::Syntax {
-            reason: format!("Need some request parameters."),
-        });
-    }
-
-    if database.is_empty() {
-        return Err(Error::Syntax {
-            reason: format!("Request has no parameter 'database'."),
-        });
-    }
-
-    let mut body = req.into_body();
-    let mut buffer: Vec<u8> = Vec::with_capacity(512);
-    let mut len = 0_usize;
-    while let Some(chunk) = body.next().await {
-        let chunk = chunk.context(HyperSnafu)?;
-        len += chunk.len();
-        if len > 102400 {
-            return Err(Error::BodyOversize { size: 102400 });
-        }
-        buffer.extend_from_slice(chunk.as_ref());
-    }
-    let lines = String::from_utf8(buffer).map_err(|_| Error::NotUtf8)?;
-    let line_protocol_lines = line_protocol_to_lines(&lines, Local::now().timestamp_millis())
-        .context(ParseLineProtocolSnafu)?;
-    debug!("Write request: {:?}", line_protocol_lines);
-    let points = parse_lines_to_points(&line_protocol_lines);
-
-    let req = WritePointsRpcRequest {
-        version: 1,
-        database,
-        points,
-    };
-
-    // 1. send Request to handler
-    let (tx, rx) = oneshot::channel();
-    let _ = sender
-        .send(tskv::Task::WritePoints { req, tx })
-        .context(ChannelSendSnafu)?;
-
-    // 3. receive Response from handler
-    let _ = match rx.await {
-        Ok(Ok(resp)) => resp,
-        Ok(Err(err)) => return Err(Error::Tskv { source: err }),
-        Err(err) => return Err(Error::ChannelReceive { source: err }),
-    };
-
-    let resp = http::Response::builder()
-        .body(Body::from("Write succeed."))
-        .unwrap();
-    Ok(resp)
 }
 
 /// Parse query('param1=val1&param2=val2') to HashMap.
@@ -156,48 +94,16 @@ fn parse_query(query: &str) -> HashMap<&str, &str> {
     map
 }
 
-fn parse_lines_to_points(lines: &[Line]) -> Vec<u8> {
-    let mut fbb = FlatBufferBuilder::new();
-    let mut point_offsets = Vec::with_capacity(lines.len());
-    for line in lines.iter() {
-        let mut tags = Vec::new();
-        for (k, v) in line.tags.iter() {
-            let fbk = fbb.create_vector(k.as_bytes());
-            let fbv = fbb.create_vector(v.as_bytes());
-            let mut tag_builder = TagBuilder::new(&mut fbb);
-            tag_builder.add_key(fbk);
-            tag_builder.add_value(fbv);
-            tags.push(tag_builder.finish());
-        }
-        let mut fields = Vec::new();
-        for (k, v) in line.fields.iter() {
-            let fbk = fbb.create_vector(k.as_bytes());
-            let fbv = fbb.create_vector(v.as_bytes());
-            let mut field_builder = FieldBuilder::new(&mut fbb);
-            field_builder.add_name(fbk);
-            field_builder.add_type_(fb_models::FieldType::Float);
-            field_builder.add_value(fbv);
-            fields.push(field_builder.finish());
-        }
-        let point_args = PointArgs {
-            tags: Some(fbb.create_vector(&tags)),
-            fields: Some(fbb.create_vector(&fields)),
-            timestamp: line.timestamp,
-        };
-        point_offsets.push(Point::create(&mut fbb, &point_args));
-    }
-    let points = fbb.create_vector(&point_offsets);
-    fbb.finish(points, None);
-    fbb.finished_data().to_vec()
-}
-
 #[cfg(test)]
 mod test {
-    use std::net::SocketAddr;
+    use std::{net::SocketAddr, sync::Arc};
 
+    use config::get_config;
     use protos::kv_service::WritePointsRpcResponse;
+    use query::db::Db;
     use tokio::{spawn, sync::mpsc};
-    use tskv::Task;
+    use trace::init_default_global_tracing;
+    use tskv::{Options, Task, TsKv};
 
     use super::serve;
 
@@ -206,13 +112,22 @@ mod test {
     #[tokio::test]
     #[ignore]
     async fn run_server() {
-        // curl -v -X POST http://127.0.0.1:8003/write/line_protocol\?database\=dba --data "ma,ta=a1,tb=b1 fa=1,fb=2 1"
+        //! ```bash
+        //! curl -v -X POST http://127.0.0.1:8003/write/line_protocol\?database\=dba --data "ma,ta=a1,tb=b1 fa=1,fb=2 1"
+        //! ```
 
+        init_default_global_tracing("tskv_log", "tskv.log", "debug");
+
+        let global_config = get_config("../config/config.toml");
         let http_host = "127.0.0.1:8003"
             .parse::<SocketAddr>()
             .expect("Invalid host");
+        let opt = Options::from(global_config);
+
+        let tskv = TsKv::open(opt, global_config.tsfamily_num).await.unwrap();
+        let db = Arc::new(Db::new(Arc::new(tskv)));
         let (sender, mut receiver) = mpsc::unbounded_channel();
-        let server_join_handle = spawn(async move { serve(http_host, sender).await });
+        let server_join_handle = spawn(async move { serve(http_host, db, sender).await });
 
         spawn(async move {
             while let Some(task) = receiver.recv().await {

--- a/query/src/catalog.rs
+++ b/query/src/catalog.rs
@@ -122,9 +122,7 @@ impl SchemaProvider for IsiphoSchema {
                 }
                 let schema = TableSchema::new(name.to_owned(), fields);
                 let table = Arc::new(ClusterTable::new(self.engine.clone(), schema));
-                tables.insert(
-                    name.to_owned(),
-                    table.clone(),);
+                tables.insert(name.to_owned(), table.clone());
                 return Some(table);
             }
         }

--- a/query/src/table.rs
+++ b/query/src/table.rs
@@ -73,6 +73,6 @@ impl TableProvider for ClusterTable {
             .await;
     }
     fn supports_filter_pushdown(&self, filter: &Expr) -> Result<TableProviderFilterPushDown> {
-           Ok(TableProviderFilterPushDown::Inexact)
+        Ok(TableProviderFilterPushDown::Inexact)
     }
 }

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -330,7 +330,7 @@ impl TsKv {
         warn!("Summary task handler started");
     }
 
-    pub fn start(tskv: TsKv, mut req_rx: UnboundedReceiver<Task>) {
+    pub fn start(tskv: Arc<TsKv>, mut req_rx: UnboundedReceiver<Task>) {
         warn!("job 'main' starting.");
         let f = async move {
             while let Some(command) = req_rx.recv().await {


### PR DESCRIPTION
# Which issue does this PR close?

# Rationale for this change

Add handler for uri `/query/sql`.

An example: `curl -v -X POST http://127.0.0.1:31007/query/sql?database=dba --data "select * from ta"`

# What changes are included in this PR?

# Are there any user-facing changes?