### PR TITLE
feat(drop) #567: Drop table and database, in tskv.

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -51,13 +51,13 @@ impl StorageConfig {
         if let Ok(size) = std::env::var("CNOSDB_STORAGE_MAX_COMPACT_SIZE") {
             self.max_compact_size = size.parse::<u64>().unwrap();
         }
-        if let Ok(size) = std::env::var("CNOSDB_STORAGE_MAX_RESIDENT") {
+        if let Ok(size) = std::env::var("CNOSDB_STORAGE_DIO_MAX_RESIDENT") {
             self.dio_max_resident = size.parse::<u64>().unwrap();
         }
-        if let Ok(size) = std::env::var("CNOSDB_STORAGE_MAX_NON_RESIDENT") {
+        if let Ok(size) = std::env::var("CNOSDB_STORAGE_DIO_MAX_NON_RESIDENT") {
             self.dio_max_non_resident = size.parse::<u64>().unwrap();
         }
-        if let Ok(size) = std::env::var("CNOSDB_STORAGE_PAGE_LEN_SCALE") {
+        if let Ok(size) = std::env::var("CNOSDB_STORAGE_DIO_PAGE_LEN_SCALE") {
             self.dio_page_len_scale = size.parse::<u64>().unwrap();
         }
     }

--- a/query_server/query/src/catalog.rs
+++ b/query_server/query/src/catalog.rs
@@ -139,6 +139,11 @@ impl SchemaProvider for IsiphoSchema {
 
     fn deregister_table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
         let mut tables = self.tables.write();
+
+        self.engine
+            .drop_table(&self.db_name, &name)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
         Ok(tables.remove(name))
     }
 

--- a/tskv/src/compaction/picker.rs
+++ b/tskv/src/compaction/picker.rs
@@ -119,7 +119,7 @@ impl Picker for LevelCompactionPicker {
                 break;
             }
             picking_files.push(file.clone());
-            file.mark_compaction();
+            file.mark_compacting();
         }
 
         if picking_files.len() <= 1 {
@@ -279,7 +279,7 @@ impl LevelCompactionPicker {
                 break;
             }
             dst_files.push(file.clone());
-            file.mark_compaction();
+            file.mark_compacting();
         }
 
         let mut picked_time_range = *src_files[0].time_range();
@@ -452,7 +452,7 @@ mod test {
                     make_tsm_file_name(&tsm_dir, file_desc.0),
                 );
                 if file_desc.4 {
-                    col.mark_compaction();
+                    col.mark_compacting();
                 }
                 col_files.push(Arc::new(col));
             }

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -36,7 +36,7 @@ pub struct Database {
 impl Database {
     pub fn new(name: &String, opt: Arc<Options>) -> Self {
         Self {
-            index: db_index::index_manger(opt.storage.index_dir())
+            index: db_index::index_manger(opt.storage.index_base_dir())
                 .write()
                 .get_db_index(&name),
             name: name.to_string(),
@@ -220,8 +220,15 @@ impl Database {
         &self.ts_families
     }
 
-    pub fn get_index(&self) -> &Arc<RwLock<db_index::DBIndex>> {
-        return &self.index;
+    pub fn for_each_ts_family<F>(&self, func: F)
+    where
+        F: FnMut((&TseriesFamilyId, &Arc<RwLock<TseriesFamily>>)),
+    {
+        self.ts_families.iter().for_each(func);
+    }
+
+    pub fn get_index(&self) -> Arc<RwLock<db_index::DBIndex>> {
+        return self.index.clone();
     }
 
     // todo: will delete in cluster version

--- a/tskv/src/engine.rs
+++ b/tskv/src/engine.rs
@@ -29,12 +29,16 @@ pub trait Engine: Send + Sync + Debug {
         fields: Vec<u32>,
     ) -> HashMap<SeriesId, HashMap<u32, Vec<DataBlock>>>;
 
-    async fn delete_series(
+    fn drop_database(&self, database: &str) -> Result<()>;
+
+    fn drop_table(&self, database: &str, table: &str) -> Result<()>;
+
+    fn delete_series(
         &self,
         db: &String,
-        sids: Vec<SeriesId>,
-        min: Timestamp,
-        max: Timestamp,
+        sids: &[SeriesId],
+        field_ids: &[FieldId],
+        time_range: &TimeRange,
     ) -> Result<()>;
 
     fn get_table_schema(&self, db: &String, tab: &String) -> Result<Option<Vec<FieldInfo>>>;

--- a/tskv/src/engine.rs
+++ b/tskv/src/engine.rs
@@ -79,12 +79,21 @@ impl Engine for MockEngine {
         todo!()
     }
 
-    async fn delete_series(
+
+    fn drop_database(&self, database: &str) -> Result<()> {
+        todo!()
+    }
+
+    fn drop_table(&self, database: &str, table: &str) -> Result<()> {
+        todo!()
+    }
+
+    fn delete_series(
         &self,
         db: &String,
-        sids: Vec<SeriesId>,
-        min: Timestamp,
-        max: Timestamp,
+        sids: &[SeriesId],
+        field_ids: &[FieldId],
+        time_range: &TimeRange,
     ) -> Result<()> {
         todo!()
     }

--- a/tskv/src/error.rs
+++ b/tskv/src/error.rs
@@ -89,4 +89,7 @@ pub enum Error {
 
     #[snafu(display("character set error"))]
     ErrCharacterSet,
+
+    #[snafu(display("panics in thread: {}", reason))]
+    ThreadJoin { reason: String },
 }

--- a/tskv/src/kv_option.rs
+++ b/tskv/src/kv_option.rs
@@ -51,8 +51,16 @@ impl StorageOptions {
         self.path.join(SUMMARY_PATH)
     }
 
-    pub fn index_dir(&self) -> PathBuf {
+    pub fn index_base_dir(&self) -> PathBuf {
         self.path.join(INDEX_PATH)
+    }
+
+    pub fn index_dir(&self, database: &str) -> PathBuf {
+        self.path.join(INDEX_PATH).join(database)
+    }
+
+    pub fn database_dir(&self, database: &str) -> PathBuf {
+        self.path.join(database)
     }
 
     pub fn tsm_dir(&self, database: &str, ts_family_id: u32) -> PathBuf {

--- a/tskv/src/record_file/errors.rs
+++ b/tskv/src/record_file/errors.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use snafu::{self, Snafu};
 
 use crate::file_manager;
@@ -14,8 +16,9 @@ pub enum RecordFileError {
         source: std::io::Error,
     },
 
-    #[snafu(display("Error with open file : {}", source))]
+    #[snafu(display("Error with open file '{}': {}", path.display(), source))]
     OpenFile {
+        path: PathBuf,
         source: file_manager::FileError,
     },
 

--- a/tskv/src/tsm/tombstone.rs
+++ b/tskv/src/tsm/tombstone.rs
@@ -42,12 +42,36 @@ pub struct Tombstone {
 /// - loop end
 pub struct TsmTombstone {
     tombstones: HashMap<FieldId, Vec<TimeRange>>,
-    tomb_accessor: File,
     tomb_size: u64,
-    mutex: Mutex<()>,
+
+    path: PathBuf,
+    tomb_accessor: Option<File>,
 }
 
 impl TsmTombstone {
+    pub fn new(path: impl AsRef<Path>, file_id: u64) -> Result<Self> {
+        let path = file_utils::make_tsm_tombstone_file_name(path, file_id);
+        let tomb_accessor = if file_manager::try_exists(&path) {
+            Some(file_manager::get_file_manager().open_create_file(&path)?)
+        } else {
+            None
+        };
+        let (tombstones, tomb_size) = if let Some(file) = tomb_accessor.as_ref() {
+            let mut tomb = HashMap::new();
+            Self::load_all(&file, &mut tomb)?;
+            (tomb, file.len())
+        } else {
+            (HashMap::new(), 0)
+        };
+
+        Ok(Self {
+            tombstones,
+            tomb_size,
+            path,
+            tomb_accessor,
+        })
+    }
+
     #[cfg(test)]
     pub fn with_path(path: impl AsRef<Path>) -> Result<Self> {
         let file = file_manager::get_file_manager().create_file(&path)?;
@@ -57,9 +81,9 @@ impl TsmTombstone {
 
         Ok(Self {
             tombstones: HashMap::new(),
-            tomb_accessor: file,
             tomb_size,
-            mutex: Mutex::new(()),
+            path: path.as_ref().into(),
+            tomb_accessor: Some(file),
         })
     }
 
@@ -73,14 +97,14 @@ impl TsmTombstone {
 
         Ok(Some(Self {
             tombstones: HashMap::new(),
-            tomb_accessor: file,
             tomb_size,
-            mutex: Mutex::new(()),
+            path: path,
+            tomb_accessor: Some(file),
         }))
     }
 
     pub fn open_for_write(path: impl AsRef<Path>, file_id: u64) -> Result<Self> {
-        let path = file_utils::make_tsm_tombstone_file_name(path, file_id);
+        let path = file_utils::make_tsm_tombstone_file_name(&path, file_id);
         let mut is_new = false;
         if !file_manager::try_exists(&path) {
             is_new = true;
@@ -94,16 +118,19 @@ impl TsmTombstone {
 
         Ok(Self {
             tombstones: HashMap::new(),
-            tomb_accessor: file,
             tomb_size,
-            mutex: Mutex::new(()),
+            path,
+            tomb_accessor: Some(file),
         })
     }
 
+    #[cfg(test)]
     pub fn load(&mut self) -> Result<()> {
-        let mut tombstones = HashMap::new();
-        Self::load_all(&self.tomb_accessor, &mut tombstones)?;
-        self.tombstones = tombstones;
+        if let Some(file) = self.tomb_accessor.as_ref() {
+            let mut tombstones = HashMap::new();
+            Self::load_all(file, &mut tombstones)?;
+            self.tombstones = tombstones;
+        }
 
         Ok(())
     }
@@ -148,13 +175,27 @@ impl TsmTombstone {
         Ok(())
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.tomb_size == 0
+    }
+
     pub fn add_range(&mut self, field_ids: &[FieldId], time_range: &TimeRange) -> Result<()> {
+        if self.tomb_accessor.is_none() {
+            self.tomb_accessor =
+                Some(file_manager::get_file_manager().open_create_file(&self.path)?);
+        }
+        let writer = self.tomb_accessor.as_ref().expect("initialized file");
+        if writer.len() == 0 {
+            Self::write_header_to(writer)?;
+            writer.sync_data(FileSync::Hard).context(error::IOSnafu)?;
+        }
+
         for field_id in field_ids.iter() {
             let tomb = Tombstone {
                 field_id: *field_id,
                 time_range: *time_range,
             };
-            Self::write_to(&self.tomb_accessor, self.tomb_size, &tomb).map(|s| {
+            Self::write_to(&writer, self.tomb_size, &tomb).map(|s| {
                 self.tomb_size += s as u64;
                 self.tombstones
                     .entry(*field_id)
@@ -202,10 +243,10 @@ impl TsmTombstone {
     }
 
     pub fn flush(&self) -> Result<()> {
-        self.tomb_accessor.set_len(self.tomb_size);
-        self.tomb_accessor
-            .sync_all(FileSync::Hard)
-            .context(error::IOSnafu)?;
+        if let Some(file) = self.tomb_accessor.as_ref() {
+            file.set_len(self.tomb_size);
+            file.sync_all(FileSync::Hard).context(error::IOSnafu)?;
+        }
         Ok(())
     }
 

--- a/tskv/src/version_set.rs
+++ b/tskv/src/version_set.rs
@@ -50,6 +50,10 @@ impl VersionSet {
             .clone()
     }
 
+    pub fn delete_db(&mut self, name: &String) -> Option<Arc<RwLock<Database>>> {
+        self.dbs.remove(name)
+    }
+
     pub fn get_all_db(&self) -> &HashMap<String, Arc<RwLock<Database>>> {
         return &self.dbs;
     }


### PR DESCRIPTION
# Which issue does this PR close?

# Rationale for this change

## Features: 
1. Call `Engine::drop_table()` when a schema provider deregisters table.
2. Cache may delete data by id.
3. File will be deleted when `ColumnFile` dropped.

## Fixes:
`LevelInfo::push_compact_meta` didn't set a valid `ColumnFile::path` after flush.

# What changes are included in this PR?

1. Add drop_table() and drop_database() in trait `Engine`.
2. Add parameter field_ids in `MemCache::delete_data()`.3. 
3. Implements `Drop` trait for `ColumnFile`.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
