### PR TITLE
Update flatbuffers to 22.9(resolved RUSTSEC-2021-0122)

### DIFF
--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -11,9 +11,8 @@ runs:
     - name: Install Build Dependencies
       shell: bash
       run: |
-        git clone https://github.com/google/flatbuffers.git
+        git clone -b v22.9.29 --depth 1 https://github.com/google/flatbuffers.git
         cd flatbuffers
-        git checkout v2.0.6
         cmake .
         make
         sudo make install

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -35,18 +35,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    
+
     - name: dep
       run: |
-        git clone https://github.com/google/flatbuffers.git
+        git clone -b v22.9.29 --depth 1 https://github.com/google/flatbuffers.git
         cd flatbuffers
-        git checkout v2.0.6
         cmake .
         make
         sudo make install
         sudo ldconfig
         flatc --version
-    
+
     - name: test
       run: make test
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ diff = "0.1.13"
 dirs = "4.0.0"
 env_logger = "0.9"
 evmap = "10.0"
-flatbuffers = "2.1"
+flatbuffers = "22.9"
 flate2 = "1.0.24"
 futures = { version = "0.3" }
 integer-encoding = "3.0.3"

--- a/common/models/src/field_info.rs
+++ b/common/models/src/field_info.rs
@@ -121,6 +121,7 @@ impl FieldInfo {
                 .ok_or(Error::InvalidFlatbufferMessage {
                     err: "".to_string(),
                 })?
+                .bytes()
                 .to_vec(),
             value_type: field.type_().into(),
             code_type: 0,

--- a/common/models/src/points.rs
+++ b/common/models/src/points.rs
@@ -15,7 +15,7 @@ impl FieldValue {
             field_id: 0,
             value_type: field.type_().into(),
             value: match field.value() {
-                Some(v) => v.to_vec(),
+                Some(v) => v.bytes().to_vec(),
                 None => Vec::new(),
             },
         })
