### PR TITLE
feat(tsm) #440: write to .tsm.tmp or .delta.tmp file first

### DIFF
--- a/tskv/src/compaction/flush.rs
+++ b/tskv/src/compaction/flush.rs
@@ -292,7 +292,7 @@ impl FlushTask {
     ) -> Result<Vec<CompactMeta>> {
         if let Some(writer) = tsm_writer.as_mut() {
             writer.write_index().context(error::WriteTsmSnafu)?;
-            writer.flush().context(error::WriteTsmSnafu)?;
+            writer.finish().context(error::WriteTsmSnafu)?;
             info!(
                 "Flush: File: {} write finished ({} B).",
                 writer.sequence(),
@@ -301,7 +301,7 @@ impl FlushTask {
         }
         if let Some(writer) = delta_writer.as_mut() {
             writer.write_index().context(error::WriteTsmSnafu)?;
-            writer.flush().context(error::WriteTsmSnafu)?;
+            writer.finish().context(error::WriteTsmSnafu)?;
             info!(
                 "Flush: File: {} write finished ({} B).",
                 writer.sequence(),

--- a/tskv/src/tsm/reader.rs
+++ b/tskv/src/tsm/reader.rs
@@ -700,7 +700,7 @@ pub mod tsm_reader_tests {
             }
         }
         writer.write_index().unwrap();
-        writer.flush().unwrap();
+        writer.finish().unwrap();
 
         let mut tombstone = TsmTombstone::with_path(&tombstone_file).unwrap();
         tombstone.add_range(&[1], &TimeRange::new(2, 4)).unwrap();

--- a/tskv/src/tsm/writer.rs
+++ b/tskv/src/tsm/writer.rs
@@ -92,6 +92,9 @@ pub enum WriteTsmError {
 
     #[snafu(display("Max file size exceed: {}", source))]
     MaxFileSizeExceed { source: MaxFileSizeExceedError },
+
+    #[snafu(display("Tsm writer has been finished: {}", path.display()))]
+    Finished { path: PathBuf },
 }
 
 impl From<WriteTsmError> for Error {
@@ -161,7 +164,10 @@ impl IndexBuf {
 /// writer.flush().unwrap();
 /// ```
 pub struct TsmWriter {
-    path: PathBuf,
+    tmp_path: PathBuf,
+    final_path: PathBuf,
+    finished: bool,
+
     writer: FileCursor,
     /// Store tsm sequence for debug
     sequence: u64,
@@ -183,9 +189,16 @@ impl TsmWriter {
         is_delta: bool,
         max_size: u64,
     ) -> Result<Self> {
-        let writer = file_manager::create_file(&path)?.into_cursor();
+        let final_path: PathBuf = path.as_ref().into();
+        let mut tmp_path_str = final_path.as_os_str().to_os_string();
+        tmp_path_str.push(".tmp");
+        let tmp_path = PathBuf::from(tmp_path_str);
+
+        let writer = file_manager::create_file(&tmp_path)?.into_cursor();
         let mut w = Self {
-            path: path.as_ref().into(),
+            tmp_path,
+            final_path,
+            finished: false,
             writer,
             sequence,
             is_delta,
@@ -201,8 +214,16 @@ impl TsmWriter {
         Ok(w)
     }
 
+    pub fn finished(&self) -> bool {
+        self.finished
+    }
+
     pub fn path(&self) -> PathBuf {
-        self.path.clone()
+        if self.finished {
+            self.final_path.clone()
+        } else {
+            self.tmp_path.clone()
+        }
     }
 
     pub fn sequence(&self) -> u64 {
@@ -226,6 +247,11 @@ impl TsmWriter {
     }
 
     pub fn write_block(&mut self, field_id: FieldId, block: &DataBlock) -> WriteTsmResult<usize> {
+        if self.finished {
+            return Err(WriteTsmError::Finished {
+                path: self.final_path.clone(),
+            });
+        }
         let mut write_pos = self.writer.pos();
         if let Some(rg) = block.time_range() {
             self.min_ts = self.min_ts.min(rg.0);
@@ -245,6 +271,11 @@ impl TsmWriter {
     }
 
     pub fn write_raw(&mut self, block_meta: &BlockMeta, block: &[u8]) -> WriteTsmResult<usize> {
+        if self.finished {
+            return Err(WriteTsmError::Finished {
+                path: self.final_path.clone(),
+            });
+        }
         let mut write_pos = self.writer.pos();
         self.min_ts = self.min_ts.min(block_meta.min_ts());
         self.max_ts = self.max_ts.max(block_meta.max_ts());
@@ -262,6 +293,11 @@ impl TsmWriter {
     }
 
     pub fn write_index(&mut self) -> WriteTsmResult<usize> {
+        if self.finished {
+            return Err(WriteTsmError::Finished {
+                path: self.final_path.clone(),
+            });
+        }
         let mut size = 0_usize;
 
         self.index_buf.set_index_offset(self.writer.pos());
@@ -278,8 +314,16 @@ impl TsmWriter {
         Ok(size)
     }
 
-    pub fn flush(&self) -> WriteTsmResult<()> {
-        self.writer.sync_all(FileSync::Hard).context(IOSnafu)
+    pub fn finish(&mut self) -> WriteTsmResult<()> {
+        if self.finished {
+            return Err(WriteTsmError::Finished {
+                path: self.final_path.clone(),
+            });
+        }
+        self.writer.sync_all(FileSync::Hard).context(IOSnafu)?;
+        std::fs::rename(&self.tmp_path, &self.final_path).context(IOSnafu)?;
+        self.finished = true;
+        Ok(())
     }
 }
 
@@ -464,7 +508,7 @@ mod test {
             }
         }
         writer.write_index().unwrap();
-        writer.flush().unwrap();
+        writer.finish().unwrap();
     }
 
     fn read_from_tsm(path: impl AsRef<Path>) -> HashMap<FieldId, Vec<DataBlock>> {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #440 .

# Rationale for this change

- Added a temporary path generated from argument `path` in `TsmWriter::open()`, and a field `tmp_path` in `TsmWriter`.
- Rename field `path` in `TsmWriter` into `final_path`.
- Rename method `flush()` in `TsmWriter` into `finish()`, this method renames file from `tmp_path` into `final_path`.
- After `flush()` called, any other write actions to this `TsmWriter` willl make an error.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
