### PR TITLE
All crates in workspace share the same versions of dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ Cargo.lock
 **/dev/
 **/data/
 **/tskv_log/
-**/data/
 
 # tmpfile
 trace.log.*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,18 +21,77 @@ members = [
 default-members = ["main"]
 
 [workspace.dependencies]
+async-recursion = "1.0.0"
+actix-rt = "2.7.0"
+async-stream = "0.3"
 async-trait = "0.1"
-chrono = "0.4"
+base64 = { version = "0.13" }
+backtrace = "0.3"
 bincode = "1.3.3"
+bytes = "1.1"
+bzip2 = "0.4.3"
+chrono = "0.4"
+clap = { version = "3" }
+color-eyre = "0.6"
+core_affinity = "0.5.10"
+crc32fast = "1.3.0"
+criterion = { version = "0.3.5" }
+crossbeam = "0.8"
+crossbeam-channel = "0.5"
+ctrlc = "3"
+dashmap = "5.2"
 datafusion = { version = "13.0.0", features = ["scheduler"] }
+dirs = "4.0.0"
+env_logger = "0.9"
+evmap = "10.0"
 flatbuffers = "2.1"
+flate2 = "1.0.24"
 futures = { version = "0.3" }
+integer-encoding = "3.0.3"
+lazy_static = "1.4"
 libc = { version = "0.2", default-features = false }
+mimalloc = { version = "0.1" }
+minivec = "0.4.0"
+mio = "0.8"
+nom = "7.1.1"
+num_cpus = "1.13.0"
+num_enum = "0.5.7"
+num-traits = "0.2.14"
+once_cell = "1.12.0"
+page_size = "0.4"
 parking_lot = { version = "0.12" }
+paste = "1.0"
+prettydiff = "0.6.1"
+pin-project = "1.0"
+priority-queue = "1.2.3"
+prost = "0.10"
+prost-build = "0.10"
+q_compress = "0.11.1"
+rand = "0.8"
+regex = "1.5"
+reqwest = { version = "0.11.11" }
+rustyline = "9.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serial_test = "0.8.0"
+sled = "0.34"
 snafu = "0.7"
+snap = "1.0.0"
+static_assertions = "1.1"
+tempfile = "3"
 tokio = { version = "1.21" }
+tokio-stream = "0.1"
+tokio-util = { version = "0.7.0" }
+toml = "0.5.9"
+tonic = "0.7"
+tonic-build = "0.7"
+tracing = "0.1.35"
+tracing-subscriber = "0.2.25"
+tracing-appender = "0.1.2"
+tracing-error = "0.1.2"
+warp = { version = "0.3" }
+walkdir = "2.3.2"
+zstd = "0.11.2"
 
 # exclude = ["client"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,8 @@
 [workspace]
-
 members = [
     "common/models",
     "common/protos",
     "common/line_protocol",
-    "common/datafusion_dep",
     "common/metrics",
     "common/trace",
     "common/utils",
@@ -20,8 +18,21 @@ members = [
     "main",
     "client",
 ]
-
 default-members = ["main"]
+
+[workspace.dependencies]
+async-trait = "0.1"
+chrono = "0.4"
+bincode = "1.3.3"
+datafusion = { version = "13.0.0", features = ["scheduler"] }
+flatbuffers = "2.1"
+futures = { version = "0.3" }
+libc = { version = "0.2", default-features = false }
+parking_lot = { version = "0.12" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+snafu = "0.7"
+tokio = { version = "1.21" }
 
 # exclude = ["client"]
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -7,9 +7,9 @@ readme = "README.md"
 
 [dependencies]
 http_protocol = { path = "../common/http_protocol", features = ["http_client"] }
-datafusion = { path = "../common/datafusion_dep" }
 
 clap = { version = "3", features = ["derive", "cargo"] }
+datafusion = { workspace = true }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,10 +8,10 @@ readme = "README.md"
 [dependencies]
 http_protocol = { path = "../common/http_protocol", features = ["http_client"] }
 
-clap = { version = "3", features = ["derive", "cargo"] }
+clap = { workspace = true, features = ["derive", "cargo"] }
 datafusion = { workspace = true }
-dirs = "4.0.0"
-env_logger = "0.9"
-mimalloc = { version = "0.1", default-features = false }
-rustyline = "9.0"
-tokio = { version = "1.21", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
+dirs = { workspace = true }
+env_logger = { workspace = true }
+mimalloc = { workspace = true, default-features = false }
+rustyline = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }

--- a/common/datafusion_dep/Cargo.toml
+++ b/common/datafusion_dep/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-name = "datafusion"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-datafusion_dep = { version = "13.0.0", features = ["scheduler"], package = "datafusion" }

--- a/common/datafusion_dep/src/lib.rs
+++ b/common/datafusion_dep/src/lib.rs
@@ -1,1 +1,0 @@
-pub use datafusion_dep::*;

--- a/common/http_protocol/Cargo.toml
+++ b/common/http_protocol/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-models = { path = "../models"}
+models = { path = "../models" }
+
 reqwest = { version = "0.11.11", features = ["native-tls", "__rustls"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 http_client = []

--- a/common/http_protocol/Cargo.toml
+++ b/common/http_protocol/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 models = { path = "../models" }
 
-reqwest = { version = "0.11.11", features = ["native-tls", "__rustls"] }
+reqwest = { workspace = true, features = ["native-tls", "__rustls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/common/line_protocol/Cargo.toml
+++ b/common/line_protocol/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-snafu = "0.7"
+snafu = { workspace = true }

--- a/common/mem_allocator/Cargo.toml
+++ b/common/mem_allocator/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = { version = "0.2", default-features = false }
+libc = { workspace = true, default-features = false }
 tikv-jemalloc-ctl = { version = "0.5", optional = true }
 tikv-jemalloc-sys = "0.5"
 
 [dev-dependencies]
-chrono = "0.4.22"
+chrono = { workspace = true}

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prometheus = { version = "0.13.2", default-features = false }
-once_cell = "1.12.0"
 trace = { path = "../trace" }
+prometheus = { version = "0.13.2", default-features = false }
+once_cell = { workspace = true }

--- a/common/models/Cargo.toml
+++ b/common/models/Cargo.toml
@@ -8,14 +8,14 @@ edition = "2021"
 [dependencies]
 protos = { path = "../protos" }
 utils = { path = "../utils" }
-datafusion = { path = "../../common/datafusion_dep" }
 
-async-trait = "0.1.57"
-bincode = "1.3.3"
-serde = { version = "1.0", features = ["derive"] }
-snafu = "0.7"
-parking_lot = "0.12"
+async-trait = { workspace = true }
+bincode = { workspace = true }
+datafusion = { workspace = true }
+parking_lot = { workspace = true }
+serde = { workspace = true }
+snafu = { workspace = true }
 
 [dev-dependencies]
-flatbuffers = "2.1"
-chrono = "0.4.22"
+chrono = { workspace = true }
+flatbuffers = { workspace = true }

--- a/common/protos/Cargo.toml
+++ b/common/protos/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 test = []
 
 [dependencies]
-chrono = "0.4"
-flatbuffers = "2.1"
+chrono = { workspace = true }
+flatbuffers = { workspace = true }
 prost = "0.10"
 rand = "0.8"
 tonic = "0.7"

--- a/common/protos/Cargo.toml
+++ b/common/protos/Cargo.toml
@@ -9,10 +9,10 @@ test = []
 [dependencies]
 chrono = { workspace = true }
 flatbuffers = { workspace = true }
-prost = "0.10"
-rand = "0.8"
-tonic = "0.7"
+prost = { workspace = true }
+rand = { workspace = true }
+tonic = { workspace = true }
 
 [build-dependencies]
-prost-build = "0.10"
-tonic-build = "0.7"
+prost-build = { workspace = true }
+tonic-build = { workspace = true }

--- a/common/trace/Cargo.toml
+++ b/common/trace/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tracing = "0.1.35"
-tracing-subscriber = "0.2.25"
-tracing-appender = "0.1.2"
-tracing-error = "0.1.2"
-color-eyre = "0.6"
-once_cell = "1.12.0"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-appender = { workspace = true }
+tracing-error = { workspace = true }
+color-eyre = { workspace = true }
+once_cell = { workspace = true }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 trace = { path = "../common/trace" }
 
 serde = { workspace = true }
-toml = "0.5.9"
+toml = { workspace = true }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 trace = { path = "../common/trace" }
 
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 toml = "0.5.9"

--- a/e2e_test/Cargo.toml
+++ b/e2e_test/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-rt = "2.7.0"
+actix-rt = { workspace = true }
 protos = { path = "../common/protos", features = ["test"] }
 
 [dev-dependencies]
 http_protocol = { path = "../common/http_protocol", features = ["http_client"] }
 
 flatbuffers = { workspace = true }
-tonic = {version = "0.7", features = ["tls", "transport"]}
+tonic = { workspace = true, features = ["tls", "transport"] }
 tokio = { workspace = true, features = ["full"] }
-tokio-stream = "0.1"
+tokio-stream = { workspace = true }

--- a/e2e_test/Cargo.toml
+++ b/e2e_test/Cargo.toml
@@ -10,8 +10,9 @@ actix-rt = "2.7.0"
 protos = { path = "../common/protos", features = ["test"] }
 
 [dev-dependencies]
-flatbuffers = "2.1"
-tonic = {version = "0.7", features = ["tls", "transport"]}
-tokio = { version = "1.21", features = ["full"] }
-tokio-stream = "0.1"
 http_protocol = { path = "../common/http_protocol", features = ["http_client"] }
+
+flatbuffers = { workspace = true }
+tonic = {version = "0.7", features = ["tls", "transport"]}
+tokio = { workspace = true, features = ["full"] }
+tokio-stream = "0.1"

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -18,30 +18,30 @@ mem_allocator = { path = "../common/mem_allocator" }
 metrics = { path = "../common/metrics" }
 http_protocol = { path = "../common/http_protocol" }
 
-async-stream = "0.3"
+async-stream = { workspace = true }
 async-trait = { workspace = true }
-backtrace = "0.3"
-base64 = { version = "0.13" }
+backtrace = { workspace = true }
+base64 = { workspace = true }
 chrono = { workspace = true }
-clap = { version = "3", features = ["derive", "env"] }
-ctrlc = "3"
+clap = { workspace = true, features = ["derive", "env"] }
+ctrlc = { workspace = true }
 datafusion = { workspace = true }
 flatbuffers = { workspace = true }
 futures = { workspace = true, default-features = false, features = ["alloc"] }
-lazy_static = "1.4"
+lazy_static = { workspace = true }
 libc = { workspace = true }
-num_cpus = "1.13.0"
-once_cell = { version = "1.4.0", features = ["parking_lot"] }
+num_cpus = { workspace = true }
+once_cell = { workspace = true, features = ["parking_lot"] }
 parking_lot = { workspace = true }
-prost = "0.10"
-regex = "1.5"
+prost = { workspace = true }
+regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
-tokio = { workspace = true, features = [ "macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time" ] }
-tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.7", features = ["transport", "tls"] }
-warp = { version = "0.3", features = ["tls"] }
+tokio = { workspace = true, features = ["macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-stream = { workspace = true, features = ["net"] }
+tonic = { workspace = true, features = ["transport", "tls"] }
+warp = { workspace = true, features = ["tls"] }
 
 [dev-dependencies]
 reqwest = "0.11"

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -17,30 +17,31 @@ spi = { path = "../query_server/spi" }
 mem_allocator = { path = "../common/mem_allocator" }
 metrics = { path = "../common/metrics" }
 http_protocol = { path = "../common/http_protocol" }
-datafusion = { path = "../common/datafusion_dep" }
+
 async-stream = "0.3"
+async-trait = { workspace = true }
 backtrace = "0.3"
-chrono = "0.4"
-futures = { version = "0.3", default-features = false, features = ["alloc"] }
-libc = "0.2"
-warp = {version = "0.3", features = ["tls"]}
 base64 = { version = "0.13" }
-lazy_static = "1.4"
-num_cpus = "1.13.0"
+chrono = { workspace = true }
 clap = { version = "3", features = ["derive", "env"] }
-flatbuffers = "2.1"
+ctrlc = "3"
+datafusion = { workspace = true }
+flatbuffers = { workspace = true }
+futures = { workspace = true, default-features = false, features = ["alloc"] }
+lazy_static = "1.4"
+libc = { workspace = true }
+num_cpus = "1.13.0"
 once_cell = { version = "1.4.0", features = ["parking_lot"] }
-parking_lot = "0.12"
+parking_lot = { workspace = true }
 prost = "0.10"
 regex = "1.5"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-snafu = "0.7"
-tokio = { version = "1.21", features = ["macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+tokio = { workspace = true, features = [ "macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time" ] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tokio-util = { version = "0.7.0" }
-tonic = {version = "0.7", features = ["transport", "tls", ]}
-ctrlc = "3"
-async-trait = "0.1"
+tonic = { version = "0.7", features = ["transport", "tls"] }
+warp = { version = "0.3", features = ["tls"] }
+
 [dev-dependencies]
 reqwest = "0.11"

--- a/query_server/query/Cargo.toml
+++ b/query_server/query/Cargo.toml
@@ -10,26 +10,27 @@ tskv = { path = "../../tskv" }
 models = { path = "../../common/models" }
 config = { path = "../../config" }
 spi = { path = "../spi" }
-datafusion = { path = "../../common/datafusion_dep" }
-criterion = { version = "0.3.5", features = ["async_tokio"] }
-tokio = { version = "1.21", features = ["full"] }
-futures = { version = "0.3" }
-parking_lot = "0.12"
-pin-project = "1.0"
-tokio-util = { version = "0.7.0" }
-async-trait = "0.1"
-rand = "0.8"
-chrono = "0.4.22"
-crossbeam = "0.8"
-serde = { version = "1.0", features = ["derive"] }
-snafu = "0.7"
-sled = "0.34"
-paste = "1.0"
-flatbuffers = "2.1"
 
-priority-queue = "1.2.3"
-num_cpus = "1"
+async-trait = { workspace = true }
+datafusion = { workspace = true }
+chrono = { workspace = true }
+criterion = { version = "0.3.5", features = ["async_tokio"] }
+crossbeam = "0.8"
+flatbuffers = { workspace = true }
+futures = { workspace = true }
 minivec = "0.4.0"
+num_cpus = "1"
+parking_lot = { workspace = true }
+paste = "1.0"
+pin-project = "1.0"
+priority-queue = "1.2.3"
+tokio = { workspace = true, features = ["full"] }
+tokio-util = { version = "0.7.0" }
+rand = "0.8"
+serde = { workspace = true }
+sled = "0.34"
+snafu = { workspace = true }
+
 # use libc on unix like platforms to set worker priority in DedicatedExecutor
 [target."cfg(unix)".dependencies.libc]
 version = "0.2"

--- a/query_server/query/Cargo.toml
+++ b/query_server/query/Cargo.toml
@@ -14,21 +14,21 @@ spi = { path = "../spi" }
 async-trait = { workspace = true }
 datafusion = { workspace = true }
 chrono = { workspace = true }
-criterion = { version = "0.3.5", features = ["async_tokio"] }
-crossbeam = "0.8"
+criterion = { workspace = true, features = ["async_tokio"] }
+crossbeam = { workspace = true }
 flatbuffers = { workspace = true }
 futures = { workspace = true }
-minivec = "0.4.0"
-num_cpus = "1"
+minivec = { workspace = true }
+num_cpus = { workspace = true }
 parking_lot = { workspace = true }
-paste = "1.0"
-pin-project = "1.0"
-priority-queue = "1.2.3"
+paste = { workspace = true }
+pin-project = { workspace = true }
+priority-queue = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tokio-util = { version = "0.7.0" }
-rand = "0.8"
+tokio-util = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
-sled = "0.34"
+sled = { workspace = true }
 snafu = { workspace = true }
 
 # use libc on unix like platforms to set worker priority in DedicatedExecutor

--- a/query_server/spi/Cargo.toml
+++ b/query_server/spi/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 models = { path = "../../common/models" }
-datafusion = { path = "../../common/datafusion_dep" }
-snafu = { version = "0.7", features = ["backtraces"] }
-async-trait = "0.1"
+async-trait = { workspace = true }
+datafusion = { workspace = true }
+snafu = { workspace = true, features = ["backtraces"] }

--- a/query_server/test/Cargo.toml
+++ b/query_server/test/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = {version = "1.21.1", features = ["full"]}
 clap = { version = "3", features = ["derive"] }
-serde = {version = "1.0.144", features = ["derive"]}
-prettydiff = "0.6.1"
 lazy_static = "1.4.0"
-reqwest = "0.11.11"
-walkdir = "2.3.2"
-toml = "0.5.9"
-snafu = "0.7.1"
 nom = "7.1.1"
+prettydiff = "0.6.1"
+reqwest = "0.11.11"
+serde = { workspace = true }
+snafu = { workspace = true }
+tokio = {workspace = true, features = ["full"]}
+toml = "0.5.9"
+walkdir = "2.3.2"

--- a/query_server/test/Cargo.toml
+++ b/query_server/test/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3", features = ["derive"] }
-lazy_static = "1.4.0"
-nom = "7.1.1"
-prettydiff = "0.6.1"
-reqwest = "0.11.11"
+clap = { workspace = true, features = ["derive"] }
+lazy_static = { workspace = true }
+nom = { workspace = true }
+prettydiff = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
 snafu = { workspace = true }
-tokio = {workspace = true, features = ["full"]}
-toml = "0.5.9"
-walkdir = "2.3.2"
+tokio = { workspace = true, features = ["full"] }
+toml = { workspace = true }
+walkdir = { workspace = true }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.62"
+channel = "1.64"
 components = [ "rustfmt", "clippy" ]

--- a/tskv/Cargo.toml
+++ b/tskv/Cargo.toml
@@ -10,51 +10,52 @@ metrics = {path = "../common/metrics"}
 protos = { path = "../common/protos", features = ["test"] }
 trace = { path = "../common/trace" }
 utils = { path = "../common/utils" }
-datafusion = { path = "../common/datafusion_dep" }
 
 async-recursion = "1.0.0"
-async-trait = "0.1"
-bincode = "1.3.3"
+async-trait = { workspace = true }
+bincode = {workspace = true}
 bytes = "1.1"
 bzip2 = "0.4.3"
-chrono = "0.4"
-crc32fast = "1.3.0"
+chrono = { workspace = true}
 core_affinity = "0.5.10"
+crc32fast = "1.3.0"
+crossbeam-channel = "0.5"
 dashmap = "5.2"
+datafusion = { workspace = true }
 evmap = "10.0"
-flatbuffers = "2.1"
+flatbuffers = { workspace = true }
 flate2 = "1.0.24"
-futures = { version = "0.3", features = ["std", "thread-pool"] }
+futures = { workspace = true, features = ["std", "thread-pool"] }
 integer-encoding = "3.0.3"
 lazy_static = "1.4"
-libc = "0.2"
+libc = {workspace = true}
+minivec = "0.4.0"
 mio = "0.8"
 num_cpus = "1.13.1"
 num_enum = "0.5.7"
 num-traits = "0.2.14"
 once_cell = "1.10"
 page_size = "0.4"
-parking_lot = { version = "0.12.1", features = ["nightly", "send_guard"] }
+parking_lot = { workspace = true, features = ["nightly", "send_guard"] }
 priority-queue = "1.2"
 q_compress = "0.11.1"
 regex = "1.5"
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 serial_test = "0.8.0"
 sled = "0.34.7"
-snafu = "0.7"
+snafu = { workspace = true }
 snap = "1.0.0"
 static_assertions = "1.1"
-tokio = { version = "1.21", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 tracing = "0.1.35"
 walkdir = "2.3"
 zstd = "0.11.2"
-minivec = "0.4.0"
-crossbeam-channel = "0.5"
+
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["async_tokio"] }
 rand = "0.8"
 tempfile = "3"
-parking_lot = { version = "0.12.1", features = ["nightly"] }
+parking_lot = { workspace = true, features = ["nightly"] }
 
 [[bench]]
 name = "kvcore_bench"

--- a/tskv/Cargo.toml
+++ b/tskv/Cargo.toml
@@ -6,55 +6,54 @@ edition = "2021"
 [dependencies]
 config = { path = "../config" }
 models = { path = "../common/models" }
-metrics = {path = "../common/metrics"}
+metrics = { path = "../common/metrics" }
 protos = { path = "../common/protos", features = ["test"] }
 trace = { path = "../common/trace" }
 utils = { path = "../common/utils" }
 
-async-recursion = "1.0.0"
+async-recursion = { workspace = true }
 async-trait = { workspace = true }
-bincode = {workspace = true}
-bytes = "1.1"
-bzip2 = "0.4.3"
-chrono = { workspace = true}
-core_affinity = "0.5.10"
-crc32fast = "1.3.0"
-crossbeam-channel = "0.5"
-dashmap = "5.2"
+bincode = { workspace = true }
+bytes = { workspace = true }
+bzip2 = { workspace = true }
+chrono = { workspace = true }
+core_affinity = { workspace = true }
+crc32fast = { workspace = true }
+crossbeam-channel = { workspace = true }
+dashmap = { workspace = true }
 datafusion = { workspace = true }
-evmap = "10.0"
+evmap = { workspace = true }
 flatbuffers = { workspace = true }
-flate2 = "1.0.24"
+flate2 = { workspace = true }
 futures = { workspace = true, features = ["std", "thread-pool"] }
-integer-encoding = "3.0.3"
-lazy_static = "1.4"
-libc = {workspace = true}
-minivec = "0.4.0"
-mio = "0.8"
-num_cpus = "1.13.1"
-num_enum = "0.5.7"
-num-traits = "0.2.14"
-once_cell = "1.10"
-page_size = "0.4"
+integer-encoding = { workspace = true }
+lazy_static = { workspace = true }
+libc = { workspace = true }
+minivec = { workspace = true }
+mio = { workspace = true }
+num_cpus = { workspace = true }
+num_enum = { workspace = true }
+num-traits = { workspace = true }
+once_cell = { workspace = true }
+page_size = { workspace = true }
 parking_lot = { workspace = true, features = ["nightly", "send_guard"] }
-priority-queue = "1.2"
-q_compress = "0.11.1"
-regex = "1.5"
+priority-queue = { workspace = true }
+q_compress = { workspace = true }
+regex = { workspace = true }
 serde = { workspace = true }
-serial_test = "0.8.0"
-sled = "0.34.7"
+serial_test = { workspace = true }
+sled = { workspace = true }
 snafu = { workspace = true }
-snap = "1.0.0"
-static_assertions = "1.1"
+snap = { workspace = true }
+static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tracing = "0.1.35"
-walkdir = "2.3"
-zstd = "0.11.2"
+walkdir = { workspace = true }
+zstd = { workspace = true }
 
 [dev-dependencies]
-criterion = { version = "0.3.5", features = ["async_tokio"] }
-rand = "0.8"
-tempfile = "3"
+criterion = { workspace = true, features = ["async_tokio"] }
+rand = { workspace = true }
+tempfile = { workspace = true }
 parking_lot = { workspace = true, features = ["nightly"] }
 
 [[bench]]

--- a/tskv/src/compaction/picker.rs
+++ b/tskv/src/compaction/picker.rs
@@ -15,8 +15,7 @@ use chrono::{
 use lazy_static::lazy_static;
 use models::Timestamp;
 use parking_lot::RwLock;
-use trace::error;
-use tracing::info;
+use trace::{error, info};
 
 use crate::{
     compaction::CompactReq,

--- a/tskv/src/engine.rs
+++ b/tskv/src/engine.rs
@@ -15,8 +15,7 @@ use protos::{
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::sync::Arc;
-use trace::debug;
-use tracing::log::info;
+use trace::{debug, info};
 
 pub type EngineRef = Arc<dyn Engine>;
 

--- a/tskv/src/index/db_index.rs
+++ b/tskv/src/index/db_index.rs
@@ -17,8 +17,6 @@ use once_cell::sync::OnceCell;
 use parking_lot::RwLock;
 use sled::Error;
 use snafu::ResultExt;
-use tracing::field::debug;
-use tracing::{error, info};
 
 use crate::Error::IndexErr;
 use config::Config;
@@ -28,7 +26,7 @@ use models::{
     tag::TagFromParts, utils, ColumnId, FieldId, FieldInfo, SeriesId, SeriesKey, Tag, ValueType,
 };
 use protos::models::Point;
-use trace::{debug, warn};
+use trace::{debug, error, info, warn};
 
 use super::utils::{decode_series_id_list, encode_inverted_index_key, encode_series_id_list};
 use super::*;

--- a/tskv/src/index/utils.rs
+++ b/tskv/src/index/utils.rs
@@ -1,7 +1,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use bytes::BufMut;
-use tracing::log::info;
+use trace::info;
 
 use models::FieldId;
 

--- a/tskv/src/summary.rs
+++ b/tskv/src/summary.rs
@@ -584,7 +584,7 @@ mod test {
     use snafu::ResultExt;
     use tokio::sync::mpsc;
     use tokio::sync::mpsc::UnboundedSender;
-    use tracing::debug;
+    use trace::debug;
 
     use config::get_config;
     use models::schema::DatabaseSchema;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #629.

# Rationale for this change

All crates in workspace share the same versions of dependencies.

# What changes are included in this PR?

1. Remove crate `datafusion_dep`.
2. Move dependencies declarations from package level to workspace level.
3. To do that in step 2，upgrade rust toolchain version to `1.64`.
4. Reorder some `Cargo.toml`.


# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
