### PR TITLE
Some refactors for flushing. 

### DIFF
--- a/common/line_protocol/src/parser.rs
+++ b/common/line_protocol/src/parser.rs
@@ -314,7 +314,7 @@ fn parse_field_value(buf: &str) -> Result<FieldValue> {
 }
 
 fn parse_numeric_field(buf: &str, positive: bool) -> Result<FieldValue> {
-    if buf.len() == 0 {
+    if buf.is_empty() {
         return Err(Error::Parse {
             pos: 0,
             content: buf.to_string(),
@@ -406,12 +406,10 @@ fn parse_boolean_field(buf: &str, boolean: bool) -> Result<FieldValue> {
 fn parse_string_field(buf: &str) -> Result<FieldValue> {
     match &buf[buf.len() - 1..] {
         "\"" => return Ok(FieldValue::Str(buf[1..buf.len() - 1].as_bytes().to_vec())),
-        _ => {
-            return Err(Error::Parse {
-                pos: 0,
-                content: buf.to_string(),
-            });
-        }
+        _ => Err(Error::Parse {
+            pos: 0,
+            content: buf.to_string(),
+        }),
     }
 }
 

--- a/query_server/query/src/instance.rs
+++ b/query_server/query/src/instance.rs
@@ -296,20 +296,12 @@ mod tests {
         )
         .await;
 
-        let mut num_cpu = num_cpus::get();
-        let mut num_cpu_w = 0;
-        loop {
-            num_cpu /= 10;
-            num_cpu_w += 1;
-            if num_cpu == 0 {
-                break;
-            }
-        }
+        let num_cpu = num_cpus::get().to_string();
         let mut re_partition = format!(
             "|               |           RepartitionExec: partitioning=RoundRobinBatch({})",
-            num_cpus::get()
+            num_cpu
         );
-        for _ in 0..60 - num_cpu_w + 1 {
+        for _ in 0..60 - num_cpu.chars().count() + 1 {
             re_partition.push(' ');
         }
         re_partition.push('|');

--- a/tskv/src/compaction/flush.rs
+++ b/tskv/src/compaction/flush.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::max,
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     iter::Peekable,
     path::{Path, PathBuf},
     rc::Rc,
@@ -8,13 +8,12 @@ use std::{
     sync::Arc,
 };
 
-use models::utils::split_code_type_id;
 use models::{
     utils as model_utils, FieldId, FieldInfo, RwLockRef, SeriesId, SeriesKey, Timestamp, ValueType,
 };
 use parking_lot::{Mutex, RwLock};
 use regex::internal::Input;
-use snafu::{NoneError, OptionExt, ResultExt, Snafu};
+use snafu::{NoneError, OptionExt, ResultExt};
 use tokio::{
     select,
     sync::{
@@ -24,22 +23,20 @@ use tokio::{
     },
 };
 use trace::{debug, error, info, warn};
-use utils;
 
-use crate::database::Database;
-use crate::index::IndexResult;
-use crate::tsm::coder_instence::CodeType;
 use crate::{
     compaction::FlushReq,
     context::GlobalContext,
-    error::{self, Result},
+    database::Database,
+    error::{self, Error, Result},
+    index::IndexResult,
     kv_option::Options,
-    memcache::{DataType, FieldVal, MemCache, MemEntry, SeriesData, SeriesDataIterator},
+    memcache::{DataType, FieldVal, MemCache, MemEntry, SeriesData},
     summary::{CompactMeta, SummaryTask, VersionEdit},
     tseries_family::{LevelInfo, Version},
-    tsm::{self, DataBlock, TsmWriter},
+    tsm::{self, coder_instence::CodeType, DataBlock, TsmWriter},
     version_set::VersionSet,
-    Error, TseriesFamilyId,
+    TseriesFamilyId,
 };
 
 struct FlushingBlock {
@@ -50,6 +47,7 @@ struct FlushingBlock {
 
 pub struct FlushTask {
     mem_caches: Vec<Arc<RwLock<MemCache>>>,
+    database: Option<Arc<RwLock<Database>>>,
     ts_family_id: TseriesFamilyId,
     global_context: Arc<GlobalContext>,
     path_tsm: PathBuf,
@@ -59,17 +57,19 @@ pub struct FlushTask {
 impl FlushTask {
     pub fn new(
         mem_caches: Vec<Arc<RwLock<MemCache>>>,
+        database: Option<Arc<RwLock<Database>>>,
         ts_family_id: TseriesFamilyId,
         global_context: Arc<GlobalContext>,
-        path_tsm: PathBuf,
-        path_delta: PathBuf,
+        path_tsm: impl AsRef<Path>,
+        path_delta: impl AsRef<Path>,
     ) -> Self {
         Self {
             mem_caches,
+            database,
             ts_family_id,
             global_context,
-            path_tsm,
-            path_delta,
+            path_tsm: path_tsm.as_ref().into(),
+            path_delta: path_delta.as_ref().into(),
         }
     }
 
@@ -77,7 +77,6 @@ impl FlushTask {
         self,
         version: Arc<Version>,
         version_edits: &mut Vec<VersionEdit>,
-        db: Option<Arc<RwLock<Database>>>,
     ) -> Result<()> {
         info!(
             "Flush: Running flush job on ts_family: {} with {} MemCaches, collecting informations.",
@@ -91,22 +90,31 @@ impl FlushTask {
         for mem in self.mem_caches.iter() {
             flushing_mems.push(mem.write());
         }
-        let mut compactor = FlushCompactIterator::new(flushing_mems.len(), version.max_level_ts);
+        let mut flushing_mems_data: HashMap<u64, Vec<Arc<RwLock<SeriesData>>>> = HashMap::new();
         for mem in flushing_mems.iter() {
             let seq_no = mem.seq_no();
             high_seq = seq_no.max(high_seq);
             low_seq = seq_no.min(low_seq);
             total_memcache_size += mem.cache_size();
 
-            compactor.append_upstream_iterator(mem.iter_series_data());
+            for (series_id, series_data) in mem.read_series_data() {
+                flushing_mems_data
+                    .entry(series_id)
+                    .or_insert_with(|| Vec::with_capacity(flushing_mems.len()))
+                    .push(series_data);
+            }
         }
 
         if total_memcache_size == 0 {
             return Ok(());
         }
 
-        let mut compact_metas = self.write_block_set(&mut compactor, 0, db)?;
         let mut max_level_ts = version.max_level_ts;
+        let mut compact_metas = self.flush_mem_caches(
+            flushing_mems_data,
+            max_level_ts,
+            tsm::MAX_BLOCK_VALUES as usize,
+        )?;
         let mut edit = VersionEdit::new();
         for cm in compact_metas.iter_mut() {
             cm.low_seq = low_seq;
@@ -118,7 +126,6 @@ impl FlushTask {
         }
         version_edits.push(edit);
 
-        drop(compactor);
         for mem in flushing_mems.iter_mut() {
             mem.flushed = true;
         }
@@ -126,54 +133,65 @@ impl FlushTask {
         Ok(())
     }
 
-    fn write_block_set(
+    /// Merges caches data and write them into a `.tsm` file and a `.delta` file
+    /// (Sometimes one of the two file type.), returns `CompactMeta`s of the wrote files.
+    fn flush_mem_caches(
         &self,
-        compactor: &mut FlushCompactIterator,
-        max_file_size: u64,
-        db: Option<Arc<RwLock<Database>>>,
+        mut caches_data: HashMap<SeriesId, Vec<Arc<RwLock<SeriesData>>>>,
+        max_level_ts: Timestamp,
+        data_block_size: usize,
     ) -> Result<Vec<CompactMeta>> {
-        let mut tsm_writer: Option<TsmWriter> = None;
         let mut delta_writer: Option<TsmWriter> = None;
-        while let Some(series_flushing_data) = compactor.next() {
-            let series_id = match compactor.last_sid {
-                None => return Err(Error::InvalidSeriesId),
-                Some(v) => v,
-            };
+        let mut tsm_writer: Option<TsmWriter> = None;
 
-            let schema = self.get_table_schema(series_id, db.clone())?;
-            let field_id_code_type_map = {
-                let mut res_map = HashMap::new();
-                for i in schema.iter() {
-                    let code_type_id = i.code_type();
-                    res_map.insert(i.field_id(), code_type_id);
-                }
-                res_map
-            };
+        for (sid, series_datas) in caches_data.iter_mut() {
+            let schema: Vec<FieldInfo> = self.get_table_schema(*sid)?;
+            let field_id_code_type_map: HashMap<FieldId, u8> =
+                HashMap::from_iter(schema.iter().map(|f| (f.field_id(), f.code_type())));
+            let mut schema_columns_value_type_map: HashMap<u32, ValueType> = HashMap::new();
+            let mut column_values_map: HashMap<u32, Vec<(Timestamp, FieldVal)>> = HashMap::new();
 
-            for (field_id, dlt_blks, tsm_blks) in series_flushing_data {
-                if !tsm_blks.is_empty() && tsm_writer.is_none() {
-                    let writer = tsm::new_tsm_writer(
-                        self.path_tsm.clone(),
-                        self.global_context.file_id_next(),
-                        false,
-                        max_file_size,
-                    )?;
-                    info!("Flush: File {}(tsm) been created.", writer.sequence());
-                    tsm_writer = Some(writer);
+            // Iterates [ MemCache ] -> next_series_id -> [ SeriesData ]
+            for series_data in series_datas.iter_mut() {
+                // Iterates SeriesData -> [ RowGroups{ schema_id, schema, [ RowData ] } ]
+                for (sch_id, sch_cols, rows) in series_data.read().flat_groups() {
+                    // Iterates [ RowData ]
+                    for row in rows.iter() {
+                        // Iterates RowData -> [ Option<FieldVal>, column_id ]
+                        for (val, col) in row.fields.iter().zip(sch_cols.iter()) {
+                            if let Some(v) = val {
+                                schema_columns_value_type_map
+                                    .entry(*col)
+                                    .or_insert_with(|| v.value_type());
+                                column_values_map
+                                    .entry(*col)
+                                    .or_insert_with(Vec::new)
+                                    .push((row.ts, v.clone()));
+                            }
+                        }
+                    }
                 }
-                if !dlt_blks.is_empty() && delta_writer.is_none() {
-                    let writer = tsm::new_tsm_writer(
-                        self.path_delta.clone(),
-                        self.global_context.file_id_next(),
-                        true,
-                        max_file_size,
-                    )?;
-                    info!("Flush: File {}(delta) been created.", writer.sequence());
-                    delta_writer = Some(writer);
-                }
+            }
 
-                for mut data_block in tsm_blks {
-                    if let Some(writer) = tsm_writer.as_mut() {
+            // Merge the collected data.
+            let merged_series_data = Self::merge_series_data(
+                *sid,
+                column_values_map,
+                schema_columns_value_type_map,
+                max_level_ts,
+                data_block_size,
+            );
+
+            // Write the merged data into files.
+            for (field_id, dlt_blks, tsm_blks) in merged_series_data {
+                if !dlt_blks.is_empty() {
+                    if delta_writer.is_none() {
+                        let writer = self.new_writer(true)?;
+                        info!("Flush: File {}(delta) been created.", writer.sequence());
+                        delta_writer = Some(writer);
+                    };
+                    let writer = delta_writer.as_mut().unwrap();
+                    for mut data_block in dlt_blks {
                         data_block
                             .set_code_type_id(*field_id_code_type_map.get(&field_id).unwrap_or(&0));
                         writer
@@ -181,8 +199,14 @@ impl FlushTask {
                             .context(error::WriteTsmSnafu)?;
                     }
                 }
-                for mut data_block in dlt_blks {
-                    if let Some(writer) = delta_writer.as_mut() {
+                if !tsm_blks.is_empty() {
+                    if tsm_writer.is_none() {
+                        let writer = self.new_writer(false)?;
+                        info!("Flush: File {}(tsm) been created.", writer.sequence());
+                        tsm_writer = Some(writer);
+                    }
+                    let writer = tsm_writer.as_mut().unwrap();
+                    for mut data_block in tsm_blks {
                         data_block
                             .set_code_type_id(*field_id_code_type_map.get(&field_id).unwrap_or(&0));
                         writer
@@ -192,6 +216,78 @@ impl FlushTask {
                 }
             }
         }
+
+        // Flush the wrote files.
+        self.finish_flush_mem_caches(delta_writer, tsm_writer)
+    }
+
+    /// For the collected data, sort and dedup by timestamp, and then group by max_level_ts.
+    /// Returns [ ( FieldId, Delta_DataBlock, Tsm_DatBlock) ]
+    fn merge_series_data(
+        series_id: SeriesId,
+        column_values: HashMap<u32, Vec<(Timestamp, FieldVal)>>,
+        column_types: HashMap<u32, ValueType>,
+        max_level_ts: Timestamp,
+        data_block_size: usize,
+    ) -> Vec<(FieldId, Vec<DataBlock>, Vec<DataBlock>)> {
+        let mut cols_data: Vec<(FieldId, Vec<DataBlock>, Vec<DataBlock>)> =
+            Vec::with_capacity(column_values.len());
+
+        for (col, mut values) in column_values.into_iter() {
+            if let Some(typ) = column_types.get(&col) {
+                values.sort_by_key(|a| a.0);
+                utils::dedup_front_by_key(&mut values, |a| a.0);
+
+                let field_id = model_utils::unite_id(col as u64, series_id);
+                let mut delta_blocks = Vec::new();
+                let mut tsm_blocks = Vec::new();
+                let mut tsm_blk = DataBlock::new(data_block_size, *typ);
+                let mut delta_blk = DataBlock::new(data_block_size, *typ);
+                for (ts, v) in values {
+                    if ts > max_level_ts {
+                        tsm_blk.insert(&v.data_value(ts));
+                        if tsm_blk.len() as usize >= data_block_size {
+                            tsm_blocks.push(tsm_blk);
+                            tsm_blk = DataBlock::new(data_block_size, *typ);
+                        }
+                    } else {
+                        delta_blk.insert(&v.data_value(ts));
+                        if delta_blk.len() as usize >= data_block_size {
+                            delta_blocks.push(delta_blk);
+                            delta_blk = DataBlock::new(data_block_size, *typ);
+                        }
+                    }
+                }
+                if !delta_blk.is_empty() {
+                    delta_blocks.push(delta_blk);
+                }
+                if !tsm_blk.is_empty() {
+                    tsm_blocks.push(tsm_blk);
+                }
+                cols_data.push((field_id, delta_blocks, tsm_blocks));
+            }
+        }
+
+        // Sort by FieldId
+        cols_data.sort_by_key(|a| a.0);
+        cols_data
+    }
+
+    fn new_writer(&self, is_delta: bool) -> Result<TsmWriter> {
+        let dir = if is_delta {
+            &self.path_delta
+        } else {
+            &self.path_tsm
+        };
+        tsm::new_tsm_writer(dir, self.global_context.file_id_next(), is_delta, 0)
+    }
+
+    /// Flush writers (if it exists) and then generate `CompactMeta`s.
+    fn finish_flush_mem_caches(
+        &self,
+        mut delta_writer: Option<TsmWriter>,
+        mut tsm_writer: Option<TsmWriter>,
+    ) -> Result<Vec<CompactMeta>> {
         if let Some(writer) = tsm_writer.as_mut() {
             writer.write_index().context(error::WriteTsmSnafu)?;
             writer.flush().context(error::WriteTsmSnafu)?;
@@ -235,49 +331,24 @@ impl FlushTask {
             ));
         }
 
+        // Sort by File id.
+        compact_metas.sort_by_key(|c| c.file_id);
+
         Ok(compact_metas)
     }
 
-    fn get_table_schema(
-        &self,
-        series_id: SeriesId,
-        db: Option<Arc<RwLock<Database>>>,
-    ) -> Result<Vec<FieldInfo>> {
-        match db {
+    fn get_table_schema(&self, series_id: SeriesId) -> Result<Vec<FieldInfo>> {
+        match self.database.as_ref() {
             None => {
                 warn!("database not found, get empty schema",);
-                Ok(vec![])
+                Ok(Vec::with_capacity(0))
             }
             Some(db) => {
-                let series_key = match db.read().get_series_key(series_id) {
-                    Ok(series_key) => {
-                        if let Some(series_key_unwrap) = series_key {
-                            series_key_unwrap
-                        } else {
-                            warn!(
-                                "table not found for series id : {}, get empty schema",
-                                series_id
-                            );
-                            return Ok(vec![]);
-                        }
-                    }
-                    Err(e) => return Err(Error::IndexErr { source: e }),
-                };
-
-                match db.read().get_table_schema(series_key.table()) {
-                    Ok(schema) => {
-                        if let Some(schema_unwrap) = schema {
-                            Ok(schema_unwrap)
-                        } else {
-                            warn!(
-                                "table schema not found for table name : {}, get empty schema",
-                                series_key.table()
-                            );
-                            return Ok(vec![]);
-                        }
-                    }
-                    Err(e) => Err(Error::IndexErr { source: e }),
-                }
+                let schema_opt = db
+                    .read()
+                    .get_table_schema_by_series_id(series_id)
+                    .context(error::IndexErrSnafu)?;
+                Ok(schema_opt.unwrap_or_else(|| Vec::with_capacity(0)))
             }
         }
     }
@@ -314,23 +385,23 @@ pub async fn run_flush_memtable_job(
             }
 
             // todo: build path by vnode data
-
             let tsf_rlock = tsf.read();
             let storage_opt = tsf_rlock.storage_opt();
             let database = tsf_rlock.database();
-            let db = version_set.read().get_db(&database);
+            let db_instance = version_set.read().get_db(&database);
             let path_tsm = storage_opt.tsm_dir(&database, *tsf_id);
             let path_delta = storage_opt.delta_dir(&database, *tsf_id);
             drop(tsf_rlock);
 
             FlushTask::new(
                 caches.clone(),
+                db_instance,
                 *tsf_id,
                 global_context.clone(),
                 path_tsm,
                 path_delta,
             )
-            .run(tsf.read().version(), &mut edits, db)
+            .run(tsf.read().version(), &mut edits)
             .await?;
 
             match compact_task_sender.send(*tsf_id) {
@@ -354,194 +425,33 @@ pub async fn run_flush_memtable_job(
     Ok(())
 }
 
-struct FlushCompactIterator<'a> {
-    iterators: Vec<Peekable<SeriesDataIterator<'a>>>,
-    max_level_ts: i64,
-    data_block_size: usize,
-
-    iterators_count: usize,
-    curr_sid: Option<SeriesId>,
-    last_sid: Option<SeriesId>,
-    flushing_series_datas: Vec<RwLockRef<SeriesData>>,
-}
-
-impl<'a> FlushCompactIterator<'a> {
-    pub fn new(capacity: usize, max_level_ts: i64) -> Self {
-        Self {
-            iterators: Vec::with_capacity(capacity),
-            max_level_ts,
-            data_block_size: 1000,
-
-            iterators_count: 0,
-            curr_sid: None,
-            last_sid: None,
-            flushing_series_datas: vec![],
-        }
-    }
-
-    pub fn append_upstream_iterator(&mut self, iterator: SeriesDataIterator<'a>) {
-        self.iterators.push(iterator.peekable());
-        self.iterators_count += 1;
-    }
-
-    pub fn next_series_id(&mut self) {
-        debug!("Selecting next series_id.");
-        let mut skipped = 0_usize;
-        self.curr_sid = None;
-        self.last_sid = None;
-        self.flushing_series_datas.truncate(0);
-        loop {
-            if skipped >= self.iterators_count {
-                // Current series_id found, or all iterators finished
-                self.curr_sid = None;
-                break;
-            }
-            for iter in self.iterators.iter_mut() {
-                if let Some((sid, series_data)) = iter.peek() {
-                    if let Some(curr_sid) = self.curr_sid {
-                        if *sid != curr_sid {
-                            debug!("Skipped series_id: {}", sid);
-                            skipped += 1;
-                            continue;
-                        }
-                    } else {
-                        debug!("Selected next series_id: '{}'", sid);
-                        self.curr_sid = Some(*sid);
-                        self.last_sid = Some(*sid);
-                    }
-                    self.flushing_series_datas.push(series_data.clone());
-                    iter.next();
-                } else {
-                    skipped += 1;
-                    continue;
-                }
-            }
-        }
-
-        debug!("Selected series_id: '{:?}'.", self.last_sid);
-    }
-
-    fn sort_dedup(v: &mut Vec<(Timestamp, FieldVal)>) {
-        v.sort_by_key(|a| a.0);
-        utils::dedup_front_by_key(v, |a| a.0);
-    }
-
-    /// Transform v into two Vec<DataBlock>, witch are delta blocks and tsm blocks.
-    fn into_splited_data_blocks(
-        value_type: ValueType,
-        v: Vec<(Timestamp, FieldVal)>,
-        max_level_ts: Timestamp,
-        data_block_size: usize,
-    ) -> (Vec<DataBlock>, Vec<DataBlock>) {
-        let mut delta_blocks = Vec::new();
-        let mut delta_blk = DataBlock::new(data_block_size, value_type);
-        let mut tsm_blocks = Vec::new();
-        let mut tsm_blk = DataBlock::new(data_block_size, value_type);
-        for (ts, v) in v {
-            if ts > max_level_ts {
-                tsm_blk.insert(&v.data_value(ts));
-                if tsm_blk.len() as usize >= data_block_size {
-                    tsm_blocks.push(tsm_blk);
-                    tsm_blk = DataBlock::new(data_block_size, value_type);
-                }
-            } else {
-                delta_blk.insert(&v.data_value(ts));
-                if delta_blk.len() as usize >= data_block_size {
-                    delta_blocks.push(delta_blk);
-                    delta_blk = DataBlock::new(data_block_size, value_type);
-                }
-            }
-        }
-        if tsm_blk.len() > 0 {
-            tsm_blocks.push(tsm_blk);
-        }
-        if delta_blk.len() > 0 {
-            delta_blocks.push(delta_blk);
-        }
-
-        (delta_blocks, tsm_blocks)
-    }
-}
-
-impl<'a> Iterator for FlushCompactIterator<'a> {
-    type Item = Vec<(FieldId, Vec<DataBlock>, Vec<DataBlock>)>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        // 1. Get next Vec<SeriesData> for next SeriesId from each MemCache.
-        self.next_series_id();
-        if self.last_sid.is_none() {
-            return None;
-        }
-
-        // 2. Merge Vec<SeriesData> of the next SeriesId.
-        if self.flushing_series_datas.is_empty() {
-            // TODO: Return something
-            return Some(vec![]);
-        }
-
-        let mut schema_columns_value_type_map: HashMap<u32, ValueType> = HashMap::new();
-        let mut column_values_map: HashMap<u32, Vec<(Timestamp, FieldVal)>> = HashMap::new();
-
-        // Iterates [ MemCache ] -> next_series_id -> [ SeriesData ]
-        for series_data in self.flushing_series_datas.iter() {
-            // Iterates SeriesData -> [ RowGroups{ schema_id, schema, [ RowData ] } ]
-            for (sch_id, sch_cols, rows) in series_data.read().flat_groups() {
-                // Iterates [ RowData ]
-                for row in rows.iter() {
-                    // Iterates RowData -> [ Option<FieldVal>, column_id ]
-                    for (val, col) in row.fields.iter().zip(sch_cols.iter()) {
-                        if let Some(v) = val {
-                            schema_columns_value_type_map
-                                .entry(*col)
-                                .or_insert_with(|| v.value_type());
-                            column_values_map
-                                .entry(*col)
-                                .or_insert_with(|| Vec::new())
-                                .push((row.ts, v.clone()));
-                        }
-                    }
-                }
-            }
-        }
-
-        let mut ret_vec: Vec<(FieldId, Vec<DataBlock>, Vec<DataBlock>)> =
-            Vec::with_capacity(column_values_map.len());
-        let mut ret_vec_col_id = Vec::with_capacity(ret_vec.capacity());
-        for (col, mut values) in column_values_map.into_iter() {
-            Self::sort_dedup(&mut values);
-            if let Some(typ) = schema_columns_value_type_map.get(&col) {
-                let (dlt, tsm) = Self::into_splited_data_blocks(
-                    *typ,
-                    values,
-                    self.max_level_ts,
-                    self.data_block_size,
-                );
-                let field_id = model_utils::unite_id(col as u64, self.last_sid.unwrap());
-                ret_vec.push((field_id, dlt, tsm));
-                ret_vec_col_id.push(col);
-            }
-        }
-        ret_vec.sort_by_key(|a| a.0);
-
-        return Some(ret_vec);
-    }
-}
-
 #[cfg(test)]
-pub mod test {
-    use models::{utils as model_utils, Timestamp};
+pub mod flush_tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    use models::{utils as model_utils, FieldId, Timestamp};
+    use parking_lot::RwLock;
     use utils::dedup_front_by_key;
 
     use crate::memcache::test::put_rows_to_cache;
+    use crate::summary::{CompactMeta, VersionEdit};
+    use crate::tseries_family::{LevelInfo, Version};
+    use crate::tsm::tsm_reader_tests::read_and_check;
+    use crate::tsm::{DataBlock, TsmReader};
     use crate::{
-        compaction::{flush::FlushCompactIterator, FlushReq},
+        compaction::FlushReq,
         context::GlobalContext,
         kv_option::Options,
         memcache::{DataType, FieldVal, MemCache},
         tseries_family::FLUSH_REQ,
-        tsm::test::check_data_block,
         version_set::VersionSet,
     };
+    use crate::{file_manager, file_utils};
+
+    use super::FlushTask;
 
     #[test]
     fn test_sort_dedup() {
@@ -560,12 +470,21 @@ pub mod test {
         assert_eq!(&data, &vec![(1, 12), (2, 22), (3, 3), (4, 42)]);
     }
 
-    #[test]
-    fn test_flush() {
+    #[tokio::test]
+    async fn test_flush() {
+        let config = config::get_config("../config/config.toml");
+        trace::init_default_global_tracing(&config.log.path, "tskv.log", "debug");
+
+        let dir = PathBuf::from_str("/tmp/test/flush/test_flush").unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let tsm_dir = dir.join("tsm");
+        let delta_dir = dir.join("delta");
+
         let mut caches = vec![
-            MemCache::new(1, 1024, 0),
-            MemCache::new(1, 1024, 0),
-            MemCache::new(1, 1024, 0),
+            MemCache::new(1, 16, 0),
+            MemCache::new(1, 16, 0),
+            MemCache::new(1, 16, 0),
         ];
         put_rows_to_cache(&mut caches[0], 1, 1, vec![0, 1, 2], (3, 4), false);
         put_rows_to_cache(&mut caches[0], 1, 2, vec![0, 1, 3], (1, 2), false);
@@ -584,102 +503,97 @@ pub mod test {
 
         let max_level_ts = 10;
 
+        // | === SeriesId: 1 === |
+        // Ts:    1,    2,    3,    4,    5,    5, 6
+        // Col_0: 1,    2,    3,    4,    None, 5, 6
+        // Col_1: 1,    2,    3,    4,    None, 5, 6
+        // Col_2: None, None, 3,    4,    None, 5, 6
+        // Col_3: 1,    2,    None, None, None, 5, 6
+        // | === SeriesId: 2 === |
+        // Ts:    7,    8,    9,    10
+        // Col_0: 7,    8,    9,    10
+        // Col_1: 7,    8,    9,    10
+        // Col_2: None, None, 9,    10
+        // Col_3: 7,    8,    None, None
         #[rustfmt::skip]
-        let expected_data: Vec<Vec<(u32, u64, Vec<DataType>, Vec<DataType>)>> = vec![
-            // | === SeriesId: 1 === |
-            // Ts:    1,    2,    3,    4,    5,    5, 6
-            // Col_0: 1,    2,    3,    4,    None, 5, 6
-            // Col_1: 1,    2,    3,    4,    None, 5, 6
-            // Col_2: None, None, 3,    4,    None, 5, 6
-            // Col_3: 1,    2,    None, None, None, 5, 6
-            vec![
-                (0, 1, vec![
-                    DataType::F64(1, 1.0), DataType::F64(2, 2.0), DataType::F64(3, 3.0), DataType::F64(4, 4.0),
-                    DataType::F64(5, 5.0), DataType::F64(6, 6.0),
-                ], vec![]),
-                (1, 1, vec![
-                    DataType::F64(1, 1.0), DataType::F64(2, 2.0), DataType::F64(3, 3.0), DataType::F64(4, 4.0),
-                    DataType::F64(5, 5.0), DataType::F64(6, 6.0),
-                ], vec![],),
-                (2, 1, vec![
-                    DataType::F64(3, 3.0), DataType::F64(4, 4.0), DataType::F64(5, 5.0), DataType::F64(6, 6.0),
-                ], vec![]),
-                (3, 1, vec![
-                    DataType::F64(1, 1.0), DataType::F64(2, 2.0), DataType::F64(5, 5.0), DataType::F64(6, 6.0),
-                ], vec![]),
-            ],
-            // | === SeriesId: 2 === |
-            // Ts:    7,    8,    9,    10,   11,   11, 12
-            // Col_0: 7,    8,    9,    10,   None, 11, 12
-            // Col_1: 7,    8,    9,    10,   None, 11, 12
-            // Col_2: None, None, 9,    10,   None, 11, 12
-            // Col_3: 7,    8,    None, None, None, 11, 12
-            vec![
-                (0, 2, vec![
-                    DataType::F64(7, 7.0), DataType::F64(8, 8.0), DataType::F64(9, 9.0), DataType::F64(10, 10.0),
-                ], vec![DataType::F64(11, 11.0), DataType::F64(12, 12.0)],),
-                (1, 2, vec![
-                    DataType::F64(7, 7.0), DataType::F64(8, 8.0), DataType::F64(9, 9.0), DataType::F64(10, 10.0),
-                ], vec![DataType::F64(11, 11.0), DataType::F64(12, 12.0)],),
-                (2, 2, vec![
-                    DataType::F64(9, 9.0), DataType::F64(10, 10.0),
-                ], vec![DataType::F64(11, 11.0), DataType::F64(12, 12.0)]),
-                (3, 2, vec![
-                    DataType::F64(7, 7.0), DataType::F64(8, 8.0),
-                ], vec![DataType::F64(11, 11.0), DataType::F64(12, 12.0)]),
-            ],
-            // | === SeriesId: 3 === |
-            // Ts:    13,   14,   15,   16,   16,   17, 18
-            // Col_0: 13,   14,   15,   16,   None, 17, 18
-            // Col_1: 13,   14,   15,   16,   None, 17, 18
-            // Col_2: None, None, 15,   16,   None, 17, 18
-            // Col_3: 13,   14,   None, None, None, 17, 18
-            vec![
-                (0, 3, vec![], vec![
-                    DataType::F64(13, 13.0), DataType::F64(14, 14.0), DataType::F64(15, 15.0),
-                    DataType::F64(16, 16.0), DataType::F64(17, 17.0), DataType::F64(18, 18.0),
-                ]),
-                (1, 3, vec![], vec![
-                    DataType::F64(13, 13.0), DataType::F64(14, 14.0), DataType::F64(15, 15.0),
-                    DataType::F64(16, 16.0), DataType::F64(17, 17.0), DataType::F64(18, 18.0),
-                ]),
-                (2, 3, vec![], vec![
-                    DataType::F64(15, 15.0), DataType::F64(16, 16.0), DataType::F64(17, 17.0), DataType::F64(18, 18.0),
-                ]),
-                (3, 3, vec![], vec![
-                    DataType::F64(13, 13.0), DataType::F64(14, 14.0), DataType::F64(17, 17.0), DataType::F64(18, 18.0),
-                ]),
-            ]
-        ];
+        let expected_delta_data: HashMap<FieldId, Vec<DataBlock>> = HashMap::from([
+            (model_utils::unite_id(0, 1), vec![DataBlock::F64{ts: vec![1, 2, 3, 4, 5, 6], val: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], code_type_id: 0}]),
+            (model_utils::unite_id(1, 1), vec![DataBlock::F64{ts: vec![1, 2, 3, 4, 5, 6], val: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], code_type_id: 0}]),
+            (model_utils::unite_id(2, 1), vec![DataBlock::F64{ts: vec![3, 4, 5, 6], val: vec![3.0, 4.0, 5.0, 6.0], code_type_id: 0}]),
+            (model_utils::unite_id(3, 1), vec![DataBlock::F64{ts: vec![1, 2, 5, 6], val: vec![1.0, 2.0, 5.0, 6.0], code_type_id: 0}]),
+            (model_utils::unite_id(0, 2), vec![DataBlock::F64{ts: vec![7, 8, 9, 10], val: vec![7.0, 8.0, 9.0, 10.0], code_type_id: 0}]),
+            (model_utils::unite_id(1, 2), vec![DataBlock::F64{ts: vec![7, 8, 9, 10], val: vec![7.0, 8.0, 9.0, 10.0], code_type_id: 0}]),
+            (model_utils::unite_id(2, 2), vec![DataBlock::F64{ts: vec![9, 10], val: vec![9.0, 10.0], code_type_id: 0}]),
+            (model_utils::unite_id(3, 2), vec![DataBlock::F64{ts: vec![7, 8], val: vec![7.0, 8.0], code_type_id: 0}]),
+        ]);
 
-        let mut flush_compact_iterator = FlushCompactIterator::new(3, max_level_ts);
-        flush_compact_iterator.append_upstream_iterator(caches[0].iter_series_data());
-        flush_compact_iterator.append_upstream_iterator(caches[1].iter_series_data());
-        flush_compact_iterator.append_upstream_iterator(caches[2].iter_series_data());
+        // | === SeriesId: 2 === |
+        // Ts:    11,   11, 12
+        // Col_0: None, 11, 12
+        // Col_1: None, 11, 12
+        // Col_2: None, 11, 12
+        // Col_3: None, 11, 12
+        // | === SeriesId: 3 === |
+        // Ts:    13,   14,   15,   16,   16,   17, 18
+        // Col_0: 13,   14,   15,   16,   None, 17, 18
+        // Col_1: 13,   14,   15,   16,   None, 17, 18
+        // Col_2: None, None, 15,   16,   None, 17, 18
+        // Col_3: 13,   14,   None, None, None, 17, 18
+        #[rustfmt::skip]
+        let expected_tsm_data: HashMap<FieldId, Vec<DataBlock>> = HashMap::from([
+            (model_utils::unite_id(0, 2), vec![DataBlock::F64{ts: vec![11, 12], val: vec![11.0, 12.0], code_type_id: 0}]),
+            (model_utils::unite_id(1, 2), vec![DataBlock::F64{ts: vec![11, 12], val: vec![11.0, 12.0], code_type_id: 0}]),
+            (model_utils::unite_id(2, 2), vec![DataBlock::F64{ts: vec![11, 12], val: vec![11.0, 12.0], code_type_id: 0}]),
+            (model_utils::unite_id(3, 2), vec![DataBlock::F64{ts: vec![11, 12], val: vec![11.0, 12.0], code_type_id: 0}]),
+            (model_utils::unite_id(0, 3), vec![DataBlock::F64{ts: vec![13, 14, 15, 16, 17, 18], val: vec![13.0, 14.0, 15.0, 16.0, 17.0, 18.0], code_type_id: 0}]),
+            (model_utils::unite_id(1, 3), vec![DataBlock::F64{ts: vec![13, 14, 15, 16, 17, 18], val: vec![13.0, 14.0, 15.0, 16.0, 17.0, 18.0], code_type_id: 0}]),
+            (model_utils::unite_id(2, 3), vec![DataBlock::F64{ts: vec![15, 16, 17, 18], val: vec![15.0, 16.0, 17.0, 18.0], code_type_id: 0}]),
+            (model_utils::unite_id(3, 3), vec![DataBlock::F64{ts: vec![13, 14, 17, 18], val: vec![13.0, 14.0, 17.0, 18.0], code_type_id: 0}]),
+        ]);
 
-        for (i, data) in expected_data.iter().enumerate() {
-            let ret_vec = flush_compact_iterator.next().unwrap();
-            for (
-                (fid, delta_blks, tsm_blks),
-                (data_col_id, data_sid, data_delta_blks, data_tsm_blks),
-            ) in ret_vec.into_iter().zip(data.iter())
-            {
-                let (col_id, sid) = model_utils::split_id(fid);
-                assert_eq!(*data_col_id, col_id);
-                assert_eq!(*data_sid, sid);
-                if data_tsm_blks.is_empty() {
-                    assert!(tsm_blks.is_empty());
-                } else {
-                    assert_eq!(tsm_blks.len(), 1);
-                    check_data_block(&tsm_blks[0], data_tsm_blks);
-                }
-                if data_delta_blks.is_empty() {
-                    assert!(delta_blks.is_empty());
-                } else {
-                    assert_eq!(delta_blks.len(), 1);
-                    check_data_block(&delta_blks[0], data_delta_blks);
-                }
+        let ts_family_id = 1;
+        let database = "test_db".to_string();
+
+        let caches = caches
+            .into_iter()
+            .map(|c| Arc::new(RwLock::new(c)))
+            .collect();
+        let global_context = Arc::new(GlobalContext::new());
+        let options = Options::from(&config);
+        #[rustfmt::skip]
+        let version = Arc::new(Version {
+            ts_family_id, database: database.clone(), storage_opt: options.storage.clone(),
+            last_seq: 1, max_level_ts,
+            levels_info: LevelInfo::init_levels(database.clone(), options.storage.clone()),
+        });
+        let flush_task = FlushTask::new(caches, None, 1, global_context, &tsm_dir, &delta_dir);
+        let mut version_edits = vec![];
+        flush_task.run(version, &mut version_edits).await.unwrap();
+
+        assert_eq!(version_edits.len(), 1);
+        let ve = version_edits.get(0).unwrap();
+        assert_eq!(ve.max_level_ts, 18);
+        assert_eq!(ve.add_files.len(), 2);
+        assert!(ve.del_files.is_empty());
+
+        let (mut tsm_reader, mut dlt_reader) = (None, None);
+        for cm in ve.add_files.iter() {
+            if cm.is_delta {
+                assert_eq!(cm.file_size, 377);
+                assert_eq!(cm.min_ts, 1);
+                assert_eq!(cm.max_ts, 10);
+                let file_path = file_utils::make_delta_file_name(&delta_dir, cm.file_id);
+                dlt_reader = Some(TsmReader::open(file_path).unwrap())
+            } else {
+                assert_eq!(cm.file_size, 366);
+                assert_eq!(cm.min_ts, 11);
+                assert_eq!(cm.max_ts, 18);
+                let file_path = file_utils::make_tsm_file_name(&tsm_dir, cm.file_id);
+                tsm_reader = Some(TsmReader::open(file_path).unwrap())
             }
         }
+
+        read_and_check(tsm_reader.as_ref().unwrap(), expected_tsm_data);
+        read_and_check(dlt_reader.as_ref().unwrap(), expected_delta_data);
     }
 }

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -250,6 +250,10 @@ impl Database {
         self.index.write().get_table_schema(table_name)
     }
 
+    pub fn get_table_schema_by_series_id(&self, sid: u64) -> IndexResult<Option<Vec<FieldInfo>>> {
+        self.index.write().get_table_schema_by_series_id(sid)
+    }
+
     pub fn get_tsfamily(&self, id: u32) -> Option<&Arc<RwLock<TseriesFamily>>> {
         self.ts_families.get(&id)
     }

--- a/tskv/src/summary.rs
+++ b/tskv/src/summary.rs
@@ -98,8 +98,6 @@ impl From<&ColumnFile> for CompactMeta {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct VersionEdit {
-    pub level: u32,
-
     pub has_seq_no: bool,
     pub seq_no: u64,
     pub has_file_id: bool,
@@ -123,7 +121,6 @@ impl Default for VersionEdit {
 impl VersionEdit {
     pub fn new() -> Self {
         Self {
-            level: 0,
             seq_no: 0,
             file_id: 0,
             add_files: vec![],
@@ -146,7 +143,6 @@ impl VersionEdit {
     }
 
     pub fn add_file(&mut self, compact_meta: CompactMeta, max_level_ts: i64) {
-        self.level = compact_meta.level;
         self.has_seq_no = true;
         self.seq_no = compact_meta.high_seq;
         self.has_file_id = true;
@@ -186,8 +182,8 @@ impl VersionEdit {
 
 impl Display for VersionEdit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "level: {}, seq_no: {}, file_id: {}, add_files: {}, del_files: {}, del_tsf: {}, add_tsf: {}, tsf_id: {}, tsf_name: {}, has_seq_no: {}, has_file_id: {}, max_level_ts: {}",
-               self.level, self.seq_no, self.file_id, self.add_files.len(), self.del_files.len(), self.del_tsf, self.add_tsf, self.tsf_id, self.tsf_name, self.has_seq_no, self.has_file_id, self.max_level_ts)
+        write!(f, "seq_no: {}, file_id: {}, add_files: {}, del_files: {}, del_tsf: {}, add_tsf: {}, tsf_id: {}, tsf_name: {}, has_seq_no: {}, has_file_id: {}, max_level_ts: {}",
+               self.seq_no, self.file_id, self.add_files.len(), self.del_files.len(), self.del_tsf, self.add_tsf, self.tsf_id, self.tsf_name, self.has_seq_no, self.has_file_id, self.max_level_ts)
     }
 }
 

--- a/tskv/src/tsm/reader.rs
+++ b/tskv/src/tsm/reader.rs
@@ -656,7 +656,8 @@ pub fn decode_data_block(
 }
 
 #[cfg(test)]
-mod test {
+pub mod tsm_reader_tests {
+    use core::panic;
     use std::{
         collections::HashMap,
         path::{Path, PathBuf},
@@ -713,7 +714,7 @@ mod test {
         (tsm_file, tombstone_file)
     }
 
-    fn read_and_check(reader: &TsmReader, expected_data: HashMap<u64, Vec<DataBlock>>) {
+    pub(crate) fn read_and_check(reader: &TsmReader, expected_data: HashMap<u64, Vec<DataBlock>>) {
         let mut read_data: HashMap<FieldId, Vec<DataBlock>> = HashMap::new();
         for idx in reader.index_iterator() {
             for blk in idx.block_iterator() {
@@ -726,8 +727,11 @@ mod test {
         }
         assert_eq!(expected_data.len(), read_data.len());
         for (field_id, data_blks) in read_data.iter() {
-            let expected_data_blks = expected_data.get(field_id).unwrap();
-            assert_eq!(data_blks, expected_data_blks);
+            let expected_data_blks = expected_data.get(field_id);
+            if expected_data_blks.is_none() {
+                panic!("Expected DataBlocks for field_id: '{}' is None", field_id);
+            }
+            assert_eq!(data_blks, expected_data_blks.unwrap());
         }
     }
 
@@ -756,7 +760,7 @@ mod test {
         read_and_check(&reader, expected_data);
     }
 
-    fn read_opt_and_check(
+    pub(crate) fn read_opt_and_check(
         reader: &TsmReader,
         field_id: FieldId,
         time_range: (Timestamp, Timestamp),


### PR DESCRIPTION
# Which issue does this PR close?

# Rationale for this change

For issue #590.

To simplify codes flushing cache to files.

# What changes are included in this PR?

1. Remove some iterators in flush.rs and memcache.rs.
2. Remove field `level` in `VersionEdit`.
3. Add a more simple way to calculate string width of num_cpu.
4. Add method `get_table_schema_by_series_id()` for `DataBase` and `DbIndex`.

# Are there any user-facing changes?