@@ -72,7 +72,7 @@ impl From<fb_models::Point<'_>> for InMemPoint {
                 let mut fields = Vec::with_capacity(fields_inner.len());
                 for f in fields_inner.into_iter() {
                     let val_type = f.type_().into();
-                    let val = f.value().unwrap().to_vec();
+                    let val = f.value().unwrap().bytes().to_vec();
                     fields.push(FieldValue {
                         field_id: 0,
                         value_type: val_type,

--- a/common/models/src/series_info.rs
+++ b/common/models/src/series_info.rs
@@ -92,9 +92,11 @@ impl SeriesKey {
         };
 
         let db = match point.db() {
-            Some(db) => String::from_utf8(db.to_vec()).map_err(|err| InvalidFlatbufferMessage {
-                err: err.to_string(),
-            })?,
+            Some(db) => {
+                String::from_utf8(db.bytes().to_vec()).map_err(|err| InvalidFlatbufferMessage {
+                    err: err.to_string(),
+                })?
+            }
 
             None => {
                 return Err(Error::InvalidFlatbufferMessage {
@@ -104,11 +106,11 @@ impl SeriesKey {
         };
 
         let table = match point.tab() {
-            Some(table) => {
-                String::from_utf8(table.to_vec()).map_err(|err| InvalidFlatbufferMessage {
+            Some(table) => String::from_utf8(table.bytes().to_vec()).map_err(|err| {
+                InvalidFlatbufferMessage {
                     err: err.to_string(),
-                })?
-            }
+                }
+            })?,
 
             None => {
                 return Err(InvalidFlatbufferMessage {

--- a/common/models/src/tag.rs
+++ b/common/models/src/tag.rs
@@ -32,12 +32,14 @@ impl Tag {
             .ok_or(Error::InvalidFlatbufferMessage {
                 err: "Tag key cannot be empty".to_string(),
             })?
+            .bytes()
             .to_vec();
         let value = tag
             .value()
             .ok_or(Error::InvalidFlatbufferMessage {
                 err: "Tag value cannot be empty".to_string(),
             })?
+            .bytes()
             .to_vec();
         Ok(Self { key, value })
     }

--- a/common/protos/build.rs
+++ b/common/protos/build.rs
@@ -98,7 +98,17 @@ mod flatbuffers_generated;
             flatbuffers_generated_mod_rs_file.write_all(b";\n")?;
             flatbuffers_generated_mod_rs_file.flush()?;
 
-            let output = Command::new("flatc")
+            let flatc_path = match env::var("FLATC_PATH") {
+                Ok(p) => {
+                    println!(
+                        "Found specified flatc path in environment FLATC_PATH( {} )",
+                        &p
+                    );
+                    p
+                }
+                Err(_) => "flatc".to_string(),
+            };
+            let output = Command::new(&flatc_path)
                 .arg("-o")
                 .arg(&output_dir_final)
                 .arg("--rust")
@@ -109,10 +119,10 @@ mod flatbuffers_generated;
                 .arg("")
                 .arg(p)
                 .output()
-                .unwrap_or_else(|_| {
+                .unwrap_or_else(|e| {
                     panic!(
-                        "Failed to generate file by flatbuffers {}.",
-                        output_file_name
+                        "Failed to generate file '{}' by flatc(path: '{}'): {:?}.",
+                        output_file_name, flatc_path, e
                     )
                 });
 

--- a/docs/quick-start-cn.md
+++ b/docs/quick-start-cn.md
@@ -115,7 +115,7 @@
    如果您的系统不在此列，需要自行编译
 
    ```shell
-   $ git clone -b v2.0.6 --depth 1 https://github.com/google/flatbuffers.git && cd flatbuffers
+   $ git clone -b v22.9.29 --depth 1 https://github.com/google/flatbuffers.git && cd flatbuffers
 
    # 根据操作系统选择以下命令之一
    $ cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -115,7 +115,7 @@ We support the following platforms, please report to us if you find it works on 
     If your system is not listed here, you can install FlatBuffers as follows
 
     ```shell
-    git clone -b v2.0.6 --depth 1 https://github.com/google/flatbuffers.git && cd flatbuffers
+    git clone -b v22.9.29 --depth 1 https://github.com/google/flatbuffers.git && cd flatbuffers
     ```
 
     ```shell
@@ -123,6 +123,7 @@ We support the following platforms, please report to us if you find it works on 
     cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
     cmake -G "Visual Studio 10" -DCMAKE_BUILD_TYPE=Release
     cmake -G "Xcode" -DCMAKE_BUILD_TYPE=Release
+
     sudo make install
     ```
 

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -211,7 +211,7 @@ impl Database {
         point: Point,
         sid: u64,
     ) -> Result<()> {
-        let table_name = String::from_utf8(point.tab().unwrap().to_vec()).unwrap();
+        let table_name = String::from_utf8(point.tab().unwrap().bytes().to_vec()).unwrap();
         let table_schema = self
             .index
             .get_table_schema(&table_name)

--- a/tskv/src/index/db_index.rs
+++ b/tskv/src/index/db_index.rs
@@ -209,7 +209,8 @@ impl DBIndex {
     }
 
     pub fn check_field_type_from_cache(&self, series_id: u64, info: &Point) -> IndexResult<()> {
-        let table_name = unsafe { String::from_utf8_unchecked(info.tab().unwrap().to_vec()) };
+        let table_name =
+            unsafe { String::from_utf8_unchecked(info.tab().unwrap().bytes().to_vec()) };
         if let Some(schema) = self.table_schema.read().get(&table_name) {
             let schema = match schema {
                 TableSchema::TsKvTableSchema(schema) => schema,
@@ -218,7 +219,7 @@ impl DBIndex {
                 }
             };
             for field in info.fields().unwrap() {
-                let field_name = String::from_utf8(field.name().unwrap().to_vec()).unwrap();
+                let field_name = String::from_utf8(field.name().unwrap().bytes().to_vec()).unwrap();
                 if let Some(v) = schema.column(&field_name) {
                     if field.type_().0 != v.column_type.field_type() as i32 {
                         trace::debug!(
@@ -239,7 +240,8 @@ impl DBIndex {
                 }
             }
             for tag in info.tags().unwrap() {
-                let tag_name: String = String::from_utf8(tag.key().unwrap().to_vec()).unwrap();
+                let tag_name: String =
+                    String::from_utf8(tag.key().unwrap().bytes().to_vec()).unwrap();
                 if let Some(v) = schema.column(&tag_name) {
                     if ColumnType::Tag != v.column_type {
                         trace::debug!("type mismatch, point: tag, schema: {}", &v.column_type);
@@ -260,8 +262,9 @@ impl DBIndex {
     pub fn check_field_type_or_else_add(&self, series_id: u64, info: &Point) -> IndexResult<()> {
         //load schema first from cache,or else from storage and than cache it!
         let mut schema = &mut TskvTableSchema::default();
-        let table_name = unsafe { String::from_utf8_unchecked(info.tab().unwrap().to_vec()) };
-        let db_name = unsafe { String::from_utf8_unchecked(info.db().unwrap().to_vec()) };
+        let table_name =
+            unsafe { String::from_utf8_unchecked(info.tab().unwrap().bytes().to_vec()) };
+        let db_name = unsafe { String::from_utf8_unchecked(info.db().unwrap().bytes().to_vec()) };
         let mut fields = self.table_schema.write();
         let mut new_schema = false;
         match fields.get_mut(&table_name) {
@@ -333,13 +336,15 @@ impl DBIndex {
 
         //check tags
         for tag in info.tags().unwrap() {
-            let tag_key = unsafe { String::from_utf8_unchecked(tag.key().unwrap().to_vec()) };
+            let tag_key =
+                unsafe { String::from_utf8_unchecked(tag.key().unwrap().bytes().to_vec()) };
             check_fn(&mut TableColumn::new_with_default(tag_key, ColumnType::Tag))?
         }
 
         //check fields
         for field in info.fields().unwrap() {
-            let field_name = unsafe { String::from_utf8_unchecked(field.name().unwrap().to_vec()) };
+            let field_name =
+                unsafe { String::from_utf8_unchecked(field.name().unwrap().bytes().to_vec()) };
             check_fn(&mut TableColumn::new_with_default(
                 field_name,
                 ColumnType::from_i32(field.type_().0),

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -364,7 +364,7 @@ impl Engine for TsKv {
         let fb_points = flatbuffers::root::<fb_models::Points>(&points)
             .context(error::InvalidFlatbufferSnafu)?;
 
-        let db_name = String::from_utf8(fb_points.db().unwrap().to_vec())
+        let db_name = String::from_utf8(fb_points.db().unwrap().bytes().to_vec())
             .map_err(|err| Error::ErrCharacterSet)?;
 
         let db_warp = self.version_set.read().get_db(&db_name);
@@ -421,7 +421,7 @@ impl Engine for TsKv {
         let fb_points = flatbuffers::root::<fb_models::Points>(&points)
             .context(error::InvalidFlatbufferSnafu)?;
 
-        let db_name = String::from_utf8(fb_points.db().unwrap().to_vec())
+        let db_name = String::from_utf8(fb_points.db().unwrap().bytes().to_vec())
             .map_err(|err| Error::ErrCharacterSet)?;
 
         let db = self

--- a/tskv/src/memcache.rs
+++ b/tskv/src/memcache.rs
@@ -130,9 +130,9 @@ impl RowData {
                 }
                 for (i, f) in fields_inner.into_iter().enumerate() {
                     let vtype = f.type_().into();
-                    let val = MiniVec::from(f.value().unwrap());
+                    let val = MiniVec::from(f.value().unwrap().bytes());
                     match schema.column(
-                        String::from_utf8(f.name().unwrap().to_vec())
+                        String::from_utf8(f.name().unwrap().bytes().to_vec())
                             .unwrap()
                             .as_str(),
                     ) {
@@ -177,7 +177,7 @@ impl From<fb_models::Point<'_>> for RowData {
                 let mut fields = Vec::with_capacity(fields_inner.len());
                 for f in fields_inner.into_iter() {
                     let vtype = f.type_().into();
-                    let val = MiniVec::from(f.value().unwrap());
+                    let val = MiniVec::from(f.value().unwrap().bytes());
                     fields.push(Some(FieldVal::new(val, vtype)));
                 }
                 fields


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

The old version of flatbuffers has some problems: **Generated code can read and write out of bounds in safe code**.

See this [rustsec link](https://rustsec.org/advisories/RUSTSEC-2021-0122.html) or [Github Issue](https://github.com/google/flatbuffers/issues/6627).

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Note that flatbuffers now uses flatbuffers::Vector instead of slices in generated models.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
