### PR TITLE
Fixes some bugs among wal

### DIFF
--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -154,6 +154,8 @@ fn main() -> Result<(), std::io::Error> {
                 server.start().expect("server start.");
                 signal::block_waiting_ctrl_c();
                 server.stop(true).await;
+                kv_inst.close().await;
+                println!("CnosDB is stopped.");
             }
         }
     });

--- a/main/src/signal.rs
+++ b/main/src/signal.rs
@@ -4,6 +4,7 @@ pub fn block_waiting_ctrl_c() {
         .expect("error setting Ctrl-C handler");
     println!("blocking waiting for Ctrl-C...");
     rx.recv().expect("could not receive from channel.");
+    println!("\nreceived Ctrl-C, CnosDB is stoping...");
 }
 
 pub fn install_crash_handler() {

--- a/tskv/src/error.rs
+++ b/tskv/src/error.rs
@@ -50,6 +50,9 @@ pub enum Error {
         source: flatbuffers::InvalidFlatbuffer,
     },
 
+    #[snafu(display("wal truncated"))]
+    WalTruncated,
+
     #[snafu(display("read record file block: {}", source))]
     LogRecordErr {
         source: crate::record_file::RecordFileError,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes nothing.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When we press Ctrl+c，CnosDB service will be closed with serial background services, but `WalManager::close()` is forgot, it made a truncated wal entry in the last wal file.

This PR aims to fix some bugs caused by the above situation.

# What changes are included in this PR?

1. fix: wal write not fsync-ed after received a sigint.
2. fix: ignore truncated entry in wal file, not panic.
3. fix: create `WalManager` twice in kvcore.
4. improve: print some tips after received a SIGINT.

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
