### PR TITLE
feat(wal): Automatic remove wal files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,10 @@ clippy:
 	cargo clippy --workspace  --all-targets --fix
 
 build:
-	cargo build --all-features --all-targets --package main
-	cargo build --all-features --all-targets --package meta
-	cargo build --all-features --all-targets --package client
+	cargo build --workspace --bins
+
+build_release:
+	cargo build --release --workspace --bins
 
 test:
 	cargo test --workspace --exclude e2e_test
@@ -32,4 +33,4 @@ clean:
 run:
 	cargo run -- run
 
-.PHONY: docs check fmt fmt_check clippy clippy_check build test docs_check clean run
+.PHONY: docs check fmt fmt_check clippy clippy_check build build_release test docs_check clean run

--- a/tskv/src/context.rs
+++ b/tskv/src/context.rs
@@ -1,8 +1,16 @@
-use crate::TseriesFamilyId;
-use std::sync::{
-    atomic::{AtomicU32, AtomicU64, Ordering},
-    Arc,
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{
+        atomic::{AtomicU32, AtomicU64, Ordering},
+        Arc,
+    },
 };
+
+use parking_lot::RwLock;
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+use crate::TseriesFamilyId;
 
 #[derive(Default, Debug)]
 pub struct GlobalContext {
@@ -82,5 +90,143 @@ impl GlobalContext {
                 Err(x) => old = x,
             }
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct GlobalSequenceContext {
+    min_seq: AtomicU64,
+    inner: Arc<RwLock<GlobalSequenceContextInner>>,
+}
+
+impl GlobalSequenceContext {
+    pub fn new(min_seq: u64, tsf_seq_map: HashMap<TseriesFamilyId, u64>) -> Self {
+        Self {
+            min_seq: AtomicU64::new(min_seq),
+            inner: Arc::new(RwLock::new(GlobalSequenceContextInner {
+                min_seq,
+                tsf_seq_map,
+            })),
+        }
+    }
+
+    /// Write lock the inner, apply arguments, then update atomic min_seq.
+    pub fn next_stage(
+        &self,
+        del_ts_family: HashSet<TseriesFamilyId>,
+        ts_family_min_seq: HashMap<TseriesFamilyId, u64>,
+    ) {
+        let mut inner = self.inner.write();
+
+        if del_ts_family.is_empty() {
+            let mut tsf_min_seq = if inner.tsf_seq_map.is_empty() {
+                u64::MAX
+            } else {
+                inner.min_seq
+            };
+            for (tsf_id, min_seq) in ts_family_min_seq {
+                inner.tsf_seq_map.insert(tsf_id, min_seq);
+                tsf_min_seq = tsf_min_seq.min(min_seq);
+            }
+            inner.min_seq = tsf_min_seq;
+        } else {
+            for tsf_id in del_ts_family {
+                inner.tsf_seq_map.remove(&tsf_id);
+            }
+            for (tsf_id, min_seq) in ts_family_min_seq {
+                inner.tsf_seq_map.insert(tsf_id, min_seq);
+            }
+            inner.reset_min_seq();
+        }
+        self.min_seq.store(inner.min_seq, Ordering::Release);
+    }
+
+    pub fn min_seq(&self) -> u64 {
+        self.min_seq.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+impl GlobalSequenceContext {
+    pub fn empty() -> Arc<Self> {
+        Arc::new(Self {
+            min_seq: AtomicU64::new(0),
+            inner: Arc::new(RwLock::new(GlobalSequenceContextInner {
+                min_seq: 0,
+                tsf_seq_map: HashMap::new(),
+            })),
+        })
+    }
+
+    pub fn set_min_seq(&self, min_seq: u64) {
+        let mut inner = self.inner.write();
+        inner.min_seq = min_seq;
+        self.min_seq.store(inner.min_seq, Ordering::Release);
+    }
+}
+
+#[derive(Debug)]
+struct GlobalSequenceContextInner {
+    /// Minimum sequence number of all `TseriesFamily`s in all `Database`s
+    min_seq: u64,
+    /// Maps `TseriesFamily`-ID to it's last sequence number flushed to disk.
+    tsf_seq_map: HashMap<TseriesFamilyId, u64>,
+}
+
+impl GlobalSequenceContextInner {
+    /// Reset min_seq using current tsf_seq_map.
+    fn reset_min_seq(&mut self) {
+        if self.tsf_seq_map.is_empty() {
+            self.min_seq = 0;
+        } else {
+            let mut min_seq = u64::MAX;
+            for (_, v) in self.tsf_seq_map.iter() {
+                min_seq = min_seq.min(*v);
+            }
+            self.min_seq = min_seq;
+        }
+    }
+}
+
+pub struct GlobalSequenceTask {
+    pub del_ts_family: HashSet<TseriesFamilyId>,
+    pub ts_family_min_seq: HashMap<TseriesFamilyId, u64>,
+}
+
+/// Start a async job to maintain GlobalSequenceCOntext.
+pub(crate) fn run_global_context_job(
+    runtime: Arc<Runtime>,
+    mut receiver: UnboundedReceiver<GlobalSequenceTask>,
+    global_sequence_context: Arc<GlobalSequenceContext>,
+) {
+    runtime.spawn(async move {
+        while let Some(t) = receiver.recv().await {
+            global_sequence_context.next_stage(t.del_ts_family, t.ts_family_min_seq);
+        }
+    });
+}
+
+#[cfg(test)]
+mod test_context {
+    use std::collections::{HashMap, HashSet};
+
+    use super::GlobalSequenceContext;
+
+    #[test]
+    fn test_global_sequence_context() {
+        let ctx = GlobalSequenceContext::empty();
+        assert_eq!(ctx.min_seq(), 0);
+
+        // Add tsfamily, no delete tsfamily
+        ctx.next_stage(HashSet::new(), HashMap::from([(1, 2), (2, 10), (3, 5)]));
+        assert_eq!(ctx.min_seq(), 2);
+
+        // Delete tsfamily, no add tsfamily
+        ctx.next_stage(HashSet::from([1, 2]), HashMap::new());
+        assert_eq!(ctx.min_seq(), 5);
+
+        // Delete tsfamily and add tsfamily
+        ctx.next_stage(HashSet::from([3]), HashMap::from([(4, 6), (5, 8), (6, 10)]));
+        assert_eq!(ctx.min_seq(), 6);
     }
 }

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -381,6 +381,18 @@ impl Database {
         check::get_ts_family_hash_tree(self, ts_family_id).await
     }
 
+    pub async fn get_min_ts_family_seq_no(&self) -> u64 {
+        let mut min_seq_no = if self.ts_families.is_empty() {
+            0_u64
+        } else {
+            u64::MAX
+        };
+        for (_, ts_family) in self.ts_families.iter() {
+            min_seq_no = min_seq_no.min(ts_family.read().seq_no());
+        }
+        min_seq_no
+    }
+
     pub fn owner(&self) -> String {
         self.owner.clone()
     }

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -381,18 +381,6 @@ impl Database {
         check::get_ts_family_hash_tree(self, ts_family_id).await
     }
 
-    pub async fn get_min_ts_family_seq_no(&self) -> u64 {
-        let mut min_seq_no = if self.ts_families.is_empty() {
-            0_u64
-        } else {
-            u64::MAX
-        };
-        for (_, ts_family) in self.ts_families.iter() {
-            min_seq_no = min_seq_no.min(ts_family.read().seq_no());
-        }
-        min_seq_no
-    }
-
     pub fn owner(&self) -> String {
         self.owner.clone()
     }

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -171,7 +171,9 @@ impl TsKv {
     }
 
     async fn recover_wal(&self) -> WalManager {
-        let wal_manager = WalManager::open(self.options.wal.clone()).await.unwrap();
+        let wal_manager = WalManager::open(self.options.wal.clone(), self.version_set.clone())
+            .await
+            .unwrap();
 
         wal_manager
             .recover(self, self.global_ctx.clone())

--- a/tskv/src/summary.rs
+++ b/tskv/src/summary.rs
@@ -441,7 +441,7 @@ impl Summary {
                 tsf_min_seq.insert(edit.tsf_id, edit.seq_no);
             }
         }
-        let version_set = self.version_set.write().await;
+        let mut version_set = self.version_set.write().await;
         for (tsf_id, version_edits) in tsf_version_edits {
             let min_seq = tsf_min_seq.get(&tsf_id);
             if let Some(tsf) = version_set.get_tsfamily_by_tf_id(tsf_id).await {
@@ -452,6 +452,7 @@ impl Summary {
                 tsf.write().new_version(new_version);
             }
         }
+        version_set.update_min_seq_no().await;
 
         Ok(())
     }

--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -874,6 +874,10 @@ impl TseriesFamily {
     pub fn storage_opt(&self) -> Arc<StorageOptions> {
         self.storage_opt.clone()
     }
+
+    pub fn seq_no(&self) -> u64 {
+        self.seq_no
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

Field `seq_no` in TsFamily that means: "the last write request sequence number that flushed to disk".

Whenever some summary of a ts family wrote, a new version generated, I added a logic that get the minimum seq_no of ts families in a database, then get the minimal seq_no of databases in version set.

When roll wal file to write, compare the min_seq_no in version set with old wal files, delete wal files which file_id is less than min_seq_no in version set.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
