### PR TITLE
fix(write): change default time unit from mills to nanos

### DIFF
--- a/common/protos/src/models_helper.rs
+++ b/common/protos/src/models_helper.rs
@@ -67,7 +67,7 @@ mod test {
         let mut points = vec![];
         for i in 0..num {
             let timestamp = if i <= num / 2 {
-                Local::now().timestamp_millis()
+                Local::now().timestamp_nanos()
             } else {
                 1
             };
@@ -121,7 +121,7 @@ mod test {
         let mut points = vec![];
         for i in 0..num {
             let timestamp = if i % 2 == 0 {
-                Local::now().timestamp_millis()
+                Local::now().timestamp_nanos()
             } else {
                 1
             };
@@ -172,7 +172,7 @@ mod test {
         let db = fbb.create_vector("db".as_bytes());
         let mut points = vec![];
         for _ in 0..num {
-            let timestamp = Local::now().timestamp_millis();
+            let timestamp = Local::now().timestamp_nanos();
             let mut tags = vec![];
             let tav = rand::random::<u8>().to_string();
             for _ in 0..19999 {
@@ -222,7 +222,7 @@ mod test {
         ];
         let field_keys = ["cpu", "mem"];
 
-        let now = Local::now().timestamp_millis();
+        let now = Local::now().timestamp_nanos();
         let database = fbb.create_vector(database.as_bytes());
         let table = fbb.create_vector(table.as_bytes());
         let mut points = vec![];

--- a/main/src/http/http_service.rs
+++ b/main/src/http/http_service.rs
@@ -186,7 +186,7 @@ impl HttpService {
                     let start = Instant::now();
                     let lines = String::from_utf8_lossy(req.as_ref());
                     let line_protocol_lines =
-                        line_protocol_to_lines(&lines, Local::now().timestamp_millis())
+                        line_protocol_to_lines(&lines, Local::now().timestamp_nanos())
                             .context(ParseLineProtocolSnafu)?;
                     let points = parse_lines_to_points(&param.db, &line_protocol_lines)?;
                     let req = WritePointsRpcRequest { version: 1, points };

--- a/tskv/tests/test_kvcore_interface.rs
+++ b/tskv/tests/test_kvcore_interface.rs
@@ -127,7 +127,7 @@ mod tests {
         let output = tskv.read(
             &database,
             sids,
-            &TimeRange::new(0, Local::now().timestamp_millis() + 100),
+            &TimeRange::new(0, Local::now().timestamp_nanos() + 100),
             fields_id,
         );
 
@@ -179,7 +179,7 @@ mod tests {
         tskv.read(
             &database,
             sids.clone(),
-            &TimeRange::new(0, Local::now().timestamp_millis() + 100),
+            &TimeRange::new(0, Local::now().timestamp_nanos() + 100),
             fields_id.clone(),
         );
 
@@ -189,7 +189,7 @@ mod tests {
         tskv.read(
             &database,
             sids.clone(),
-            &TimeRange::new(0, Local::now().timestamp_millis() + 100),
+            &TimeRange::new(0, Local::now().timestamp_nanos() + 100),
             fields_id,
         );
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

I used to insert points without a timestamp for test, query `SELECT time, col from tbl` returns invalid time value now:

```
-- SQL
SELECT
    DATE_BIN(INTERVAL '3 minutes', time, TIMESTAMP '1970-01-01T00:00:00Z') AS time,
    tag_1 AS metric
    avg(field_1) AS value
FROM ma 
GROUP BY 1, 2

-- RESULTS:
-- 1970-01-01T00:27:00.000000000,ALPHA,1.0
``` 

It's service HTTP creates line-protocol Parser using invalid default value:

```rust
 let line_protocol_lines = 
    line_protocol_to_lines(&lines, Local::now().timestamp_millis())
        .context(ParseLineProtocolSnafu)?;
```

# What changes are included in this PR?

To fix it I changed to `timestamp_nanos()`

```rust
 let line_protocol_lines = 
    line_protocol_to_lines(&lines, Local::now().timestamp_nanos())
        .context(ParseLineProtocolSnafu)?;
```

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
