### PR TITLE
feat(query) #539: support convert filter expr to domains for TableScan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.idea/
 /.vscode/
 /dev/
+/query/dev
 
 # Cargo
 **/target

--- a/models/src/errors.rs
+++ b/models/src/errors.rs
@@ -19,4 +19,11 @@ pub enum Error {
 
     #[snafu(display("Invalid serde message: {}", err))]
     InvalidSerdeMessage { err: String },
+
+    #[snafu(display(
+        "Internal error: {}. This was likely caused by a bug in Cnosdb's \
+    code and we would welcome that you file an bug report in our issue tracker",
+        err
+    ))]
+    Internal { err: String },
 }

--- a/models/src/field_info.rs
+++ b/models/src/field_info.rs
@@ -9,7 +9,7 @@ use crate::{
 
 const FIELD_NAME_MAX_LEN: usize = 512;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone, Eq, Hash)]
 pub enum ValueType {
     Unknown,
     Float,

--- a/query/src/helper/domain.rs
+++ b/query/src/helper/domain.rs
@@ -1,0 +1,1326 @@
+use std::{collections::VecDeque, result};
+
+use datafusion::{
+    arrow::datatypes::DataType,
+    error::DataFusionError,
+    logical_plan::Column,
+    logical_plan::{ExprVisitable, ExpressionVisitor, Operator, Recursion},
+    prelude::Expr,
+    scalar::ScalarValue,
+};
+
+use crate::predicate::{ColumnDomains, Domain, Range};
+
+type Result<T> = result::Result<T, DataFusionError>;
+
+#[derive(Clone, Default)]
+struct RowExpressionToDomainsVisitorContext {
+    current_domain_stack: VecDeque<ColumnDomains<Column>>,
+}
+
+struct NormalizedSimpleComparison {
+    column: Column,
+    op: Operator,
+    value: ScalarValue,
+}
+
+impl NormalizedSimpleComparison {
+    fn reverse_op(op: Operator) -> Operator {
+        match op {
+            Operator::Lt => Operator::Gt,
+            Operator::LtEq => Operator::GtEq,
+            Operator::Gt => Operator::Lt,
+            Operator::GtEq => Operator::LtEq,
+            _ => op,
+        }
+    }
+    /// Extract a normalized simple comparison between a Column and a ScalarValue if possible
+    /// otherwise return None
+    fn of(left: Expr, op: Operator, right: Expr) -> Option<NormalizedSimpleComparison> {
+        if !Self::is_comparison_op(op) {
+            return None;
+        }
+
+        match (left, op, right) {
+            (Expr::Column(column), _, Expr::Literal(value)) => Some(Self { column, op, value }),
+            (Expr::Literal(value), _, Expr::Column(column)) => Some(Self {
+                column,
+                op: Self::reverse_op(op),
+                value,
+            }),
+            (_, _, _) => None,
+        }
+    }
+    /// Determine if a data type is sortable
+    fn is_orderable(&self) -> bool {
+        match self.value {
+            ScalarValue::Boolean(_)
+            | ScalarValue::Null
+            | ScalarValue::List(_, _)
+            | ScalarValue::IntervalYearMonth(_)
+            | ScalarValue::IntervalDayTime(_)
+            | ScalarValue::IntervalMonthDayNano(_)
+            | ScalarValue::Struct(_, _) => false,
+
+            ScalarValue::Float32(_)
+            | ScalarValue::Float64(_)
+            | ScalarValue::Decimal128(_, _, _)
+            | ScalarValue::Int8(_)
+            | ScalarValue::Int16(_)
+            | ScalarValue::Int32(_)
+            | ScalarValue::Int64(_)
+            | ScalarValue::UInt8(_)
+            | ScalarValue::UInt16(_)
+            | ScalarValue::UInt32(_)
+            | ScalarValue::UInt64(_)
+            | ScalarValue::Utf8(_)
+            | ScalarValue::LargeUtf8(_)
+            | ScalarValue::Binary(_)
+            | ScalarValue::LargeBinary(_)
+            | ScalarValue::Date32(_)
+            | ScalarValue::Date64(_)
+            | ScalarValue::TimestampSecond(_, _)
+            | ScalarValue::TimestampMillisecond(_, _)
+            | ScalarValue::TimestampMicrosecond(_, _)
+            | ScalarValue::TimestampNanosecond(_, _) => true,
+        }
+    }
+    // Determine if data types are comparable
+    fn _is_comparable(&self) -> bool {
+        true
+    }
+
+    fn is_eq_op(&self) -> bool {
+        self.op.eq(&Operator::Eq)
+    }
+
+    fn is_comparison_op(op: Operator) -> bool {
+        matches!(
+            op,
+            Operator::Eq
+                | Operator::NotEq
+                | Operator::Lt
+                | Operator::LtEq
+                | Operator::Gt
+                | Operator::GtEq
+        )
+    }
+}
+
+pub struct RowExpressionToDomainsVisitor<'a> {
+    ctx: &'a mut RowExpressionToDomainsVisitorContext,
+}
+
+type GetRangeFromDataTypeAndValue = fn(data_type: &DataType, scalar_value: &ScalarValue) -> Range;
+
+/// Get the corresponding range constructor according to the comparison operator
+fn get_get_range_fn(op: &Operator) -> Option<GetRangeFromDataTypeAndValue> {
+    match op {
+        Operator::Eq => Some(Range::eq),
+        Operator::NotEq => Some(Range::ne),
+        Operator::Lt => Some(Range::lt),
+        Operator::LtEq => Some(Range::le),
+        Operator::Gt => Some(Range::gt),
+        Operator::GtEq => Some(Range::ge),
+        _ => None,
+    }
+}
+
+impl ExpressionVisitor for RowExpressionToDomainsVisitor<'_> {
+    fn pre_visit(self, expr: &Expr) -> Result<Recursion<Self>> {
+        // Note: expressions that can be used as and/or child nodes need to be processed.
+        // Expressions returning boolean need to be processed, If the expression is not supported, push ColumnDomains::all() onto the stack.
+        // If the expression supports it, return Continue directly.
+        match expr {
+            // Expr::Alias(_, _)
+            // | Expr::Negative(_)
+            // | Expr::ScalarVariable(_, _)
+            // | Expr::Case { .. }
+            // | Expr::Cast { .. }
+            // | Expr::TryCast { .. }
+            // | Expr::Sort { .. }
+            // | Expr::ScalarFunction { .. }
+            // | Expr::ScalarUDF { .. }
+            // | Expr::WindowFunction { .. }
+            // | Expr::AggregateFunction { .. }
+            // | Expr::GroupingSet(_)
+            // | Expr::AggregateUDF { .. }
+            // | Expr::Exists { .. }
+            // | Expr::InSubquery { .. }
+            // | Expr::ScalarSubquery(_)
+            // | Expr::Wildcard
+            // | Expr::QualifiedWildcard { .. }
+            // | Expr::GetIndexedField { .. } => {}
+            Expr::Column(_) | Expr::Literal(_) | Expr::BinaryExpr { .. } => {
+                Ok(Recursion::Continue(self))
+            }
+            // TODO Currently not supported, follow-up support needs to implement the corresponding expression in post_visit
+            Expr::Not(_)
+            | Expr::IsNotNull(_)
+            | Expr::IsNull(_)
+            | Expr::Between { .. }
+            | Expr::InList { .. } => {
+                self.ctx
+                    .current_domain_stack
+                    .push_back(ColumnDomains::all());
+                Ok(Recursion::Stop(self))
+            }
+            _ => Ok(Recursion::Stop(self)),
+        }
+    }
+
+    fn post_visit(self, expr: &Expr) -> datafusion::common::Result<Self> {
+        match expr {
+            Expr::BinaryExpr { left, op, right } => {
+                match op {
+                    // stack中为expr，清空，生成domain
+                    Operator::Eq
+                    | Operator::NotEq
+                    | Operator::Lt
+                    | Operator::LtEq
+                    | Operator::Gt
+                    | Operator::GtEq => {
+                        Self::construct_value_set_and_push_current_domain_stack(
+                            self.ctx, left, op, right,
+                        );
+                    }
+                    // The stack is domain, pop it, and generate a new domain
+                    Operator::And => {
+                        let domain1_opt = self.ctx.current_domain_stack.pop_back();
+                        let domain2_opt = self.ctx.current_domain_stack.pop_back();
+
+                        // Executed to this point, it means that all child nodes are valid and exist, and there is no need to deal with the case of None
+                        if let (Some(ref mut d1), Some(d2)) = (domain1_opt, domain2_opt) {
+                            d1.intersect(&d2);
+                            self.ctx.current_domain_stack.push_back(d1.to_owned());
+                        }
+                    }
+                    Operator::Or => {
+                        let domain1_opt = self.ctx.current_domain_stack.pop_back();
+                        let domain2_opt = self.ctx.current_domain_stack.pop_back();
+
+                        // Executed to this point, it means that all child nodes are valid and exist, and there is no need to deal with the case of None
+                        if let (Some(ref mut d1), Some(d2)) = (domain1_opt, domain2_opt) {
+                            d1.column_wise_union(&d2);
+                            self.ctx.current_domain_stack.push_back(d1.to_owned());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            // TODO The stack is the domain, and the domain is generated
+            Expr::Not(_) | Expr::Between { .. } | Expr::InList { .. } => {}
+            _ => {}
+        }
+
+        Ok(self)
+    }
+}
+
+impl RowExpressionToDomainsVisitor<'_> {
+    pub fn expr_to_column_domains(expr: &Expr) -> Result<ColumnDomains<Column>> {
+        let mut ctx = RowExpressionToDomainsVisitorContext::default();
+        expr.accept(RowExpressionToDomainsVisitor { ctx: &mut ctx })?;
+        Ok(ctx
+            .current_domain_stack
+            .pop_back()
+            .unwrap_or_else(ColumnDomains::all))
+    }
+
+    /// Convert nsc to RangeValueSet
+    ///
+    /// Note: nsc must supports ordering, i.e. is_orderable == true
+    fn nsc_to_column_domains_with_range(nsc: &NormalizedSimpleComparison) -> ColumnDomains<Column> {
+        let col = &nsc.column;
+        let value = &nsc.value;
+        let op = &nsc.op;
+        // Get the function that constructs Range by dataType and ScalarValue.
+        // If op does not support it, it will return None, but it must be supported here (because op is obtained from nsc)
+        let val_set = get_get_range_fn(op)
+            // Construct Range
+            .map(|f| f(&value.get_datatype(), value))
+            // Construct ValueSet by Range, where of_ranges will not return an exception, because the parameter has only one range
+            .map(|r| Domain::of_ranges(&[r]).unwrap())
+            // Normally this is not triggered (unless there is a bug), but returns ValueSet::All for safety
+            .unwrap_or(Domain::All);
+
+        ColumnDomains::of(col.to_owned(), &val_set)
+    }
+    /// Convert nsc to EqutableValueSet
+    ///
+    /// Note: nsc does not support ordering, i.e. is_orderable == false
+    fn nsc_to_domains_with_equtable(nsc: &NormalizedSimpleComparison) -> ColumnDomains<Column> {
+        let col = &nsc.column;
+        let value = &nsc.value;
+        let is_eq_op = nsc.is_eq_op();
+        let val_set = Domain::of_values(&value.get_datatype(), is_eq_op, &[value]);
+        ColumnDomains::of(col.to_owned(), &val_set)
+    }
+    /// Construct comparison operations as simple column-value comparison data structures nsc.
+    ///
+    /// Choose a different NscToValueSet function based on whether the data type supports sorting.
+    ///
+    /// Convert nsc to ValueSet via NscToValueSet function
+    ///
+    /// Push the domain into the stack
+    fn construct_value_set_and_push_current_domain_stack(
+        ctx: &mut RowExpressionToDomainsVisitorContext,
+        left: &Expr,
+        op: &Operator,
+        right: &Expr,
+    ) {
+        let domains_opt = NormalizedSimpleComparison::of(left.clone(), *op, right.clone())
+            .map(|ref nsc| {
+                if nsc.is_orderable() {
+                    return Self::nsc_to_column_domains_with_range(nsc);
+                }
+                Self::nsc_to_domains_with_equtable(nsc)
+            })
+            .or_else(|| Some(ColumnDomains::all()));
+
+        if let Some(domains) = domains_opt {
+            ctx.current_domain_stack.push_back(domains);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Add;
+
+    use super::*;
+    use chrono::{Duration, NaiveDate};
+
+    use datafusion::{
+        logical_expr::{binary_expr, expr_fn::col},
+        logical_plan::{and, or, Operator},
+        prelude::{in_list, lit, random},
+    };
+
+    /// resolves the domain of the specified expression
+    fn get_domains(expr: &Expr) -> Result<ColumnDomains<Column>> {
+        RowExpressionToDomainsVisitor::expr_to_column_domains(expr)
+    }
+    fn get_tuple_int_and_expr_with_except_column_domains() -> (Expr, ColumnDomains<Column>) {
+        let filter1 = binary_expr(col("i1"), Operator::Lt, lit(-1000000));
+        let filter2 = binary_expr(col("i2"), Operator::Eq, lit(2147483647));
+        let filter3 = binary_expr(col("i3"), Operator::Gt, lit(3_333_333_333_333_333_i64));
+
+        let result_expr = and(and(filter1, filter2), filter3);
+
+        // build except result
+        //   i1: (_, -1000000)
+        //   i2: [2147483647, 2147483647]
+        //   i3: (3333333333333333, _)
+        let i1 = Range::lt(&DataType::Int32, &ScalarValue::Int32(Some(-1000000_i32)));
+        let i2 = Range::eq(&DataType::Int32, &ScalarValue::Int32(Some(2147483647_i32)));
+        let i3 = Range::gt(
+            &DataType::Int64,
+            &ScalarValue::Int64(Some(3333333333333333_i64)),
+        );
+
+        let i1_domain = Domain::of_ranges(&[i1]).unwrap();
+        let i2_domain = Domain::of_ranges(&[i2]).unwrap();
+        let i3_domain = Domain::of_ranges(&[i3]).unwrap();
+
+        let except_column_domains = &mut ColumnDomains::of(Column::from_name("i1"), &i1_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("i2"), &i2_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("i3"), &i3_domain);
+
+        (result_expr, except_column_domains.to_owned())
+    }
+
+    fn get_tuple_float_and_expr_with_except_column_domains() -> (Expr, ColumnDomains<Column>) {
+        let filter_f1 = binary_expr(col("f1"), Operator::Lt, lit(-1000000.1));
+        let filter_f2 = binary_expr(col("f2"), Operator::Eq, lit(2.2));
+        let filter_f3 = binary_expr(col("f3"), Operator::Gt, lit(3333333333333333.3));
+
+        let result_expr = and(and(filter_f1, filter_f2), filter_f3);
+
+        // build except result
+        //   f1: (_, -1000000.1)
+        //   f2: [2.2, 2.2]
+        //   f3: (3333333333333333.3, _)
+        let f1 = Range::lt(&DataType::Float64, &ScalarValue::Float64(Some(-1000000.1)));
+        let f2 = Range::eq(&DataType::Float64, &ScalarValue::Float64(Some(2.2)));
+        let f3 = Range::gt(
+            &DataType::Float64,
+            &ScalarValue::Float64(Some(3333333333333333.3)),
+        );
+
+        let f1_domain = Domain::of_ranges(&[f1]).unwrap();
+        let f2_domain = Domain::of_ranges(&[f2]).unwrap();
+        let f3_domain = Domain::of_ranges(&[f3]).unwrap();
+
+        let except_column_domains = &mut ColumnDomains::of(Column::from_name("f1"), &f1_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("f2"), &f2_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("f3"), &f3_domain);
+
+        (result_expr, except_column_domains.to_owned())
+    }
+
+    fn get_tuple_bool_and_expr_with_except_column_domains() -> (Expr, ColumnDomains<Column>) {
+        let filter_b1 = binary_expr(col("b1"), Operator::Eq, lit(true));
+        let filter_b2 = binary_expr(col("b2"), Operator::Eq, lit(true));
+        let filter_b3 = binary_expr(col("b3"), Operator::Eq, lit(true));
+
+        let result_expr = and(and(filter_b1, filter_b2), filter_b3);
+
+        // build except result
+        //   b1: true
+        //   b2: true
+        //   b3: true
+        let b = ScalarValue::Boolean(Some(true));
+
+        let domain = Domain::of_values(&DataType::Boolean, true, &[&b, &b, &b]);
+
+        let except_column_domains = &mut ColumnDomains::of(Column::from_name("b1"), &domain);
+        except_column_domains.insert_or_intersect(Column::from_name("b2"), &domain);
+        except_column_domains.insert_or_intersect(Column::from_name("b3"), &domain);
+
+        (result_expr, except_column_domains.to_owned())
+    }
+
+    fn get_tuple_string_and_expr_with_except_column_domains() -> (Expr, ColumnDomains<Column>) {
+        let filter_s1 = binary_expr(col("s1"), Operator::Lt, lit("true"));
+        let filter_s2 = binary_expr(col("s2"), Operator::Eq, lit(" 99 0 _ *"));
+        let filter_s3 = binary_expr(col("s3"), Operator::Gt, lit(""));
+
+        let result_expr = and(and(filter_s1, filter_s2), filter_s3);
+
+        // build except result
+        //   s1: (_, true)
+        //   s2: [" 99 0 _ *", " 99 0 _ *"]
+        //   s3: ("", _)
+        let s1 = Range::lt(
+            &DataType::Utf8,
+            &ScalarValue::Utf8(Some("true".to_string())),
+        );
+        let s2 = Range::eq(
+            &DataType::Utf8,
+            &ScalarValue::Utf8(Some(" 99 0 _ *".to_string())),
+        );
+        let s3 = Range::gt(&DataType::Utf8, &ScalarValue::Utf8(Some("".to_string())));
+
+        let s1_domain = Domain::of_ranges(&[s1]).unwrap();
+        let s2_domain = Domain::of_ranges(&[s2]).unwrap();
+        let s3_domain = Domain::of_ranges(&[s3]).unwrap();
+
+        let except_column_domains = &mut ColumnDomains::of(Column::from_name("s1"), &s1_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("s2"), &s2_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("s3"), &s3_domain);
+
+        (result_expr, except_column_domains.to_owned())
+    }
+
+    fn get_tuple_date64_and_expr_with_except_column_domains() -> (Expr, ColumnDomains<Column>) {
+        let epoch_l = NaiveDate::from_ymd(1970, 1, 1)
+            .and_hms(1, 1, 1)
+            .add(Duration::milliseconds(1000_i64));
+
+        let epoch_m = NaiveDate::from_ymd(2022, 12, 31)
+            .and_hms(1, 1, 1)
+            .add(Duration::milliseconds(1000_i64));
+
+        let epoch_h = NaiveDate::from_ymd(2000, 1, 1)
+            .and_hms(1, 1, 1)
+            .add(Duration::milliseconds(1000_i64));
+
+        let epoch_h_expr = Expr::Literal(ScalarValue::Date64(Some(epoch_h.timestamp())));
+        let epoch_m_expr = Expr::Literal(ScalarValue::Date64(Some(epoch_m.timestamp_micros())));
+        let epoch_l_expr = Expr::Literal(ScalarValue::Date64(Some(epoch_l.timestamp_millis())));
+
+        let filter_d1 = binary_expr(col("d1"), Operator::Lt, epoch_h_expr);
+        let filter_d2 = binary_expr(col("d2"), Operator::Eq, epoch_m_expr);
+        let filter_d3 = binary_expr(col("d3"), Operator::Gt, epoch_l_expr);
+
+        let result_expr = and(and(filter_d1, filter_d2), filter_d3);
+
+        // build except result
+        //   d1: (_, Date64(946688462))
+        //   d2: [Date64(1672448462000000), Date64(1672448462000000)]
+        //   d3: (Date64(3662000), _)
+        let d1 = Range::lt(
+            &DataType::Date64,
+            &ScalarValue::Date64(Some(epoch_h.timestamp())),
+        );
+        let d2 = Range::eq(
+            &DataType::Date64,
+            &ScalarValue::Date64(Some(epoch_m.timestamp_micros())),
+        );
+        let d3 = Range::gt(
+            &DataType::Date64,
+            &ScalarValue::Date64(Some(epoch_l.timestamp_millis())),
+        );
+
+        let d1_domain = Domain::of_ranges(&[d1]).unwrap();
+        let d2_domain = Domain::of_ranges(&[d2]).unwrap();
+        let d3_domain = Domain::of_ranges(&[d3]).unwrap();
+
+        let except_column_domains = &mut ColumnDomains::of(Column::from_name("d1"), &d1_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("d2"), &d2_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("d3"), &d3_domain);
+
+        (result_expr, except_column_domains.to_owned())
+    }
+
+    /// simple and test - 1
+    /// eg.
+    ///   i1 < -1000000 and i2 = 2147483647 and i3 > 3333333333333333
+    ///   ===>
+    ///   i1: (_, -1000000)
+    ///   i2: [2147483647, 2147483647]
+    ///   i3: (3333333333333333, _)
+    #[tokio::test]
+    async fn test_simple_and_to_domain_1() {
+        let (and, except_column_domains) = get_tuple_int_and_expr_with_except_column_domains();
+
+        let result = get_domains(&and);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err",
+            &and
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        assert!(
+            except_column_domains.eq(column_domain),
+            "convert expr {} to column domains err, excepted {:?}, found {:?}",
+            &and,
+            except_column_domains,
+            column_domain,
+        );
+    }
+
+    /// simple and test - 2
+    /// eg.
+    /// i1 < -1000000 and i2 = 2147483647 and i3 > 3333333333333333
+    /// f1 < -1000000.1 and f2 = 2.2 and f3 > 3333333333333333.3
+    ///   ===>
+    ///   i1: (_, -1000000)
+    ///   i2: [2147483647, 2147483647]
+    ///   i3: (3333333333333333, _)
+    ///   f1: (_, -1000000.1)
+    ///   f2: [2.2, 2.2]
+    ///   f3: (3333333333333333.3, _)
+    #[tokio::test]
+    async fn test_simple_and_to_domain_2() {
+        let (and_i, ref mut except_column_domains) =
+            get_tuple_int_and_expr_with_except_column_domains();
+        let (and_f, and_f_except_column_domains) =
+            get_tuple_float_and_expr_with_except_column_domains();
+
+        let and = and(and_i, and_f);
+
+        let result = get_domains(&and);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err",
+            &and
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        // // build except result
+        except_column_domains.intersect(&and_f_except_column_domains);
+
+        assert!(
+            except_column_domains.eq(&column_domain),
+            "convert expr {} to column domains err, excepted {:?}, found {:?}",
+            &and,
+            except_column_domains,
+            column_domain,
+        );
+    }
+
+    /// simple and test - 3
+    /// eg.
+    /// i1 < 1 and i2 = 2 and i3 > -3 and \
+    /// f1 < 1.1 and f2 = 2.2 and f3 > 3.3 and \
+    /// b1 < 1.1 and b2 = 2.2 and b3 > 3.3 and \
+    ///   ===>
+    ///   i1: (_, -1000000)
+    ///   i2: [2147483647, 2147483647]
+    ///   i3: (3333333333333333, _)
+    ///   f1: (_, -1000000.1)
+    ///   f2: [2.2, 2.2]
+    ///   f3: (3333333333333333.3, _)
+    ///   b1: [true, true]
+    ///   b2: [true, true]
+    ///   b3: [true, true]
+    #[tokio::test]
+    async fn test_simple_and_to_domain_3() {
+        let (and_i, ref mut except_column_domains) =
+            get_tuple_int_and_expr_with_except_column_domains();
+        let (and_f, and_f_except_column_domains) =
+            get_tuple_float_and_expr_with_except_column_domains();
+        let (and_b, and_b_except_column_domains) =
+            get_tuple_bool_and_expr_with_except_column_domains();
+
+        let and = and(and(and_i, and_f), and_b);
+
+        let result = get_domains(&and);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err",
+            &and
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        // build except result
+        except_column_domains.intersect(&and_f_except_column_domains);
+        except_column_domains.intersect(&and_b_except_column_domains);
+
+        assert!(
+            except_column_domains.eq(&column_domain),
+            "convert expr {} to column domains err, excepted {:?}, found {:?}",
+            &and,
+            except_column_domains,
+            column_domain,
+        );
+    }
+
+    /// simple and test - 4
+    /// eg.
+    /// i1 < 1 and i2 = 2 and i3 > -3 and \
+    /// f1 < 1.1 and f2 = 2.2 and f3 > 3.3 and \
+    /// b1 < 1.1 and b2 = 2.2 and b3 > 3.3 and \
+    /// s1 < 1.1 and s2 = 2.2 and s3 > 3.3 and \
+    ///   ===>
+    ///   i1: (_, -1000000)
+    ///   i2: [2147483647, 2147483647]
+    ///   i3: (3333333333333333, _)
+    ///   f1: (_, -1000000.1)
+    ///   f2: [2.2, 2.2]
+    ///   f3: (3333333333333333.3, _)
+    ///   b1: [true, true]
+    ///   b2: [true, true]
+    ///   b3: [true, true]
+    ///   s1: (_, true)
+    ///   s2: [" 99 0 _ *", " 99 0 _ *"]
+    ///   s3: ("", _)
+    #[tokio::test]
+    async fn test_simple_and_to_domain_4() {
+        let (and_i, ref mut except_column_domains) =
+            get_tuple_int_and_expr_with_except_column_domains();
+        let (and_f, and_f_except_column_domains) =
+            get_tuple_float_and_expr_with_except_column_domains();
+        let (and_b, and_b_except_column_domains) =
+            get_tuple_bool_and_expr_with_except_column_domains();
+        let (and_s, and_s_except_column_domains) =
+            get_tuple_string_and_expr_with_except_column_domains();
+
+        let and = and(and(and(and_i, and_f), and_b), and_s);
+
+        let result = get_domains(&and);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err",
+            &and
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        // build except result
+        except_column_domains.intersect(&and_f_except_column_domains);
+        except_column_domains.intersect(&and_b_except_column_domains);
+        except_column_domains.intersect(&and_s_except_column_domains);
+
+        assert!(
+            except_column_domains.eq(&column_domain),
+            "convert expr {} to column domains err, excepted {:?}, found {:?}",
+            &and,
+            except_column_domains,
+            column_domain,
+        );
+    }
+
+    /// simple and test - 5
+    /// eg.
+    /// i1 < 1 and i2 = 2 and i3 > -3 and \
+    /// f1 < 1.1 and f2 = 2.2 and f3 > 3.3 and \
+    /// b1 < 1.1 and b2 = 2.2 and b3 > 3.3 and \
+    /// s1 < 1.1 and s2 = 2.2 and s3 > 3.3 and \
+    /// d1 < 1.1 and d2 = 2.2 and d3 > 3.3
+    ///   ===>
+    ///   i1: (_, -1000000)
+    ///   i2: [2147483647, 2147483647]
+    ///   i3: (3333333333333333, _)
+    ///   f1: (_, -1000000.1)
+    ///   f2: [2.2, 2.2]
+    ///   f3: (3333333333333333.3, _)
+    ///   b1: [true, true]
+    ///   b2: [true, true]
+    ///   b3: [true, true]
+    ///   s1: (_, true)
+    ///   s2: [" 99 0 _ *", " 99 0 _ *"]
+    ///   s3: ("", _)
+    ///   d1: (_, Date64(946688462))
+    ///   d2: [Date64(1672448462000000), Date64(1672448462000000)]
+    ///   d3: (Date64(3662000), _)
+    #[tokio::test]
+    async fn test_simple_and_to_domain_5() {
+        let (and_i, ref mut except_column_domains) =
+            get_tuple_int_and_expr_with_except_column_domains();
+        let (and_f, and_f_except_column_domains) =
+            get_tuple_float_and_expr_with_except_column_domains();
+        let (and_b, and_b_except_column_domains) =
+            get_tuple_bool_and_expr_with_except_column_domains();
+        let (and_s, and_s_except_column_domains) =
+            get_tuple_string_and_expr_with_except_column_domains();
+        let (and_d, and_d_except_column_domains) =
+            get_tuple_date64_and_expr_with_except_column_domains();
+
+        let and = and(and(and(and(and_i, and_f), and_b), and_s), and_d);
+
+        let result = get_domains(&and);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err",
+            &and
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        // build except result
+        except_column_domains.intersect(&and_f_except_column_domains);
+        except_column_domains.intersect(&and_b_except_column_domains);
+        except_column_domains.intersect(&and_s_except_column_domains);
+        except_column_domains.intersect(&and_d_except_column_domains);
+
+        assert!(
+            except_column_domains.eq(&column_domain),
+            "convert expr {} to column domains err, excepted {:?}, found {:?}",
+            &and,
+            except_column_domains,
+            column_domain,
+        );
+    }
+
+    /// and & or
+    /// eg.
+    ///   i1 < 1 and i2 = 2 and i3 > -3 or \
+    ///   i1 <-10 and i2 = 3 and i3 < 3
+    ///   ===>
+    ///   i1: (_, 1)
+    ///   i2: [2, 2], [3, 3]
+    ///   i3: (_, _)
+    #[tokio::test]
+    async fn test_and_or_to_domain_1() {
+        let filter1_1 = binary_expr(col("i1"), Operator::Lt, lit(1));
+        let filter2_1 = binary_expr(col("i2"), Operator::Eq, lit(2));
+        let filter3_1 = binary_expr(col("i3"), Operator::Gt, lit(-3));
+
+        let filter1_2 = binary_expr(col("i1"), Operator::Lt, lit(-10));
+        let filter2_2 = binary_expr(col("i2"), Operator::Eq, lit(3));
+        let filter3_2 = binary_expr(col("i3"), Operator::Lt, lit(3));
+
+        let and_1 = and(and(filter1_1, filter2_1), filter3_1);
+        let and_2 = and(and(filter1_2, filter2_2), filter3_2);
+
+        let or = or(and_1, and_2);
+
+        let result = get_domains(&or);
+
+        assert!(result.is_ok(), "convert expr {} to column domains err", &or);
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        // build except result
+        //   i1: (_, 1)
+        //   i2: [2, 2], [3, 3]
+        //   i3: (_, _)
+        let i1 = Range::lt(&DataType::Int32, &ScalarValue::Int32(Some(1_i32)));
+
+        let i2_1 = Range::eq(&DataType::Int32, &ScalarValue::Int32(Some(2_i32)));
+        let i2_2 = Range::eq(&DataType::Int32, &ScalarValue::Int32(Some(3_i32)));
+
+        let i3 = Range::all(&DataType::Int32);
+
+        let i1_domain = Domain::of_ranges(&[i1]).unwrap();
+        let i2_domain = Domain::of_ranges(&[i2_1, i2_2]).unwrap();
+        let i3_domain = Domain::of_ranges(&[i3]).unwrap();
+
+        let except_column_domains = &mut ColumnDomains::of(Column::from_name("i1"), &i1_domain);
+
+        except_column_domains.insert_or_intersect(Column::from_name("i2"), &i2_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("i3"), &i3_domain);
+
+        assert!(
+            except_column_domains.eq(&column_domain),
+            "convert expr {} to column domains err, excepted {:?}, found {:?}",
+            &or,
+            except_column_domains,
+            column_domain,
+        );
+    }
+
+    /// and & or
+    /// eg.
+    ///   1 < i1 and 2 = i2 and -3 > i3 or \
+    ///   -10 < i1 and 3 = i2 and 3 < i3
+    ///   ===>
+    ///   i1: (-10, _)
+    ///   i2: [2, 2], [3, 3]
+    ///   i3: (_, -3), (3, _)
+    #[tokio::test]
+    async fn test_and_or_to_domain_1_reverse() {
+        let filter1_1 = binary_expr(lit(1), Operator::Lt, col("i1"));
+        let filter2_1 = binary_expr(lit(2), Operator::Eq, col("i2"));
+        let filter3_1 = binary_expr(lit(-3), Operator::Gt, col("i3"));
+
+        let filter1_2 = binary_expr(lit(-10), Operator::Lt, col("i1"));
+        let filter2_2 = binary_expr(lit(3), Operator::Eq, col("i2"));
+        let filter3_2 = binary_expr(lit(3), Operator::Lt, col("i3"));
+
+        let and_1 = and(and(filter1_1, filter2_1), filter3_1);
+        let and_2 = and(and(filter1_2, filter2_2), filter3_2);
+
+        let or = or(and_1, and_2);
+
+        let result = get_domains(&or);
+
+        assert!(result.is_ok(), "convert expr {} to column domains err", &or);
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        // build except result
+        //   i1: (-10, _)
+        //   i2: [2, 2], [3, 3]
+        //   i3: (_, -3), (3, _)
+        let i1 = Range::gt(&DataType::Int32, &ScalarValue::Int32(Some(-10_i32)));
+
+        let i2_1 = Range::eq(&DataType::Int32, &ScalarValue::Int32(Some(2_i32)));
+        let i2_2 = Range::eq(&DataType::Int32, &ScalarValue::Int32(Some(3_i32)));
+
+        let i3_1 = Range::lt(&DataType::Int32, &ScalarValue::Int32(Some(-3_i32)));
+        let i3_2 = Range::gt(&DataType::Int32, &ScalarValue::Int32(Some(3_i32)));
+
+        let i1_domain = Domain::of_ranges(&[i1]).unwrap();
+        let i2_domain = Domain::of_ranges(&[i2_1, i2_2]).unwrap();
+        let i3_domain = Domain::of_ranges(&[i3_1, i3_2]).unwrap();
+
+        let except_column_domains = &mut ColumnDomains::of(Column::from_name("i1"), &i1_domain);
+
+        except_column_domains.insert_or_intersect(Column::from_name("i2"), &i2_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("i3"), &i3_domain);
+
+        assert!(
+            except_column_domains.eq(&column_domain),
+            "convert expr {} to column domains err, excepted {:?}, found {:?}",
+            &or,
+            except_column_domains,
+            column_domain,
+        );
+    }
+
+    /// Expression simplification
+    /// eg.
+    ///   i1 < 1 and i1 < 2 and \
+    ///   i2 = 2 and i2 > -3 and \
+    ///   (i3 = 1 or i3 = 2 or i3 = 2)
+    ///   ===>
+    ///   i1: (_, 1)
+    ///   i2: [2, 2]
+    ///   i3: [1, 1], [2, 2]
+    #[tokio::test]
+    async fn test_simplify_expr_to_domain() {
+        // and
+        let filter1_1 = binary_expr(col("i1"), Operator::Lt, lit(1));
+        let filter1_2 = binary_expr(col("i1"), Operator::Lt, lit(2));
+        // and
+        let filter2_1 = binary_expr(col("i2"), Operator::Eq, lit(2));
+        let filter2_2 = binary_expr(col("i2"), Operator::Gt, lit(-3));
+        // or
+        let filter3_1 = binary_expr(col("i3"), Operator::Eq, lit(1));
+        let filter3_2 = binary_expr(col("i3"), Operator::Eq, lit(2));
+        let filter3_3 = binary_expr(col("i3"), Operator::Eq, lit(2));
+
+        let and_1 = and(filter1_1, filter1_2);
+        let and_2 = and(filter2_1, filter2_2);
+        let or_3 = or(or(filter3_1, filter3_2), filter3_3);
+
+        let and = and(and(and_1, and_2), or_3);
+
+        let result = get_domains(&and);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err",
+            &and
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        // build except result
+        //   i1: (_, 1)
+        //   i2: [2, 2]
+        //   i3: [1, 1], [2, 2]
+        let i1 = Range::lt(&DataType::Int32, &ScalarValue::Int32(Some(1_i32)));
+        let i2 = Range::eq(&DataType::Int32, &ScalarValue::Int32(Some(2_i32)));
+
+        let i3_1 = Range::eq(&DataType::Int32, &ScalarValue::Int32(Some(1_i32)));
+        let i3_2 = Range::eq(&DataType::Int32, &ScalarValue::Int32(Some(2_i32)));
+
+        let i1_domain = Domain::of_ranges(&[i1]).unwrap();
+        let i2_domain = Domain::of_ranges(&[i2]).unwrap();
+        let i3_domain = Domain::of_ranges(&[i3_1, i3_2]).unwrap();
+
+        let except_column_domains = &mut ColumnDomains::of(Column::from_name("i1"), &i1_domain);
+
+        except_column_domains.insert_or_intersect(Column::from_name("i2"), &i2_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("i3"), &i3_domain);
+
+        assert!(
+            except_column_domains.eq(&column_domain),
+            "convert expr {} to column domains err, excepted {:?}, found {:?}",
+            &and,
+            except_column_domains,
+            column_domain,
+        );
+    }
+
+    /// complex application scenarios - 1
+    /// eg.
+    ///   host = "192.168.1.222" and port > 10000 and port < 20000 and \
+    ///   time < "2022/12/31 01:01:01" and time >= "1970/01/01 01:01:01"
+    ///   ===>
+    ///   host: "192.168.1.222"
+    ///   port: [10000, 20000]
+    ///   time: ["1970/01/01 01:01:01", "2022/12/31 01:01:01")
+    #[tokio::test]
+    async fn test_complex_application_to_domain_1() {
+        let host = binary_expr(col("host"), Operator::Eq, lit("192.168.1.222"));
+        let port_low = binary_expr(col("port"), Operator::LtEq, lit(20000));
+        let port_high = binary_expr(col("port"), Operator::GtEq, lit(10000));
+
+        let epoch_l = NaiveDate::from_ymd(1970, 1, 1)
+            .and_hms(1, 1, 1)
+            .add(Duration::milliseconds(1000_i64));
+
+        let epoch_m = NaiveDate::from_ymd(2022, 12, 31)
+            .and_hms(1, 1, 1)
+            .add(Duration::milliseconds(1000_i64));
+
+        let filter_d2 = binary_expr(col("time"), Operator::Lt, lit(epoch_m.timestamp_micros()));
+        let filter_d3 = binary_expr(col("time"), Operator::GtEq, lit(epoch_l.timestamp_millis()));
+
+        let and_1 = and(and(host, port_low), port_high);
+        let and_2 = and(filter_d2, filter_d3);
+
+        let and = and(and_1, and_2);
+
+        let result = get_domains(&and);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err",
+            &and
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        // build except result
+        //   host: "192.168.1.222"
+        //   port: [10000, 20000]
+        //   time: ["1970/01/01 01:01:01", "2022/12/31 01:01:01")
+        let host = Range::eq(
+            &DataType::Utf8,
+            &ScalarValue::Utf8(Some("192.168.1.222".to_string())),
+        );
+        let port_1 = Range::ge(&DataType::Int32, &ScalarValue::Int32(Some(10000_i32)));
+        let port_2 = Range::le(&DataType::Int32, &ScalarValue::Int32(Some(20000_i32)));
+
+        let time_1 = Range::ge(&DataType::Int64, &ScalarValue::Int64(Some(3662000_i64)));
+        let time_2 = Range::lt(
+            &DataType::Int64,
+            &ScalarValue::Int64(Some(1672448462000000_i64)),
+        );
+
+        let host_domain = Domain::of_ranges(&[host]).unwrap();
+        let port_1_domain = Domain::of_ranges(&[port_1]).unwrap();
+        let port_2_domain = Domain::of_ranges(&[port_2]).unwrap();
+        let time_1_domain = Domain::of_ranges(&[time_1]).unwrap();
+        let time_2_domain = Domain::of_ranges(&[time_2]).unwrap();
+
+        let except_column_domains = &mut ColumnDomains::of(Column::from_name("host"), &host_domain);
+
+        except_column_domains.insert_or_intersect(Column::from_name("port"), &port_1_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("port"), &port_2_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("time"), &time_1_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("time"), &time_2_domain);
+
+        assert!(
+            except_column_domains.eq(&column_domain),
+            "convert expr {} to column domains err, excepted {:?}, found {:?}",
+            &and,
+            except_column_domains,
+            column_domain,
+        );
+    }
+
+    /// complex application scenarios - 2
+    /// eg.
+    ///   region = "hangzhou" and \
+    ///   (host >= host200 or host <= host099) and \
+    ///   time < "2022/12/31 01:01:01" and time >= "1970/01/01 01:01:01"
+    ///   ===>
+    ///   region: "hangzhou"
+    ///   host: (_, host099], [host200, _)
+    ///   time: ["1970/01/01 01:01:01", "2022/12/31 01:01:01")
+    #[tokio::test]
+    async fn test_complex_application_to_domain_2() {
+        let region = binary_expr(col("region"), Operator::Eq, lit("hangzhou"));
+        let host_low = binary_expr(col("host"), Operator::LtEq, lit("host099"));
+        let host_high = binary_expr(col("host"), Operator::GtEq, lit("host200"));
+
+        let epoch_l = NaiveDate::from_ymd(1970, 1, 1)
+            .and_hms(1, 1, 1)
+            .add(Duration::milliseconds(1000_i64));
+
+        let epoch_m = NaiveDate::from_ymd(2022, 12, 31)
+            .and_hms(1, 1, 1)
+            .add(Duration::milliseconds(1000_i64));
+
+        let filter_d2 = binary_expr(col("time"), Operator::Lt, lit(epoch_m.timestamp_micros()));
+        let filter_d3 = binary_expr(col("time"), Operator::GtEq, lit(epoch_l.timestamp_millis()));
+
+        let host_or = or(host_low, host_high);
+        let time_and = and(filter_d2, filter_d3);
+
+        let and = and(and(region, host_or), time_and);
+
+        let result = get_domains(&and);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err",
+            &and
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        // build except result
+        //   region: "hangzhou"
+        //   host: (_, host099], [host200, _)
+        //   time: ["1970/01/01 01:01:01", "2022/12/31 01:01:01")
+        let region = Range::eq(
+            &DataType::Utf8,
+            &ScalarValue::Utf8(Some("hangzhou".to_string())),
+        );
+        let host_1 = Range::le(
+            &DataType::Utf8,
+            &ScalarValue::Utf8(Some("host099".to_string())),
+        );
+        let host_2 = Range::ge(
+            &DataType::Utf8,
+            &ScalarValue::Utf8(Some("host200".to_string())),
+        );
+
+        let time_1 = Range::ge(&DataType::Int64, &ScalarValue::Int64(Some(3662000_i64)));
+        let time_2 = Range::lt(
+            &DataType::Int64,
+            &ScalarValue::Int64(Some(1672448462000000_i64)),
+        );
+
+        println!("{:#?}", &time_1);
+        println!("{:#?}", &time_2);
+
+        let region_domain = Domain::of_ranges(&[region]).unwrap();
+        let host_domain = Domain::of_ranges(&[host_1, host_2]).unwrap();
+        let time_1_domain = Domain::of_ranges(&[time_1]).unwrap();
+        let time_2_domain = Domain::of_ranges(&[time_2]).unwrap();
+
+        let except_column_domains =
+            &mut ColumnDomains::of(Column::from_name("region"), &region_domain);
+
+        except_column_domains.insert_or_intersect(Column::from_name("host"), &host_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("time"), &time_1_domain);
+        except_column_domains.insert_or_intersect(Column::from_name("time"), &time_2_domain);
+
+        assert!(
+            except_column_domains.eq(&column_domain),
+            "convert expr {} to column domains err, excepted {:?}, found {:?}",
+            &and,
+            except_column_domains,
+            column_domain,
+        );
+    }
+
+    /// partial support push down
+    /// eg.
+    ///   c1 > 1 and c2 > 1 or \
+    ///   c1 > -1
+    ///   ===>
+    ///   c1: (-1, _)
+    #[tokio::test]
+    async fn test_partial_support_expr_to_domain_1() {
+        let c1_1 = binary_expr(col("c1"), Operator::Gt, lit(1));
+        let c2_1 = binary_expr(col("c2"), Operator::Gt, lit(1));
+
+        let c1_2 = binary_expr(col("c1"), Operator::Gt, lit(-1));
+
+        let and_1 = and(c1_1, c2_1);
+
+        let and = or(and_1, c1_2);
+
+        let result = get_domains(&and);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err",
+            &and
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        // build except result
+        let range = Range::gt(&DataType::Int32, &ScalarValue::Int32(Some(-1_i32)));
+        let domain = Domain::of_ranges(&[range]).unwrap();
+        let except_column_domains: ColumnDomains<Column> =
+            ColumnDomains::of(Column::from_name("c1"), &domain);
+
+        assert!(
+            except_column_domains.eq(column_domain),
+            "convert expr {} to column domains err, excepted {:?}, found {:?}",
+            &and,
+            except_column_domains,
+            column_domain,
+        );
+    }
+
+    /// not support push down - 1
+    /// eg.
+    ///   c1 > 1 or \
+    ///   c2 > 1
+    ///   ===>
+    ///   All
+    #[tokio::test]
+    async fn test_not_support_expr_to_domain_1() {
+        let c1 = binary_expr(col("c1"), Operator::Gt, lit(1));
+        let c2 = binary_expr(col("c2"), Operator::Gt, lit(1));
+
+        let or = or(c1, c2);
+
+        let result = get_domains(&or);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err: {}",
+            &or,
+            result.unwrap_err()
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        assert!(
+            column_domain.is_all(),
+            "convert expr {} to column domains err, excepted ColumnDomains::All",
+            &or
+        );
+    }
+
+    /// not support push down - 2
+    /// eg.
+    ///   c1 in Values(1), (2), (3)
+    ///   ===>
+    ///   All
+    #[tokio::test]
+    async fn test_not_support_expr_to_domain_2() {
+        let list = vec![lit(1), lit(2), lit(3)];
+
+        let in_list = in_list(col("c1"), list, false);
+
+        let result = get_domains(&in_list);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err",
+            &in_list
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        assert!(
+            column_domain.is_all(),
+            "convert expr {} to column domains err, excepted ColumnDomains::All",
+            &in_list
+        );
+    }
+
+    /// not support push down - 3
+    /// eg.
+    ///   not c1 > 1
+    ///   ===>
+    ///   All
+    #[tokio::test]
+    async fn test_not_support_expr_to_domain_3() {
+        let c1 = binary_expr(col("c1"), Operator::Gt, lit(1));
+
+        let not = Expr::Not(Box::new(c1));
+
+        let result = get_domains(&not);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err",
+            &not
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        assert!(
+            column_domain.is_all(),
+            "convert expr {} to column domains err, excepted ColumnDomains::All",
+            &not
+        );
+    }
+
+    /// not support push down - 4
+    /// eg.
+    ///   c1 is null
+    ///   ===>
+    ///   All
+    #[tokio::test]
+    async fn test_not_support_expr_to_domain_4() {
+        let is_null = Expr::IsNull(Box::new(col("c1")));
+
+        let result = get_domains(&is_null);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err: {}",
+            &is_null,
+            result.unwrap_err()
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        assert!(
+            column_domain.is_all(),
+            "convert expr {} to column domains err, excepted ColumnDomains::All",
+            &is_null
+        );
+    }
+
+    /// not support push down - 5
+    /// eg.
+    ///   c1 > random()
+    ///   ===>
+    ///   All
+    #[tokio::test]
+    async fn test_not_support_expr_to_domain_5() {
+        let with_func = binary_expr(col("c1"), Operator::Gt, random());
+
+        let result = get_domains(&with_func);
+
+        assert!(
+            result.is_ok(),
+            "convert expr {} to column domains err: {}",
+            &with_func,
+            result.unwrap_err()
+        );
+
+        // println!("{:#?}", result.as_ref().unwrap());
+
+        let column_domain = result.as_ref().unwrap();
+
+        assert!(
+            column_domain.is_all(),
+            "convert expr {} to column domains err, excepted ColumnDomains::All",
+            &with_func
+        );
+    }
+
+    #[cfg(test)]
+    mod test_normalized_simple_comparison {
+        use super::*;
+
+        #[tokio::test]
+        async fn test_of() {
+            let c1 = "c1";
+            let val = 1_i32;
+            let nsc_option = NormalizedSimpleComparison::of(col(c1), Operator::Gt, lit(val));
+
+            assert!(nsc_option.is_some());
+            let nsc = nsc_option.unwrap();
+
+            assert_eq!(nsc.column, Column::from_name(c1));
+            assert_eq!(nsc.op, Operator::Gt);
+            assert_eq!(nsc.value, ScalarValue::Int32(Some(val)));
+
+            let nsc_option = NormalizedSimpleComparison::of(lit(val), Operator::Gt, col(c1));
+
+            assert!(nsc_option.is_some());
+            let nsc = nsc_option.unwrap();
+
+            assert_eq!(nsc.column, Column::from_name(c1));
+            assert_eq!(nsc.op, Operator::Lt);
+            assert_eq!(nsc.value, ScalarValue::Int32(Some(val)));
+        }
+
+        #[tokio::test]
+        async fn test_reverse() {
+            let wait_reverse = vec![
+                Operator::Lt,
+                Operator::LtEq,
+                Operator::Gt,
+                Operator::GtEq,
+                Operator::Eq,
+                Operator::NotEq,
+            ];
+            let except_reverse = vec![
+                Operator::Gt,
+                Operator::GtEq,
+                Operator::Lt,
+                Operator::LtEq,
+                Operator::Eq,
+                Operator::NotEq,
+            ];
+
+            let after_reverse: Vec<Operator> = wait_reverse
+                .iter()
+                .map(|e| NormalizedSimpleComparison::reverse_op(*e))
+                .collect();
+
+            assert_eq!(except_reverse, after_reverse);
+        }
+    }
+}

--- a/query/src/helper/mod.rs
+++ b/query/src/helper/mod.rs
@@ -1,3 +1,7 @@
+mod domain;
+
+pub use domain::RowExpressionToDomainsVisitor;
+
 use std::result;
 
 use datafusion::{

--- a/query/src/predicate.rs
+++ b/query/src/predicate.rs
@@ -1,17 +1,26 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    cmp::{self, Ordering},
+    collections::{BTreeMap, HashMap, HashSet},
+    hash::Hash,
+    sync::Arc,
+};
 
 use datafusion::{
-    arrow::{
-        array::BooleanArray, compute::filter_record_batch, error::ArrowError,
-        record_batch::RecordBatch,
-    },
+    arrow::datatypes::DataType,
     error::DataFusionError,
     logical_expr::{utils::expr_to_columns, Expr, Operator},
-    physical_expr::PhysicalExpr,
+    logical_plan::combine_filters,
+    scalar::ScalarValue,
 };
+use models::{Error, Result};
+
 use trace::info;
 
-type ArrowResult<T> = Result<T, ArrowError>;
+use crate::{
+    helper::RowExpressionToDomainsVisitor,
+    schema::{TableFiled, TableSchema},
+};
+
 pub type PredicateRef = Arc<Predicate>;
 
 #[derive(Default, Debug)]
@@ -30,17 +39,830 @@ impl TimeRange {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+enum Bound {
+    /// lower than the value, but infinitesimally close to the value.
+    Below,
+    // exactly the value.
+    Exactly,
+    // higher than the value, but infinitesimally close to the value.
+    Above,
+}
+
+/// A point on the continuous space defined by the specified type.
+///
+/// Each point may be just below, exact, or just above the specified value according to the Bound.
+#[derive(Debug, Clone)]
+pub struct Marker {
+    data_type: DataType,
+    value: Option<ScalarValue>,
+    bound: Bound,
+}
+
+impl Marker {
+    /// Infinitely (greater than a nonexistent number).
+    fn lower_unbound(data_type: DataType) -> Marker {
+        Self {
+            data_type,
+            value: None,
+            bound: Bound::Above,
+        }
+    }
+    /// Infinitely small (less than a nonexistent number).
+    fn upper_unbound(data_type: DataType) -> Marker {
+        Self {
+            data_type,
+            value: None,
+            bound: Bound::Below,
+        }
+    }
+
+    fn is_lower_unbound(&self) -> bool {
+        match (&self.value, &self.bound) {
+            (None, Bound::Above) => true,
+            (_, _) => false,
+        }
+    }
+
+    fn is_upper_unbound(&self) -> bool {
+        match (&self.value, &self.bound) {
+            (None, Bound::Below) => true,
+            (_, _) => false,
+        }
+    }
+    /// Check if data types are compatible.
+    fn check_type_compatibility(&self, other: &Self) -> bool {
+        self.data_type == other.data_type
+    }
+}
+
+impl PartialEq for Marker {
+    fn eq(&self, other: &Self) -> bool {
+        if !self.check_type_compatibility(other) {
+            return false;
+        }
+
+        if self.is_upper_unbound() {
+            return other.is_upper_unbound();
+        }
+
+        if self.is_lower_unbound() {
+            return other.is_lower_unbound();
+        }
+        // self not unbound
+        if other.is_upper_unbound() {
+            return false;
+        }
+        // self not unbound
+        if other.is_lower_unbound() {
+            return false;
+        }
+        // value and other.value are present
+        self.value
+            .as_ref()
+            .unwrap()
+            .eq(other.value.as_ref().unwrap())
+    }
+}
+
+impl PartialOrd for Marker {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        if !self.check_type_compatibility(other) {
+            return None;
+        }
+        // (∞, ∞)
+        // => Equal
+        // (∞, _)
+        // => Greater
+        if self.is_upper_unbound() {
+            return if other.is_upper_unbound() {
+                Some(std::cmp::Ordering::Equal)
+            } else {
+                Some(std::cmp::Ordering::Greater)
+            };
+        }
+        // (-∞, -∞)
+        // => Equal
+        // (-∞, _)
+        // => Less
+        if self.is_lower_unbound() {
+            return if other.is_lower_unbound() {
+                Some(std::cmp::Ordering::Equal)
+            } else {
+                Some(std::cmp::Ordering::Less)
+            };
+        }
+        // self not unbound
+        // (_, ∞)
+        // => Less
+        if other.is_upper_unbound() {
+            return Some(std::cmp::Ordering::Less);
+        }
+        // self not unbound
+        // (_, -∞)
+        // => Greater
+        if other.is_lower_unbound() {
+            return Some(std::cmp::Ordering::Greater);
+        }
+        // value and other.value are present
+        let self_data = self.value.as_ref().unwrap();
+        let other_data = other.value.as_ref().unwrap();
+
+        self_data.partial_cmp(other_data)
+    }
+}
+
+impl Eq for Marker {}
+
+impl Ord for Marker {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+/// A Range of values across the continuous space defined by the types of the Markers.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Range {
+    low: Marker,
+    high: Marker,
+}
+
+impl Range {
+    fn get_type(&self) -> &DataType {
+        &self.low.data_type
+    }
+    /// Check if data types are compatible.
+    ///
+    /// Returns an exception if the data types do not match.
+    ///
+    /// Returns the data type of self if the data types match.
+    fn check_type_compatibility(&self, other: &Range) -> Result<DataType> {
+        if !self.low.check_type_compatibility(&other.low) {
+            return Err(Error::Internal {
+                err: format!(
+                    "mismatched types: excepted {}, found {}",
+                    self.get_type(),
+                    other.get_type()
+                ),
+            });
+        }
+
+        Ok(self.low.data_type.clone())
+    }
+    /// Constructs a range of values match all records (-∞, +∞).
+    pub fn all(data_type: &DataType) -> Range {
+        let low = Marker {
+            data_type: data_type.clone(),
+            value: None,
+            bound: Bound::Above,
+        };
+        let high = Marker {
+            data_type: data_type.clone(),
+            value: None,
+            bound: Bound::Below,
+        };
+
+        Self { low, high }
+    }
+    /// Constructs a range of values equal to scalar_value [scalar_value, scalar_value].
+    pub fn eq(data_type: &DataType, scalar_value: &ScalarValue) -> Range {
+        let low = Marker {
+            data_type: data_type.clone(),
+            value: Some(scalar_value.clone()),
+            bound: Bound::Exactly,
+        };
+        let high = Marker {
+            data_type: data_type.clone(),
+            value: Some(scalar_value.clone()),
+            bound: Bound::Exactly,
+        };
+
+        Self { low, high }
+    }
+    /// TODO Constructs a range of values not equal to scalar_value [scalar_value, scalar_value].
+    pub fn ne(data_type: &DataType, _scalar_value: &ScalarValue) -> Range {
+        let low = Marker {
+            data_type: data_type.clone(),
+            value: None,
+            bound: Bound::Below,
+        };
+        let high = Marker {
+            data_type: data_type.clone(),
+            value: None,
+            bound: Bound::Above,
+        };
+
+        Self { low, high }
+    }
+    /// Construct a range of values greater than scalar_value (scalar_value, +∞).
+    pub fn gt(data_type: &DataType, scalar_value: &ScalarValue) -> Range {
+        let low = Marker {
+            data_type: data_type.clone(),
+            value: Some(scalar_value.clone()),
+            bound: Bound::Above,
+        };
+        let high = Marker::upper_unbound(data_type.clone());
+
+        Self { low, high }
+    }
+    /// Construct a range of values greater than or equal to scalar_value [scalar_value, +∞).
+    pub fn ge(data_type: &DataType, scalar_value: &ScalarValue) -> Range {
+        let low = Marker {
+            data_type: data_type.clone(),
+            value: Some(scalar_value.clone()),
+            bound: Bound::Exactly,
+        };
+        let high = Marker::upper_unbound(data_type.clone());
+
+        Self { low, high }
+    }
+    /// Construct a range of values smaller than scalar_value (-∞, scalar_value).
+    pub fn lt(data_type: &DataType, scalar_value: &ScalarValue) -> Range {
+        let low = Marker::lower_unbound(data_type.clone());
+        let high = Marker {
+            data_type: data_type.clone(),
+            value: Some(scalar_value.clone()),
+            bound: Bound::Below,
+        };
+
+        Self { low, high }
+    }
+    /// Construct a range of values less than or equal to scalar_value (-∞, scalar_value].
+    pub fn le(data_type: &DataType, scalar_value: &ScalarValue) -> Range {
+        let low = Marker::lower_unbound(data_type.clone());
+        let high = Marker {
+            data_type: data_type.clone(),
+            value: Some(scalar_value.clone()),
+            bound: Bound::Exactly,
+        };
+
+        Self { low, high }
+    }
+    /// Determine if two ranges of values overlap.
+    ///
+    /// If there is overlap, return Ok(true).
+    ///
+    /// If there no overlap, return Ok(false).
+    ///
+    /// Returns an exception if the data types are incompatible.
+    fn overlaps(&self, other: &Self) -> Result<bool> {
+        self.check_type_compatibility(other)?;
+        if self.low <= other.high && other.low <= self.high {
+            return Ok(true);
+        }
+        Ok(false)
+    }
+    /// Calculates the intersection of two ranges.
+    ///
+    /// return an exception, if there is no intersection.
+    fn intersect(&self, other: &Self) -> Result<Self> {
+        // Type mismatch directly returns an exception
+        if self.overlaps(other)? {
+            // There is overlap, calculate the intersection
+            let low = cmp::max(&self.low, &other.low);
+            let high = cmp::min(&self.high, &other.high);
+
+            return Ok(Self {
+                low: low.clone(),
+                high: high.clone(),
+            });
+        }
+        // If the type matches and there is no intersection, an exception is returned.
+        // If it is executed here, it means that there is a bug in the upper-level system logic.
+        Err(Error::Internal {
+            err: "cannot intersect non-overlapping ranges".to_string(),
+        })
+    }
+    /// Calculates the span of two ranges
+    ///
+    /// return new Range
+    ///
+    /// Returns an exception if the data types are incompatible.
+    fn span(&self, other: &Self) -> Result<Self> {
+        //Type mismatch directly returns an exception
+        if self.overlaps(other)? {
+            // There is overlap, calculate the intersection
+            let low = cmp::min(&self.low, &other.low);
+            let high = cmp::max(&self.high, &other.high);
+
+            return Ok(Self {
+                low: low.clone(),
+                high: high.clone(),
+            });
+        }
+        // If the type matches and there is no intersection, an exception is returned.
+        // If it is executed here, it means that there is a bug in the upper-level system logic.
+        Err(Error::Internal {
+            err: "cannot span non-overlapping ranges".to_string(),
+        })
+    }
+    /// whether to match all lines
+    pub fn is_all(&self) -> bool {
+        self.low.is_lower_unbound() && self.high.is_upper_unbound()
+    }
+
+    pub fn low_ref(&self) -> &Marker {
+        &self.low
+    }
+
+    pub fn high_ref(&self) -> &Marker {
+        &self.high
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ValueEntry {
+    data_type: DataType,
+    value: ScalarValue,
+}
+
+/// A set containing zero or more Ranges of the same type over a continuous space of possible values.
+///
+/// Ranges are coalesced into the most compact representation of non-overlapping Ranges.
+///
+/// This structure allows iteration across these compacted Ranges in increasing order, as well as other common set-related operation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RangeValueSet {
+    // data_type: DataType,
+    low_indexed_ranges: BTreeMap<Marker, Range>,
+}
+
+/// A set containing values that are uniquely identifiable.
+///
+/// Assumes an infinite number of possible values.
+/// The values may be collectively included (aka whitelist) or collectively excluded (aka !whitelist).
+#[derive(Debug, Clone, PartialEq)]
+pub struct EqutableValueSet {
+    data_type: DataType,
+    white_list: bool,
+    entries: HashSet<ValueEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Domain {
+    Range(RangeValueSet),
+    Equtable(EqutableValueSet),
+    None,
+    All,
+}
+
+impl Domain {
+    /// Ranges are coalesced into the most compact representation of non-overlapping Ranges.
+    ///
+    /// Return new ValueSet(RangeValueSet)
+    ///
+    /// Returns an exception if the data types are incompatible.
+    pub fn of_ranges(res: &[Range]) -> Result<Domain> {
+        if res.is_empty() {
+            return Ok(Domain::None);
+        }
+
+        let mut ranges = res.to_vec();
+        ranges.sort_by(|l, r| l.low.cmp(&r.low));
+
+        // at least one element
+        let mut current = ranges.get(0).unwrap().to_owned();
+
+        let mut low_indexed_ranges: BTreeMap<Marker, Range> = BTreeMap::default();
+
+        for next in &ranges[1..] {
+            // Check if types match
+            current.check_type_compatibility(next)?;
+
+            match current.overlaps(next) {
+                Ok(true) => {
+                    // If the two ranges have intersection, then merge
+                    let span_range = current.span(next).unwrap();
+                    current = span_range
+                }
+                Ok(false) => {
+                    // If there is no intersection between the two ranges,
+                    // save the current range interpolation,
+                    // and switch the current range to the next range
+                    low_indexed_ranges.insert(current.low.clone(), current.clone());
+                    current = next.clone();
+                }
+                Err(_) => {}
+            }
+        }
+        low_indexed_ranges.insert(current.low.clone(), current);
+
+        Ok(Domain::Range(RangeValueSet { low_indexed_ranges }))
+    }
+    /// Construct a set of values.
+    ///
+    /// white_list = true means equal to values
+    ///
+    /// white_list = false means not equal to values
+    pub fn of_values(data_type: &DataType, white_list: bool, values: &[&ScalarValue]) -> Domain {
+        let entries: HashSet<ValueEntry> = values
+            .iter()
+            .map(|e| ValueEntry {
+                data_type: data_type.clone(),
+                value: (*e).clone(),
+            })
+            .collect();
+
+        Domain::Equtable(EqutableValueSet {
+            data_type: data_type.clone(),
+            white_list,
+            entries,
+        })
+    }
+    /// Calculates the intersection of two ranges, and returns None if the intersection does not exist
+    ///
+    /// This method returns the new value without changing the old value
+    fn intersect(&self, other: &Domain) -> Result<Domain> {
+        match (self, other) {
+            (Self::Range(ref self_val_set), Self::Range(ref other_val_set)) => {
+                Domain::range_intersect(self_val_set, other_val_set)
+            }
+            (Self::Equtable(ref self_val_set), Self::Equtable(ref other_val_set)) => {
+                Domain::value_intersect(self_val_set, other_val_set)
+            }
+            (Self::None, _) | (_, Self::None) => Ok(Self::None),
+            (Self::All, _) => Ok(other.clone()),
+            (_, Self::All) => Ok(self.clone()),
+            _ => Err(Error::Internal {
+                err: "mismatched ValueSet type".to_string(),
+            }),
+        }
+    }
+    /// Calculates the union of two ranges
+    ///
+    /// This method returns the new value without changing the old value
+    ///
+    /// Returns an exception if the ValueSet types are incompatible.
+    ///
+    /// This method returns the new ValueSet without changing the old value
+    fn union(&self, other: &Domain) -> Result<Domain> {
+        match (self, other) {
+            (Self::Range(ref self_val_set), Self::Range(ref other_val_set)) => {
+                Domain::range_union(self_val_set, other_val_set)
+            }
+            (Self::Equtable(ref self_val_set), Self::Equtable(ref other_val_set)) => {
+                Domain::value_union(self_val_set, other_val_set)
+            }
+            (Self::None, _) => Ok(other.clone()),
+            (_, Self::None) => Ok(self.clone()),
+            (Self::All, _) | (_, Self::All) => Ok(Self::All),
+            _ => Err(Error::Internal {
+                err: "mismatched ValueSet type".to_string(),
+            }),
+        }
+    }
+    /// Merge and intersect two ordered range sets
+    ///
+    /// This method returns the new ValueSet without changing the old value
+    fn range_intersect(first: &RangeValueSet, other: &RangeValueSet) -> Result<Domain> {
+        let mut result: Vec<Range> = Vec::default();
+
+        let mut first_values = first.low_indexed_ranges.values();
+        let mut other_values = other.low_indexed_ranges.values();
+
+        let mut first_current_range: Range;
+        let mut other_current_range: Range;
+
+        match (first_values.next(), other_values.next()) {
+            (Some(first_range), Some(other_range)) => {
+                first_current_range = first_range.to_owned();
+                other_current_range = other_range.to_owned();
+                loop {
+                    if first_current_range.overlaps(&other_current_range)? {
+                        let range = first_current_range.intersect(&other_current_range)?;
+                        result.push(range);
+                    }
+
+                    match first_current_range.high.cmp(&other_current_range.high) {
+                        Ordering::Less | Ordering::Equal => {
+                            if let Some(range) = first_values.next() {
+                                first_current_range = range.to_owned();
+                            } else {
+                                break;
+                            }
+                        }
+                        _ => {
+                            if let Some(range) = other_values.next() {
+                                other_current_range = range.to_owned();
+                            } else {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            (_, _) => {
+                return Err(Error::Internal {
+                    err: "RangeValueSet not contains value".to_string(),
+                });
+            }
+        }
+
+        Domain::of_ranges(result.as_ref())
+    }
+    /// Merge and intersect two equable value sets
+    ///
+    /// This method returns the new ValueSet without changing the old value
+    fn value_intersect(first: &EqutableValueSet, other: &EqutableValueSet) -> Result<Domain> {
+        let result_data_type = &first.data_type;
+        let result_white_list: bool;
+        let result_entries: Vec<&ScalarValue>;
+
+        let first_entries = &first.entries;
+        let other_entries = &other.entries;
+
+        match (first.white_list, other.white_list) {
+            // A = {first_entries}
+            // B = {other_entries}
+            // first = A
+            // other = B
+            // so.
+            //   A ∩ B
+            (true, true) => {
+                result_white_list = true;
+                result_entries = first_entries
+                    .intersection(other_entries)
+                    .map(|e| &e.value)
+                    .collect();
+            }
+            // A = {first_entries}
+            // B = {other_entries}
+            // first = A
+            // other = !B
+            // so.
+            //   first ∩ other
+            //   => A ∩ !B
+            //   => A - B
+            (true, false) => {
+                result_white_list = true;
+                result_entries = first_entries
+                    .difference(other_entries)
+                    .map(|e| &e.value)
+                    .collect();
+            }
+            // A = {first_entries}
+            // B = {other_entries}
+            // first = !A
+            // other = B
+            // so.
+            //   first ∩ other
+            //   => !A ∩ B
+            //   => B - A
+            (false, true) => {
+                result_white_list = true;
+                result_entries = other_entries
+                    .difference(first_entries)
+                    .map(|e| &e.value)
+                    .collect();
+            }
+            // A = {first_entries}
+            // B = {other_entries}
+            // first = !A
+            // other = !B
+            // so.
+            //   first ∩ other
+            //   => !A ∩ !B
+            //   => !(A ∪ B)
+            (false, false) => {
+                result_white_list = false;
+                result_entries = other_entries
+                    .union(first_entries)
+                    .map(|e| &e.value)
+                    .collect();
+            }
+        }
+
+        Ok(Domain::of_values(
+            result_data_type,
+            result_white_list,
+            result_entries.as_ref(),
+        ))
+    }
+    /// Merge and intersect two equable value sets
+    ///
+    /// This method returns the new ValueSet without changing the old value
+    fn range_union(first: &RangeValueSet, other: &RangeValueSet) -> Result<Domain> {
+        let mut result: Vec<_> = first.low_indexed_ranges.values().cloned().collect();
+        let mut other_ranges: Vec<_> = other.low_indexed_ranges.values().cloned().collect();
+
+        result.append(&mut other_ranges);
+
+        Domain::of_ranges(&result)
+    }
+
+    fn value_union(first: &EqutableValueSet, other: &EqutableValueSet) -> Result<Domain> {
+        let result_data_type = &first.data_type;
+        let result_white_list: bool;
+        let result_entries: Vec<&ScalarValue>;
+
+        let first_entries = &first.entries;
+        let other_entries = &other.entries;
+
+        match (first.white_list, other.white_list) {
+            (true, true) => {
+                result_white_list = true;
+                result_entries = first_entries
+                    .union(other_entries)
+                    .map(|e| &e.value)
+                    .collect();
+            }
+            (true, false) => {
+                result_white_list = false;
+                result_entries = other_entries
+                    .difference(first_entries)
+                    .map(|e| &e.value)
+                    .collect();
+            }
+            (false, true) => {
+                result_white_list = false;
+                result_entries = first_entries
+                    .difference(other_entries)
+                    .map(|e| &e.value)
+                    .collect();
+            }
+            (false, false) => {
+                result_white_list = false;
+                result_entries = other_entries
+                    .intersection(first_entries)
+                    .map(|e| &e.value)
+                    .collect();
+            }
+        }
+
+        Ok(Domain::of_values(
+            result_data_type,
+            result_white_list,
+            result_entries.as_ref(),
+        ))
+    }
+}
+
+/// ColumnDomains is internally represented as a normalized map of each column to its
+///
+/// respective allowable value domain(ValueSet). Conceptually, these ValueSet can be thought of
+///
+/// as being AND'ed together to form the representative predicate.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnDomains<T>
+where
+    T: Eq + Hash + Clone,
+{
+    // None means no matching record.
+    // Empty map means match all records.
+    column_to_domain: Option<HashMap<T, Domain>>,
+}
+
+impl<T: Eq + Hash + Clone> ColumnDomains<T> {
+    pub fn all() -> Self {
+        Self {
+            column_to_domain: Some(HashMap::default()),
+        }
+    }
+    pub fn none() -> Self {
+        Self {
+            column_to_domain: None,
+        }
+    }
+    pub fn of(col: T, domain: &Domain) -> Self {
+        let mut result = ColumnDomains::all();
+        result
+            .column_to_domain
+            .as_mut()
+            .and_then(|map| map.insert(col, domain.clone()));
+        result
+    }
+
+    pub fn is_all(&self) -> bool {
+        if let Some(map) = &self.column_to_domain {
+            return map.is_empty();
+        }
+        false
+    }
+
+    pub fn is_none(&self) -> bool {
+        self.column_to_domain.is_none()
+    }
+
+    pub fn translate_column<U, F>(&self, f: F) -> ColumnDomains<U>
+    where
+        U: Eq + Hash + Clone,
+        F: Fn(&T) -> Option<U>,
+    {
+        if self.is_all() {
+            return ColumnDomains::all();
+        }
+
+        if self.is_none() {
+            return ColumnDomains::none();
+        }
+
+        let new_column_to_domain: Option<HashMap<U, Domain>> =
+            self.column_to_domain.as_ref().map(|e| {
+                e.iter()
+                    .map(|(k, v)| (f(k), v.clone()))
+                    .filter(|(k, _)| k.is_some())
+                    .map(|(k, v)| (k.unwrap(), v))
+                    .collect()
+            });
+
+        ColumnDomains {
+            column_to_domain: new_column_to_domain,
+        }
+    }
+
+    /// Intersection with other will change the current value
+    pub fn intersect(&mut self, other: &ColumnDomains<T>) {
+        match (
+            self.column_to_domain.as_mut(),
+            other.column_to_domain.as_ref(),
+        ) {
+            (Some(map1), Some(map2)) => {
+                // Calculate the intersection for each column
+                map2.iter().for_each(|(k2, v2)| {
+                    map1.entry(k2.clone())
+                        .and_modify(|v1| {
+                            *v1 = v1.intersect(v2).unwrap_or(Domain::None);
+                        })
+                        .or_insert_with(|| v2.clone());
+                });
+            }
+            (_, None) => {
+                self.column_to_domain = None;
+            }
+            (None, _) => {}
+        }
+    }
+
+    /// The union with other will change the current value
+    ///
+    /// Note:
+    ///
+    ///   The resulting ColumnDomains only retain all columns that appear in self and other, not a standard union
+    pub fn column_wise_union(&mut self, other: &ColumnDomains<T>) {
+        match (
+            self.column_to_domain.as_ref(),
+            other.column_to_domain.as_ref(),
+        ) {
+            (Some(map1), Some(map2)) => {
+                let mut result: HashMap<T, Domain> = HashMap::default();
+                // Take the union of the values corresponding to the keys contained in both maps and save them
+                map2.iter().for_each(|(k2, v2)| {
+                    let unioned_value = map1.get(k2).map(|v1| v1.union(v2).unwrap_or(Domain::All));
+
+                    if let Some(e) = unioned_value {
+                        result.insert(k2.clone(), e);
+                    };
+                });
+                self.column_to_domain = Some(result);
+            }
+            (_, None) => {}
+            (None, _) => {
+                self.column_to_domain = other.column_to_domain.clone();
+            }
+        }
+    }
+
+    pub fn insert_or_union(&mut self, col: T, domain: &Domain) {
+        self.column_to_domain
+            .get_or_insert(HashMap::default())
+            .entry(col)
+            .and_modify(|e| {
+                if let Ok(v) = e.union(domain) {
+                    *e = v;
+                }
+            })
+            .or_insert_with(|| domain.clone());
+    }
+
+    pub fn insert_or_intersect(&mut self, col: T, domain: &Domain) {
+        if let Some(map) = self.column_to_domain.as_mut() {
+            map.entry(col)
+                .and_modify(|e| {
+                    *e = e.intersect(domain).unwrap_or(Domain::None);
+                })
+                .or_insert_with(|| domain.clone());
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct Predicate {
     filters: Vec<Expr>,
+    pushed_down_domains: Option<ColumnDomains<TableFiled>>,
     limit: Option<usize>,
     timeframe: TimeRange,
 }
 
 impl Predicate {
-    pub fn new(filters: Vec<Expr>, limit: Option<usize>, timeframe: TimeRange) -> Self {
+    pub fn new(
+        filters: Vec<Expr>,
+        pushed_down_domains: Option<ColumnDomains<TableFiled>>,
+        limit: Option<usize>,
+        timeframe: TimeRange,
+    ) -> Self {
         Self {
             filters,
+            pushed_down_domains,
             limit,
             timeframe,
         }
@@ -126,26 +948,103 @@ impl Predicate {
         }
         self
     }
+
+    /// resolve and extract supported filter
+    /// convert filter to ColumnDomains and set self
+    pub fn extract_pushed_down_domains(
+        mut self,
+        filters: &[Expr],
+        table_schema: &TableSchema,
+    ) -> Predicate {
+        if let Some(ref expr) = combine_filters(filters) {
+            let domains_result = expr_to_domains(expr, table_schema);
+            match domains_result {
+                Ok(domains) => {
+                    self.pushed_down_domains = Some(domains);
+                }
+                Err(e) => {
+                    info!(
+                        "Error, {}, building push-down predicates for filters: {:#?}. No
+                    predicates are pushed down",
+                        e, filters
+                    );
+                }
+            }
+        }
+        self
+    }
+
+    /// resolve the time range based on the input expression
+    pub fn with_time_frame(mut self, max_ts: i64, min_ts: i64) -> Self {
+        self.timeframe = TimeRange::new(max_ts, min_ts);
+        self
+    }
 }
 
-pub fn batch_filter(
-    batch: &RecordBatch,
-    predicate: &Arc<dyn PhysicalExpr>,
-) -> ArrowResult<RecordBatch> {
-    predicate
-        .evaluate(batch)
-        .map(|v| v.into_array(batch.num_rows()))
-        .map_err(DataFusionError::into)
-        .and_then(|array| {
-            array
-                .as_any()
-                .downcast_ref::<BooleanArray>()
-                .ok_or_else(|| {
-                    DataFusionError::Internal(
-                        "Filter predicate evaluated to non-boolean value".to_string(),
-                    )
-                    .into()
-                })
-                .and_then(|filter_array| filter_record_batch(batch, filter_array))
-        })
+pub fn expr_to_domains(
+    expr: &Expr,
+    table_schema: &TableSchema,
+) -> Result<ColumnDomains<TableFiled>, DataFusionError> {
+    let fields = &table_schema.fields;
+    let column_domains = RowExpressionToDomainsVisitor::expr_to_column_domains(expr)?;
+    let resutl = column_domains.translate_column(|col| fields.get(&col.name).cloned());
+
+    Ok(resutl)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_of_ranges() {
+        let f1 = Range::lt(&DataType::Float64, &ScalarValue::Float64(Some(-1000000.1)));
+        let f2 = Range::gt(&DataType::Float64, &ScalarValue::Float64(Some(2.2)));
+        let f3 = Range::eq(
+            &DataType::Float64,
+            &ScalarValue::Float64(Some(3333333333333333.3)),
+        );
+
+        let domain_1 = Domain::of_ranges(&[f1]).unwrap();
+        let domain_2 = Domain::of_ranges(&[f2, f3]).unwrap();
+
+        assert!(matches!(domain_1, Domain::Range(_)));
+
+        assert!(match domain_2 {
+            Domain::Range(val_set) => {
+                // f2 and f3 will span to 1 range
+                val_set.low_indexed_ranges.len() == 1
+            }
+            _ => false,
+        });
+    }
+
+    #[tokio::test]
+    async fn test_of_values() {
+        let val = ScalarValue::Int32(Some(10_i32));
+
+        let elementss = &[&val, &val];
+        let domain = Domain::of_values(&DataType::Int32, true, elementss);
+
+        let except_result = ValueEntry {
+            data_type: DataType::Int32,
+            value: val,
+        };
+
+        // println!("{:#?}", domain);
+
+        match domain {
+            Domain::Equtable(val_set) => {
+                assert!(
+                    val_set.entries.len() == 1,
+                    "except val_set contain one value"
+                );
+                let ele = val_set.entries.iter().next().unwrap();
+                assert_eq!(ele.to_owned(), except_result);
+            }
+            _ => {
+                panic!("excepted Domain::Equtable")
+            }
+        };
+    }
 }

--- a/query/src/schema.rs
+++ b/query/src/schema.rs
@@ -44,7 +44,7 @@ impl TableSchema {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableFiled {
     pub id: u64,
     pub name: String,
@@ -106,7 +106,7 @@ impl TryFrom<ArrowDataType> for ColumnType {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ColumnType {
     Tag,
     Time,

--- a/query/src/table.rs
+++ b/query/src/table.rs
@@ -11,7 +11,10 @@ use datafusion::{
 };
 use tskv::engine::EngineRef;
 
-use crate::{predicate::Predicate, schema::TableSchema, tskv_exec::TskvExec};
+use crate::{
+    helper::expr_applicable_for_cols, predicate::Predicate, schema::TableSchema,
+    tskv_exec::TskvExec,
+};
 
 pub struct ClusterTable {
     engine: EngineRef,
@@ -63,8 +66,10 @@ impl TableProvider for ClusterTable {
         let filter = Arc::new(
             Predicate::default()
                 .set_limit(limit)
+                .extract_pushed_down_domains(filters, &self.schema)
                 .pushdown_exprs(filters),
         );
+
         return self
             .create_physical_plan(projection, filter.clone(), self.schema())
             .await;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- support 'and' expr TableScan pushdown
- partial support 'or' expr  TableScan pushdown
- support '=' '>' '<'  '<=' '>=' operators expr  TableScan pushdown
- support Neste supported expr
- not support 'not' 'in' 'is not null' 'not null' 'between and'

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
no
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
no