### PR TITLE
fix(tskv): Query select count(1) return incorrect value.

### DIFF
--- a/common/lru_cache/src/lib.rs
+++ b/common/lru_cache/src/lib.rs
@@ -348,7 +348,7 @@ impl<K, V> Drop for Cache<K, V> {
         self.table.drain().for_each(|(_, ent)| unsafe {
             let mut ent = *Box::from_raw(ent.as_ptr());
             ptr::drop_in_place(ent.k.as_mut_ptr());
-            ptr::drop_in_place(ent.k.as_mut_ptr());
+            ptr::drop_in_place(ent.v.as_mut_ptr());
         });
         let _head = unsafe { *Box::from_raw(self.head) };
         let _tail = unsafe { *Box::from_raw(self.tail) };

--- a/common/protos/src/models_helper.rs
+++ b/common/protos/src/models_helper.rs
@@ -119,7 +119,7 @@ mod test {
 
     pub fn create_tags<'a>(
         fbb: &mut flatbuffers::FlatBufferBuilder<'a>,
-        tags: Vec<(&str, &str)>,
+        tags: &[(&str, &str)],
     ) -> WIPOffset<Vector<'a, ForwardsUOffset<Tag<'a>>>> {
         let mut vec = vec![];
         for (k, v) in tags.iter() {
@@ -135,7 +135,7 @@ mod test {
 
     pub fn create_fields<'a>(
         fbb: &mut flatbuffers::FlatBufferBuilder<'a>,
-        fields: Vec<(&str, FieldType, &[u8])>,
+        fields: &[(&str, FieldType, &[u8])],
     ) -> WIPOffset<Vector<'a, ForwardsUOffset<Field<'a>>>> {
         let mut vec = vec![];
         for (name, ft, val) in fields.iter() {
@@ -167,30 +167,31 @@ mod test {
         point_builder.finish()
     }
 
+    /// Generate `num` points, tags and fields are always the same value.
+    ///
+    /// - Database: "db0"
+    /// - table,ta=a,tb=b fa=100i,fb=1000 1
+    /// - table,ta=a,tb=b fa=100i,fb=1000 2
+    /// - ...
+    /// - table,ta=a,tb=b fa=100i,fb=1000 num-1
+    #[allow(clippy::too_many_arguments)]
     pub fn create_const_points<'a>(
         fbb: &mut flatbuffers::FlatBufferBuilder<'a>,
+        database: &str,
+        table: &str,
+        tags: Vec<(&str, &str)>,
+        fields: Vec<(&str, FieldType, &[u8])>,
+        start_timestamp: i64,
         num: usize,
     ) -> WIPOffset<Points<'a>> {
-        let db = fbb.create_vector("db0".as_bytes());
+        let db = fbb.create_vector(database.as_bytes());
         let mut points = vec![];
-        for _ in 0..num {
-            let timestamp = 1;
-            let tags = create_tags(
-                fbb,
-                vec![("ta", &("a".to_string())), ("tb", &("b".to_string()))],
-            );
+        for timestamp in start_timestamp..start_timestamp + num as i64 {
+            let tags = create_tags(fbb, &tags);
 
-            let fav = 100_i64.to_be_bytes();
-            let fbv = 1000_i64.to_be_bytes();
-            let fields = create_fields(
-                fbb,
-                vec![
-                    ("fa", FieldType::Integer, fav.as_slice()),
-                    ("fb", FieldType::Float, fbv.as_slice()),
-                ],
-            );
+            let fields = create_fields(fbb, &fields);
 
-            let table = fbb.create_vector("table".as_bytes());
+            let table = fbb.create_vector(table.as_bytes());
             points.push(create_point(
                 fbb,
                 timestamp,
@@ -228,9 +229,10 @@ mod test {
             let tags = create_tags(
                 fbb,
                 vec![
-                    ("ta", &("a".to_string() + &tav)),
-                    ("tb", &("b".to_string() + &tbv)),
-                ],
+                    ("ta", ("a".to_string() + &tav).as_str()),
+                    ("tb", ("b".to_string() + &tbv).as_str()),
+                ]
+                .as_slice(),
             );
 
             let fav = rand::random::<i64>().to_be_bytes();
@@ -240,7 +242,8 @@ mod test {
                 vec![
                     ("fa", FieldType::Integer, fav.as_slice()),
                     ("fb", FieldType::Float, fbv.as_slice()),
-                ],
+                ]
+                .as_slice(),
             );
 
             let table = fbb.create_vector("table".as_bytes());
@@ -283,18 +286,20 @@ mod test {
                 create_tags(
                     fbb,
                     vec![
-                        ("ta", &("a".to_string() + &tav)),
-                        ("tb", &("b".to_string() + &tbv)),
-                    ],
+                        ("ta", ("a".to_string() + &tav).as_str()),
+                        ("tb", ("b".to_string() + &tbv).as_str()),
+                    ]
+                    .as_slice(),
                 )
             } else {
                 create_tags(
                     fbb,
                     vec![
-                        ("ta", &("a".to_string() + &tav)),
-                        ("tb", &("b".to_string() + &tbv)),
-                        ("tc", &("c".to_string() + &tbv)),
-                    ],
+                        ("ta", ("a".to_string() + &tav).as_str()),
+                        ("tb", ("b".to_string() + &tbv).as_str()),
+                        ("tc", ("c".to_string() + &tbv).as_str()),
+                    ]
+                    .as_slice(),
                 )
             };
 
@@ -306,7 +311,8 @@ mod test {
                     vec![
                         ("fa", FieldType::Integer, fav.as_slice()),
                         ("fb", FieldType::Float, fbv.as_slice()),
-                    ],
+                    ]
+                    .as_slice(),
                 )
             } else {
                 create_fields(
@@ -315,7 +321,8 @@ mod test {
                         ("fa", FieldType::Integer, fav.as_slice()),
                         ("fb", FieldType::Float, fbv.as_slice()),
                         ("fc", FieldType::Float, fbv.as_slice()),
-                    ],
+                    ]
+                    .as_slice(),
                 )
             };
 
@@ -352,7 +359,7 @@ mod test {
             for _ in 0..19999 {
                 tags.push(("tag", tav.as_str()));
             }
-            let tags = create_tags(fbb, tags);
+            let tags = create_tags(fbb, &tags);
 
             let mut fields = vec![];
             let fav = rand::random::<i64>().to_be_bytes();
@@ -361,7 +368,7 @@ mod test {
                 fields.push(("field_integer", FieldType::Integer, fav.as_slice()));
                 fields.push(("field_float", FieldType::Float, fbv.as_slice()));
             }
-            let fields = create_fields(fbb, fields);
+            let fields = create_fields(fbb, &fields);
 
             let table = fbb.create_vector("table".as_bytes());
             points.push(create_point(
@@ -407,14 +414,14 @@ mod test {
             let tags = create_tags(fbb, vec![
                 (tag_key_values[0].0, tag_key_values[0].1[i as usize / tag_key_values[0].1.len() % tag_key_values[0].1.len()]),
                 (tag_key_values[1].0, tag_key_values[1].1[i as usize % tag_key_values[1].1.len()]),
-            ]);
+            ].as_slice());
 
             let mut fields = vec![];
             let fv = rand::random::<f64>().to_be_bytes();
             for fk in field_keys {
                 fields.push((fk, FieldType::Float, fv.as_slice()));
             }
-            let fields = create_fields(fbb, fields);
+            let fields = create_fields(fbb, &fields);
 
             points.push(create_point(
                 fbb,

--- a/tskv/src/compaction/check.rs
+++ b/tskv/src/compaction/check.rs
@@ -700,8 +700,8 @@ mod test {
         for (timestamp, v) in timestamps.into_iter().zip(rows_ref.into_iter()) {
             let db = fbb.create_vector(database.as_bytes());
             let table = fbb.create_vector(table.as_bytes());
-            let tags = models_helper::create_tags(&mut fbb, vec![("ta", "a1"), ("tb", "b1")]);
-            let fields = models_helper::create_fields(&mut fbb, v);
+            let tags = models_helper::create_tags(&mut fbb, &[("ta", "a1"), ("tb", "b1")]);
+            let fields = models_helper::create_fields(&mut fbb, &v);
             let point = models_helper::create_point(&mut fbb, timestamp, db, table, tags, fields);
             points.push(point);
         }

--- a/tskv/src/compaction/check.rs
+++ b/tskv/src/compaction/check.rs
@@ -159,21 +159,17 @@ pub(crate) async fn get_ts_family_hash_tree(
     }
     let time_range_nanosec = get_default_time_range(schemas)?;
 
-    // let ts_family_rlock = ts_family.read();
-    // let version = ts_family_rlock.version();
-    // let ts_family_id = ts_family_rlock.tf_id();
-    // drop(ts_family_rlock);
     let (version, ts_family_id) = {
         let ts_family_rlock = ts_family.read();
         (ts_family_rlock.version(), ts_family_rlock.tf_id())
     };
-    let mut readers: Vec<TsmReader> = Vec::new();
+    let mut readers: Vec<Arc<TsmReader>> = Vec::new();
     for path in version
         .levels_info()
         .iter()
         .flat_map(|l| l.files.iter().map(|f| f.file_path()))
     {
-        let r = TsmReader::open(path).await?;
+        let r = version.get_tsm_reader(path).await?;
         readers.push(r);
     }
 

--- a/tskv/src/compaction/flush.rs
+++ b/tskv/src/compaction/flush.rs
@@ -632,7 +632,11 @@ pub mod flush_tests {
             }
         }
 
-        read_and_check(tsm_reader.as_ref().unwrap(), expected_tsm_data).await;
-        read_and_check(dlt_reader.as_ref().unwrap(), expected_delta_data).await;
+        read_and_check(tsm_reader.as_ref().unwrap(), expected_tsm_data)
+            .await
+            .unwrap();
+        read_and_check(dlt_reader.as_ref().unwrap(), expected_delta_data)
+            .await
+            .unwrap();
     }
 }

--- a/tskv/src/compaction/iterator.rs
+++ b/tskv/src/compaction/iterator.rs
@@ -1,0 +1,34 @@
+/// Wraps an iterator with `peek()` method that returns an optional reference
+/// to the next element.
+#[derive(Clone, Debug)]
+pub struct BufferedIterator<I: Iterator> {
+    iter: I,
+    /// Remember a peeked value, even if it was None.
+    peeked: Option<Option<I::Item>>,
+}
+
+impl<I: Iterator> BufferedIterator<I> {
+    pub fn new(iter: I) -> BufferedIterator<I> {
+        BufferedIterator { iter, peeked: None }
+    }
+
+    pub fn peek(&mut self) -> Option<&I::Item> {
+        let iter = &mut self.iter;
+        self.peeked.get_or_insert_with(|| iter.next()).as_ref()
+    }
+
+    pub fn peek_mut(&mut self) -> Option<&mut I::Item> {
+        let iter = &mut self.iter;
+        self.peeked.get_or_insert_with(|| iter.next()).as_mut()
+    }
+
+    pub fn next(&mut self) -> Option<&I::Item> {
+        let iter = &mut self.iter;
+        self.peeked.insert(iter.next()).as_ref()
+    }
+
+    pub fn next_mut(&mut self) -> Option<&mut I::Item> {
+        let iter = &mut self.iter;
+        self.peeked.insert(iter.next()).as_mut()
+    }
+}

--- a/tskv/src/compaction/mod.rs
+++ b/tskv/src/compaction/mod.rs
@@ -1,6 +1,7 @@
 pub mod check;
 mod compact;
 mod flush;
+mod iterator;
 pub mod job;
 mod picker;
 

--- a/tskv/src/compaction/picker.rs
+++ b/tskv/src/compaction/picker.rs
@@ -421,6 +421,7 @@ mod test {
     use tokio::sync::mpsc;
 
     use crate::compaction::test::create_options;
+    use crate::compaction::{LevelCompactionPicker, Picker};
     use crate::{
         file_utils::make_tsm_file_name,
         kv_option::{Options, StorageOptions},
@@ -544,8 +545,10 @@ mod test {
             ]), // 0.00001
         ];
 
+        let storage_opt = opt.storage.clone();
         let tsf = create_tseries_family(Arc::new("dba".to_string()), opt, levels_sketch);
-        let compact_req = tsf.pick_compaction().unwrap();
+        let picker = LevelCompactionPicker::new(storage_opt);
+        let compact_req = picker.pick_compaction(tsf.version()).unwrap();
         assert_eq!(compact_req.out_level, 2);
         assert_eq!(compact_req.files.len(), 2);
     }

--- a/tskv/src/tsm/mod.rs
+++ b/tskv/src/tsm/mod.rs
@@ -22,9 +22,6 @@ const BLOOM_FILTER_SIZE: usize = 64;
 const BLOOM_FILTER_BITS: u64 = 512; // 64 * 8
 const FOOTER_SIZE: usize = BLOOM_FILTER_SIZE + 8; // 72
 
-#[derive(Debug, Snafu)]
-pub enum TsmError {}
-
 pub trait BlockReader {
     fn decode(&mut self, block: &BlockMeta) -> crate::error::Result<DataBlock>;
 }

--- a/tskv/src/tsm/reader.rs
+++ b/tskv/src/tsm/reader.rs
@@ -512,6 +512,10 @@ impl TsmReader {
         self.tombstone.read().get_cloned_time_ranges(field_id)
     }
 
+    pub(crate) fn tsm_id(&self) -> u64 {
+        self.tsm_id
+    }
+
     pub(crate) fn bloom_filter(&self) -> Arc<BloomFilter> {
         self.index_reader.index_ref.bloom_filter()
     }

--- a/tskv/src/tsm/writer.rs
+++ b/tskv/src/tsm/writer.rs
@@ -479,19 +479,24 @@ async fn write_footer_to(
 }
 
 #[cfg(test)]
-mod test {
+pub mod tsm_writer_tests {
     use std::{
         collections::HashMap,
+        io::{Error as IoError, ErrorKind as IoErrorKind},
         path::{Path, PathBuf},
         sync::Arc,
     };
 
     use models::{FieldId, ValueType};
+    use snafu::ResultExt;
 
-    use crate::file_system::file_manager::{self, get_file_manager, FileManager};
-    use crate::file_system::IFile;
     use crate::{
+        error::{self, Error, Result},
+        file_system::file_manager::{self, get_file_manager, FileManager},
+        file_system::IFile,
+        file_utils::{self, make_tsm_file_name},
         memcache::FieldVal,
+        tsm::tsm_reader_tests::read_and_check,
         tsm::{
             codec::DataBlockEncoding, new_tsm_writer, ColumnReader, DataBlock, IndexReader,
             TsmReader, TsmWriter,
@@ -500,67 +505,42 @@ mod test {
 
     const TEST_PATH: &str = "/tmp/test/tsm_writer";
 
-    async fn write_to_tsm(
-        dir: impl AsRef<Path>,
-        file_name: &str,
+    pub async fn write_to_tsm(
+        path: impl AsRef<Path>,
         data: &HashMap<FieldId, Vec<DataBlock>>,
-    ) {
+    ) -> Result<()> {
+        let tsm_seq = file_utils::get_tsm_file_id_by_path(&path)?;
+        let path = path.as_ref();
+        let dir = path.parent().unwrap();
         if !file_manager::try_exists(&dir) {
-            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::create_dir_all(&dir).context(super::IOSnafu)?;
         }
-        let tsm_path = dir.as_ref().join(file_name);
-        let mut writer = TsmWriter::open(tsm_path, 0, false, 0).await.unwrap();
+        let mut writer = TsmWriter::open(path, tsm_seq, false, 0).await?;
         for (fid, blks) in data.iter() {
             for blk in blks.iter() {
-                writer.write_block(*fid, blk).await.unwrap();
+                writer
+                    .write_block(*fid, blk)
+                    .await
+                    .context(error::WriteTsmSnafu)?;
             }
         }
-        writer.write_index().await.unwrap();
-        writer.finish().await.unwrap();
-    }
-
-    async fn read_from_tsm(path: impl AsRef<Path>) -> HashMap<FieldId, Vec<DataBlock>> {
-        let file = Arc::new(file_manager::open_file(&path).await.unwrap());
-        let len = file.len();
-
-        let index = IndexReader::open(0, file.clone()).await.unwrap();
-        let mut data: HashMap<FieldId, Vec<DataBlock>> = HashMap::new();
-        for idx_meta in index.iter() {
-            let mut cr = ColumnReader::new(file.clone(), idx_meta.block_iterator());
-            loop {
-                match cr.next().await {
-                    None => break,
-                    Some(blk_ret) => {
-                        let blk = blk_ret.unwrap();
-                        data.entry(idx_meta.field_id())
-                            .or_insert_with(Vec::new)
-                            .push(blk);
-                    }
-                }
-            }
-        }
-        data
-    }
-
-    async fn check_tsm(path: impl AsRef<Path>, data: &HashMap<FieldId, Vec<DataBlock>>) {
-        let tsm_data = read_from_tsm(path).await;
-        for (k, v) in tsm_data.iter() {
-            assert_eq!(v, data.get(k).unwrap());
-        }
+        writer.write_index().await.context(error::WriteTsmSnafu)?;
+        writer.finish().await.context(error::WriteTsmSnafu)
     }
 
     #[tokio::test]
     async fn test_tsm_write_fast() {
-        let dir = Path::new(TEST_PATH);
         #[rustfmt::skip]
         let data: HashMap<FieldId, Vec<DataBlock>> = HashMap::from([
             (1, vec![DataBlock::U64 { ts: vec![2, 3, 4], val: vec![12, 13, 15], enc: DataBlockEncoding::default() }]),
             (2, vec![DataBlock::U64 { ts: vec![2, 3, 4], val: vec![101, 102, 103], enc: DataBlockEncoding::default() }]),
         ]);
 
-        let file_name = "_000001.tsm";
-        write_to_tsm(dir, file_name, &data).await;
-        check_tsm(dir.join(file_name), &data).await;
+        let tsm_file = make_tsm_file_name(TEST_PATH, 0);
+        write_to_tsm(&tsm_file, &data).await.unwrap();
+
+        let reader = TsmReader::open(tsm_file).await.unwrap();
+        read_and_check(&reader, data).await.unwrap();
     }
 
     #[tokio::test]
@@ -586,9 +566,10 @@ mod test {
             ]),
         ]);
 
-        let dir = Path::new(TEST_PATH).join("1");
-        let file_name = "_000001.tsm";
-        write_to_tsm(&dir, file_name, &data).await;
-        check_tsm(dir.join(file_name), &data).await;
+        let tsm_file = make_tsm_file_name(TEST_PATH, 1);
+        write_to_tsm(&tsm_file, &data).await.unwrap();
+
+        let reader = TsmReader::open(tsm_file).await.unwrap();
+        read_and_check(&reader, data).await.unwrap();
     }
 }

--- a/tskv/src/wal.rs
+++ b/tskv/src/wal.rs
@@ -199,7 +199,7 @@ impl WalWriter {
         id: TseriesFamilyId,
         tenant: Arc<Vec<u8>>,
     ) -> Result<(u64, usize)> {
-        let mut seq = self.max_sequence;
+        let seq = self.max_sequence;
         let tenant_len = tenant.len() as u64;
 
         let written_size = self
@@ -218,7 +218,6 @@ impl WalWriter {
                 .as_slice(),
             )
             .await?;
-        seq += 1;
 
         if self.config.sync {
             self.inner.sync().await?;
@@ -230,6 +229,10 @@ impl WalWriter {
     }
 
     pub async fn close(mut self) -> Result<()> {
+        info!(
+            "Closing wal with sequence: [{}, {})",
+            self.min_sequence, self.max_sequence
+        );
         let footer = build_footer(self.min_sequence, self.max_sequence);
         self.inner.write_footer(footer).await?;
         self.inner.close().await


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

## Compaction

There is a bug in compaction when input data is like this:

```
File#1: { FieldId: 1, Ts: [1, 2, ..., 900] }, { FieldId: 2, ...}
File#2: { FieldId: 0, ... }, { FieldId: 1, Ts: [901, 902, ..., 1100], {FieldId: 2, ...} }
```

Unfortunately, when File#2 has a field FieldId(0) before FieldId(1) which is the next merging field id group (by current incorrect logic, the correct next merging field id should be FieldId(0) ), compaction logic generated unexpected result when group FieldIds from File#1 and File#2.

Now incorrectly generated data is like this:

```
...
============================================================
Offset: 824538 | Field | FieldId: 1, FieldType: Float, BlockCount: 4, MinTime: 1  MaxTime: 1100  PointsCount: 2200
------------------------------------------------------------
  Block | FieldId: 1, MinTime: 1, MaxTime: 1000,  Count: 1000, Offset: 78, Size: 60, ValOffset: 100
  Block | FieldId: 1, MinTime: 1000, MaxTime: 1100, Count: 100, Offset: 233, Size: 60, ValOffset: 250
  Block | FieldId: 1, MinTime: 1, MaxTime: 1000 Count: 1000, Offset: 1078, Size: 60 ValOffset: 1100
  Block | FieldId: 1, MinTime: 1000, MaxTime: 1100, Count: 100, Offset: 1233, Size: 60, ValOffset: 1250
============================================================
...
```

The correct data will be like this:

```
...
============================================================
Offset: 824538 | Field | FieldId: 1, FieldType: Float, BlockCount: 4, MinTime: 1  MaxTime: 1100  PointsCount: 2200
------------------------------------------------------------
  Block | FieldId: 1, MinTime: 1  MaxTime: 1000,  Count: 1000, Offset: 78, Size: 60, ValOffset: 100
  Block | FieldId: 1, MinTime: 1000, MaxTime: 1100, Count: 100, Offset: 233, Size: 60, ValOffset: 250
============================================================
...
```

## Compaction_2

Some changes about performance.

## WAL

WAL write returned (`seq`+1), but we want `seq`.


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
