### PR TITLE
chore: add detail message fot IndexError::FieldType

### DIFF
--- a/tskv/src/index/errors.rs
+++ b/tskv/src/index/errors.rs
@@ -26,8 +26,8 @@ pub enum IndexError {
     #[snafu(display("Unrecognized version"))]
     Version,
 
-    #[snafu(display("Unrecognized FieldType"))]
-    FieldType,
+    #[snafu(display("Unrecognized FieldType: {}", msg))]
+    FieldType { msg: String },
 
     #[snafu(display("Not Found Field"))]
     NotFoundField,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

## There are serial freak IndexError::FieldType instantiation

Error messages are not clear enough such as #735, so added detail message for IndexError::FieldType.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
