### PR TITLE
feature: periodically fsync wal files

### DIFF
--- a/config/config_31001.toml
+++ b/config/config_31001.toml
@@ -17,9 +17,6 @@ compact_trigger_file_num = 4
 compact_trigger_cold_duration = "1h"
 max_compact_size = "2G" # 2147483648
 max_concurrent_compaction = 4
-dio_max_resident = 1024
-dio_max_non_resident = 1024
-dio_page_len_scale = 1
 strict_write = false
 
 [wal]
@@ -27,6 +24,7 @@ enabled = true
 path = '/tmp/cnosdb/1001/wal'
 max_file_size = "1G" # 1073741824
 sync = false
+sync_interval = "0" # h, m, s
 
 [cache]
 max_buffer_size = "128M" # 134217728

--- a/config/config_32001.toml
+++ b/config/config_32001.toml
@@ -17,9 +17,6 @@ compact_trigger_file_num = 4
 compact_trigger_cold_duration = "1h"
 max_compact_size = "2G" # 2147483648
 max_concurrent_compaction = 4
-dio_max_resident = 1024
-dio_max_non_resident = 1024
-dio_page_len_scale = 1
 strict_write = false
 
 [wal]
@@ -27,6 +24,7 @@ enabled = true
 path = '/tmp/cnosdb/2001/wal'
 max_file_size = "1G" # 1073741824
 sync = false
+sync_interval = "0" # h, m, s, ms, us, ns
 
 [cache]
 max_buffer_size = "128M" # 134217728

--- a/tskv/src/kv_option.rs
+++ b/tskv/src/kv_option.rs
@@ -130,6 +130,7 @@ pub struct WalOptions {
     pub path: PathBuf,
     pub max_file_size: u64,
     pub sync: bool,
+    pub sync_interval: Duration,
 }
 
 impl From<&Config> for WalOptions {
@@ -140,6 +141,7 @@ impl From<&Config> for WalOptions {
             path: PathBuf::from(config.wal.path.clone()),
             max_file_size: config.wal.max_file_size,
             sync: config.wal.sync,
+            sync_interval: config.wal.sync_interval,
         }
     }
 }

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -203,48 +203,79 @@ impl TsKv {
         wal_manager
     }
 
-    fn run_wal_job(&self, mut wal_manager: WalManager, mut receiver: Receiver<WalTask>) {
-        warn!("job 'WAL' starting.");
+    pub(crate) fn run_wal_job(&self, mut wal_manager: WalManager, mut receiver: Receiver<WalTask>) {
+        async fn on_write(
+            wal_manager: &mut WalManager,
+            points: Arc<Vec<u8>>,
+            cb: oneshot::Sender<Result<(u64, usize)>>,
+            id: TseriesFamilyId,
+            tenant: Arc<Vec<u8>>,
+        ) {
+            let ret = wal_manager
+                .write(WalEntryType::Write, points, id, tenant)
+                .await;
+            let send_ret = cb.send(ret);
+            if let Err(e) = send_ret {
+                warn!("send WAL write result failed: {:?}", e);
+            }
+        }
+
+        async fn on_tick(wal_manager: &WalManager) {
+            if let Err(e) = wal_manager.sync().await {
+                error!("Failed flushing WAL file: {:?}", e);
+            }
+        }
+
+        async fn on_cancel(wal_manager: WalManager) {
+            info!("Job 'WAL' closing.");
+            if let Err(e) = wal_manager.close().await {
+                error!("Failed to close job 'WAL': {:?}", e);
+            }
+            info!("Job 'WAL' closed.");
+        }
+
+        info!("Job 'WAL' starting.");
         let mut close_receiver = self.close_sender.subscribe();
-        let f = async move {
-            loop {
-                tokio::select! {
-                    wal_task = receiver.recv() => {
-                        match wal_task {
-                            Some(WalTask::Write { id, points, tenant, cb }) => {
-                                // write wal
-                                let ret = wal_manager.write(WalEntryType::Write, points, id, tenant).await;
-                                let send_ret = cb.send(ret);
-                                match send_ret {
-                                    Ok(wal_result) => {}
-                                    Err(err) => {
-                                        warn!("send WAL write result failed.")
-                                    }
-                                }
+        let _ = self.runtime.spawn(async move {
+            info!("Job 'WAL' started.");
+
+            let sync_interval = wal_manager.sync_interval();
+            if sync_interval == Duration::ZERO {
+                loop {
+                    tokio::select! {
+                        wal_task = receiver.recv() => {
+                            match wal_task {
+                                Some(WalTask::Write { id, points, tenant, cb }) => on_write(&mut wal_manager, points, cb, id, tenant).await,
+                                _ => break
                             }
-                            _ => {
-                                break;
-                            }
+                        }
+                        close_task = close_receiver.recv() => {
+                            on_cancel(wal_manager).await;
+                            break;
                         }
                     }
-                    close_task = close_receiver.recv() => {
-                        info!("job 'WAL' closing.");
-                        if let Err(e) = wal_manager.close().await {
-                            error!("Failed to close wal: {:?}", e);
-                        }
-                        info!("job 'WAL' closed.");
-                        if let Ok(tx) = close_task {
-                            if let Err(e) = tx.send(()).await {
-                                error!("Failed to send wal closed signal: {:?}", e);
+                }
+            } else {
+                let mut ticker = tokio::time::interval(sync_interval);
+                loop {
+                    tokio::select! {
+                        wal_task = receiver.recv() => {
+                            match wal_task {
+                                Some(WalTask::Write { id, points, tenant, cb }) => on_write(&mut wal_manager, points, cb, id, tenant).await,
+                                _ => break
                             }
                         }
-                        break;
+                        _ = ticker.tick() => {
+                            on_tick(&wal_manager).await;
+                        }
+                        close_task = close_receiver.recv() => {
+                            on_cancel(wal_manager).await;
+                            break;
+                        }
                     }
                 }
             }
-        };
-        self.runtime.spawn(f);
-        info!("job 'WAL' started.");
+        });
     }
 
     fn run_flush_job(

--- a/tskv/src/wal.rs
+++ b/tskv/src/wal.rs
@@ -221,6 +221,10 @@ impl WalWriter {
         Ok((seq, written_size))
     }
 
+    pub async fn sync(&self) -> Result<()> {
+        self.inner.sync().await
+    }
+
     pub async fn close(mut self) -> Result<()> {
         info!(
             "Closing wal with sequence: [{}, {})",
@@ -456,8 +460,16 @@ impl WalManager {
         Ok(seq_gt_min_seq)
     }
 
+    pub async fn sync(&self) -> Result<()> {
+        self.current_file.sync().await
+    }
+
     pub async fn close(self) -> Result<()> {
         self.current_file.close().await
+    }
+
+    pub fn sync_interval(&self) -> std::time::Duration {
+        self.config.sync_interval
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes nothing.

# Rationale for this change

1. Added a new config type: duration, such as `"1s"`, `"1000ms"`, etc.
2. Flush WAL files to disk periodically using that duration.
3. Script `wal.rs` has too many lines, so moved it as directory `wal/`, split into `mod.rs`, `reader.rs`, `writer.rs`, `job.rs`.
4. Close background tasks using `CancellationToken`, instead of a pair of broadcast channels.
5. Close background tasks concurrently. 

# What changes are included in this PR?

## 1. Added new config item

```toml
[wal]
enabled = true
path = 'data/wal'
sync = false
# Add sync_interval
sync_interval = "0" # h, m, s
```

## 2. Re-arrange dependencies declarations for `kvcore.rs`.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
