### PR TITLE
chore: Alter group_imports and imports_granularity in rustfmt.toml

### DIFF
--- a/client/src/command.rs
+++ b/client/src/command.rs
@@ -1,18 +1,20 @@
 //! Command within CLI
 
-use crate::ctx::{ResultSet, SessionContext};
-use crate::exec::connect_database;
-use crate::functions::{display_all_functions, Function};
-use crate::print_format::PrintFormat;
-use crate::print_options::PrintOptions;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Instant;
+
 use clap::ArgEnum;
 use datafusion::arrow::array::{ArrayRef, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result};
-use std::str::FromStr;
-use std::sync::Arc;
-use std::time::Instant;
+
+use crate::ctx::{ResultSet, SessionContext};
+use crate::exec::connect_database;
+use crate::functions::{display_all_functions, Function};
+use crate::print_format::PrintFormat;
+use crate::print_options::PrintOptions;
 
 /// Command
 #[derive(Debug)]

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -1,9 +1,10 @@
 //! Cnosdb Configuration Options
 
-use datafusion::arrow::datatypes::DataType;
-use datafusion::scalar::ScalarValue;
 use std::collections::HashMap;
 use std::env;
+
+use datafusion::arrow::datatypes::DataType;
+use datafusion::scalar::ScalarValue;
 
 pub const TARGET_PARTITIONS: &str = "target_partitions";
 

--- a/client/src/ctx.rs
+++ b/client/src/ctx.rs
@@ -1,10 +1,11 @@
 use datafusion::arrow::record_batch::RecordBatch;
-
 use http_protocol::header::ACCEPT;
+use http_protocol::http_client::HttpClient;
 use http_protocol::parameter::{SqlParam, WriteParam};
-use http_protocol::{http_client::HttpClient, status_code::OK};
+use http_protocol::status_code::OK;
 
-use crate::{config::ConfigOptions, print_format::PrintFormat};
+use crate::config::ConfigOptions;
+use crate::print_format::PrintFormat;
 
 pub const DEFAULT_USER: &str = "cnosdb";
 pub const DEFAULT_PASSWORD: &str = "";

--- a/client/src/exec.rs
+++ b/client/src/exec.rs
@@ -1,17 +1,17 @@
 //! Execution functions
 
-use crate::{
-    command::{Command, OutputFormat},
-    ctx::SessionContext,
-    helper::CliHelper,
-    print_options::PrintOptions,
-};
-use rustyline::error::ReadlineError;
-use rustyline::Editor;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
 use std::time::Instant;
+
+use rustyline::error::ReadlineError;
+use rustyline::Editor;
+
+use crate::command::{Command, OutputFormat};
+use crate::ctx::SessionContext;
+use crate::helper::CliHelper;
+use crate::print_options::PrintOptions;
 
 /// run and execute SQL statements and commands from a file, against a context with the given print options
 pub async fn exec_from_lines(

--- a/client/src/functions.rs
+++ b/client/src/functions.rs
@@ -1,11 +1,12 @@
 //! Functions that are query-able and searchable via the `\h` command
+use std::fmt;
+use std::str::FromStr;
+use std::sync::Arc;
+
 use datafusion::arrow::array::StringArray;
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::arrow::util::pretty::pretty_format_batches;
-use std::fmt;
-use std::str::FromStr;
-use std::sync::Arc;
 
 #[derive(Debug)]
 pub enum Function {

--- a/client/src/helper.rs
+++ b/client/src/helper.rs
@@ -2,18 +2,12 @@
 //! and auto-completion for file name during creating external table.
 
 use datafusion::sql::parser::{DFParser, Statement};
-use rustyline::completion::Completer;
-use rustyline::completion::FilenameCompleter;
-use rustyline::completion::Pair;
+use rustyline::completion::{Completer, FilenameCompleter, Pair};
 use rustyline::error::ReadlineError;
 use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
-use rustyline::validate::ValidationContext;
-use rustyline::validate::ValidationResult;
-use rustyline::validate::Validator;
-use rustyline::Context;
-use rustyline::Helper;
-use rustyline::Result;
+use rustyline::validate::{ValidationContext, ValidationResult, Validator};
+use rustyline::{Context, Helper, Result};
 
 #[derive(Default)]
 pub struct CliHelper {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,10 +1,13 @@
-use clap::Parser;
-use client::ctx::{SessionConfig, SessionContext};
-use client::{exec, print_format::PrintFormat, print_options::PrintOptions, CNOSDB_CLI_VERSION};
-use datafusion::error::Result;
 use std::env;
 use std::net::IpAddr;
 use std::path::Path;
+
+use clap::Parser;
+use client::ctx::{SessionConfig, SessionContext};
+use client::print_format::PrintFormat;
+use client::print_options::PrintOptions;
+use client::{exec, CNOSDB_CLI_VERSION};
+use datafusion::error::Result;
 
 #[derive(Debug, Parser, PartialEq)]
 #[clap(author, version, about, long_about= None)]

--- a/client/src/print_format.rs
+++ b/client/src/print_format.rs
@@ -1,4 +1,6 @@
 //! Print format variants
+use std::str::FromStr;
+
 use datafusion::arrow::csv::writer::WriterBuilder;
 use datafusion::arrow::json::{ArrayWriter, LineDelimitedWriter};
 use datafusion::arrow::record_batch::RecordBatch;
@@ -7,7 +9,6 @@ use datafusion::error::{DataFusionError, Result};
 use http_protocol::header::{
     APPLICATION_CSV, APPLICATION_JSON, APPLICATION_NDJSON, APPLICATION_TABLE, APPLICATION_TSV,
 };
-use std::str::FromStr;
 
 /// Allow records to be printed in different formats
 #[derive(Debug, PartialEq, Eq, clap::ArgEnum, Clone, Copy)]
@@ -83,11 +84,13 @@ impl PrintFormat {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::sync::Arc;
+
     use datafusion::arrow::array::Int32Array;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::from_slice::FromSlice;
-    use std::sync::Arc;
+
+    use super::*;
 
     #[test]
     fn test_print_batches_with_sep() {

--- a/client/src/print_options.rs
+++ b/client/src/print_options.rs
@@ -1,6 +1,7 @@
+use std::time::Instant;
+
 use crate::ctx::ResultSet;
 use crate::print_format::PrintFormat;
-use std::time::Instant;
 
 #[derive(Debug, Clone)]
 pub struct PrintOptions {

--- a/common/error_code/error_code_macro/src/lib.rs
+++ b/common/error_code/error_code_macro/src/lib.rs
@@ -3,12 +3,10 @@ mod parse;
 extern crate core;
 
 use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens};
+use syn::{Data, Fields, LitStr};
 
 use crate::parse::{parse_error_code_enum, EnumInfo, FieldContainer};
-use quote::quote;
-use quote::ToTokens;
-use syn::Fields;
-use syn::{Data, LitStr};
 
 type MultiSynResult<T> = std::result::Result<T, Vec<syn::Error>>;
 

--- a/common/error_code/error_code_macro/src/parse.rs
+++ b/common/error_code/error_code_macro/src/parse.rs
@@ -1,10 +1,12 @@
-use crate::{default_mode_code, MultiSynResult};
-use proc_macro2::Span;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
+
+use proc_macro2::Span;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{custom_keyword, token, Attribute, Field, Fields, LitInt, LitStr};
+
+use crate::{default_mode_code, MultiSynResult};
 
 #[derive(Clone)]
 pub struct Code {

--- a/common/error_code/src/lib.rs
+++ b/common/error_code/src/lib.rs
@@ -1,7 +1,8 @@
 mod test;
 
-pub use error_code_macro::ErrorCoder;
 use std::fmt::{Debug, Display, Formatter};
+
+pub use error_code_macro::ErrorCoder;
 
 pub trait ErrorCode: std::error::Error {
     /// mod_code 2 , variant code 4, e.g. 010001

--- a/common/error_code/src/test.rs
+++ b/common/error_code/src/test.rs
@@ -1,6 +1,6 @@
-use crate::ErrorCode;
-use crate::ErrorCoder;
 use snafu::Snafu;
+
+use crate::{ErrorCode, ErrorCoder};
 
 #[derive(ErrorCoder, Snafu, Debug)]
 #[error_code(mod_code = "00")]

--- a/common/http_protocol/src/response.rs
+++ b/common/http_protocol/src/response.rs
@@ -1,7 +1,6 @@
-use serde::{Deserialize, Serialize};
-
 use models::error_code::ErrorCode;
 pub use reqwest::Response;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize)]
 pub struct EmptyResponse {}

--- a/common/license/src/lib.rs
+++ b/common/license/src/lib.rs
@@ -2,10 +2,13 @@
 
 mod rsa_aes;
 
-use rsa::{pkcs1, pkcs1v15, pkcs8::der::Encode};
+use std::ops::Index;
+use std::{fs, io, os};
+
+use rsa::pkcs8::der::Encode;
+use rsa::{pkcs1, pkcs1v15};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-use std::{fs, io, ops::Index, os};
 
 const AES_IV: &str = "HdeK5LOtDhdjh*9G";
 const AES_KEY: &str = "Co7f#ki&Y@xK!OLPOwiaAWP&(Jn9dfje";

--- a/common/license/src/rsa_aes.rs
+++ b/common/license/src/rsa_aes.rs
@@ -1,25 +1,22 @@
 #![allow(dead_code, unused_imports, unused_variables)]
 
-use crypto::{
-    aes,
-    aes::KeySize::KeySize256,
-    blockmodes::PkcsPadding,
-    buffer::{
-        BufferResult::BufferUnderflow, ReadBuffer, RefReadBuffer, RefWriteBuffer, WriteBuffer,
-    },
-    digest::Digest,
-    md5::Md5,
-    symmetriccipher::SymmetricCipherError,
-};
-use rand::{rngs::OsRng, RngCore};
+use std::fs;
+
+use crypto::aes;
+use crypto::aes::KeySize::KeySize256;
+use crypto::blockmodes::PkcsPadding;
+use crypto::buffer::BufferResult::BufferUnderflow;
+use crypto::buffer::{ReadBuffer, RefReadBuffer, RefWriteBuffer, WriteBuffer};
+use crypto::digest::Digest;
+use crypto::md5::Md5;
+use crypto::symmetriccipher::SymmetricCipherError;
+use rand::rngs::OsRng;
+use rand::RngCore;
+use rsa::pkcs1::{DecodeRsaPublicKey, EncodeRsaPrivateKey, EncodeRsaPublicKey};
+use rsa::pkcs8::LineEnding;
+use rsa::{PaddingScheme, PublicKey, RsaPrivateKey, RsaPublicKey};
 
 use crate::LicenseResult;
-use rsa::{
-    pkcs1::{DecodeRsaPublicKey, EncodeRsaPrivateKey, EncodeRsaPublicKey},
-    pkcs8::LineEnding,
-    PaddingScheme, PublicKey, RsaPrivateKey, RsaPublicKey,
-};
-use std::fs;
 
 pub const PUBLIC_RSA_FILENAME: &str = "public.rsa";
 pub const PRIVATE_RSA_FILENAME: &str = "private.rsa";
@@ -167,8 +164,10 @@ impl RsaAes {
 }
 
 mod test {
+    use rand::rngs::OsRng;
+    use rand::RngCore;
+
     use crate::rsa_aes::RsaAes;
-    use rand::{rngs::OsRng, RngCore};
 
     #[test]
     fn test_aes256() {

--- a/common/line_protocol/src/parser.rs
+++ b/common/line_protocol/src/parser.rs
@@ -1,6 +1,8 @@
-use crate::{Error, Result};
 use std::cmp::Ordering;
+
 use utils::BkdrHasher;
+
+use crate::{Error, Result};
 
 pub struct Parser {
     default_time: i64,
@@ -492,7 +494,8 @@ fn next_timestamp(buf: &str) -> Option<(&str, usize)> {
 
 #[cfg(test)]
 mod test {
-    use std::{fs::File, io::Read};
+    use std::fs::File;
+    use std::io::Read;
 
     use crate::parser::{
         next_field_set, next_measurement, next_tag_set, next_timestamp, FieldValue, Line, Parser,

--- a/common/lru_cache/src/lib.rs
+++ b/common/lru_cache/src/lib.rs
@@ -1,12 +1,10 @@
-use std::{
-    borrow::Borrow,
-    collections::HashMap,
-    fmt::{Debug, Display},
-    hash::{Hash, Hasher},
-    mem::{self, MaybeUninit},
-    ptr::{self, NonNull},
-    sync::Arc,
-};
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::fmt::{Debug, Display};
+use std::hash::{Hash, Hasher};
+use std::mem::{self, MaybeUninit};
+use std::ptr::{self, NonNull};
+use std::sync::Arc;
 
 use parking_lot::Mutex;
 use utils::BkdrHasher;

--- a/common/mem_allocator/src/lib.rs
+++ b/common/mem_allocator/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate core;
 use core::alloc::{GlobalAlloc, Layout};
+
 use libc::{c_int, c_void};
 use tikv_jemalloc_sys as ffi;
 
@@ -99,8 +100,9 @@ unsafe impl GlobalAlloc for Jemalloc {
 
 #[cfg(test)]
 mod tests {
-    use crate::Jemalloc;
     use chrono::Utc;
+
+    use crate::Jemalloc;
     #[global_allocator]
     static A: Jemalloc = Jemalloc;
     #[test]

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -1,9 +1,10 @@
+use std::ops::Not;
+
 use once_cell::sync::Lazy;
 use prometheus::{
-    default_registry, gather, register_histogram_vec, register_int_counter_vec, IntCounterVec,
+    default_registry, gather, linear_buckets, register_histogram_vec, register_int_counter_vec,
+    HistogramOpts, HistogramVec, IntCounter, IntCounterVec, Opts,
 };
-use prometheus::{linear_buckets, HistogramOpts, HistogramVec, IntCounter, Opts};
-use std::ops::Not;
 use trace::error;
 
 pub const NAMESPACE: &str = "cnosdb";

--- a/common/models/src/arrow_array.rs
+++ b/common/models/src/arrow_array.rs
@@ -1,14 +1,13 @@
-use crate::Error;
 use arrow_schema::Field;
-use datafusion::arrow::{
-    array::{
-        ArrayBuilder, BooleanBuilder, Float64Builder, Int64Builder, StringBuilder,
-        TimestampMicrosecondBuilder, TimestampMillisecondBuilder, TimestampNanosecondBuilder,
-        TimestampSecondBuilder, UInt64Builder,
-    },
-    datatypes::{DataType, SchemaRef, TimeUnit},
-    error::ArrowError,
+use datafusion::arrow::array::{
+    ArrayBuilder, BooleanBuilder, Float64Builder, Int64Builder, StringBuilder,
+    TimestampMicrosecondBuilder, TimestampMillisecondBuilder, TimestampNanosecondBuilder,
+    TimestampSecondBuilder, UInt64Builder,
 };
+use datafusion::arrow::datatypes::{DataType, SchemaRef, TimeUnit};
+use datafusion::arrow::error::ArrowError;
+
+use crate::Error;
 
 pub trait WriteArrow {
     fn write(self, builder: &mut Box<dyn ArrayBuilder>) -> Result<(), ArrowError>;

--- a/common/models/src/auth/mod.rs
+++ b/common/models/src/auth/mod.rs
@@ -1,7 +1,7 @@
-use crate::auth::privilege::DatabasePrivilege;
 use openssl::error::ErrorStack;
 use snafu::Snafu;
 
+use crate::auth::privilege::DatabasePrivilege;
 use crate::define_result;
 
 pub mod privilege;

--- a/common/models/src/auth/privilege.rs
+++ b/common/models/src/auth/privilege.rs
@@ -1,4 +1,5 @@
-use std::{fmt::Display, hash::Hash};
+use std::fmt::Display;
+use std::hash::Hash;
 
 use serde::{Deserialize, Serialize};
 

--- a/common/models/src/auth/role.rs
+++ b/common/models/src/auth/role.rs
@@ -1,19 +1,14 @@
-use std::{
-    collections::{HashMap, HashSet},
-    hash::Hash,
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+use std::sync::Arc;
 
-use crate::auth::AuthError;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 
+use super::privilege::{DatabasePrivilege, GlobalPrivilege, Privilege, TenantObjectPrivilege};
+use super::Result;
+use crate::auth::AuthError;
 use crate::oid::{Id, Identifier};
-
-use super::{
-    privilege::{DatabasePrivilege, GlobalPrivilege, Privilege, TenantObjectPrivilege},
-    Result,
-};
 
 pub enum UserRole<T> {
     // 拥有对整个数据库实例的最高级权限

--- a/common/models/src/auth/user.rs
+++ b/common/models/src/auth/user.rs
@@ -1,14 +1,12 @@
-use std::{collections::HashSet, fmt::Display};
+use std::collections::HashSet;
+use std::fmt::Display;
 
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
+use super::privilege::{DatabasePrivilege, Privilege, PrivilegeChecker, TenantObjectPrivilege};
+use super::{rsa_utils, AuthError, Result};
 use crate::oid::{Identifier, Oid};
-
-use super::{
-    privilege::{DatabasePrivilege, Privilege, PrivilegeChecker, TenantObjectPrivilege},
-    rsa_utils, AuthError, Result,
-};
 
 pub const ROOT: &str = "root";
 pub const ROOT_PWD: &str = "";

--- a/common/models/src/codec.rs
+++ b/common/models/src/codec.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
 
 pub const BIGINT_CODEC: [Encoding; 4] = [
     Encoding::Default,

--- a/common/models/src/errors.rs
+++ b/common/models/src/errors.rs
@@ -1,5 +1,7 @@
+use std::fmt::Debug;
+use std::io;
+
 use snafu::Snafu;
-use std::{fmt::Debug, io};
 
 #[macro_export]
 macro_rules! define_result {

--- a/common/models/src/field_info.rs
+++ b/common/models/src/field_info.rs
@@ -1,11 +1,10 @@
-use protos::models as fb_models;
-use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
-use crate::{
-    errors::{Error, Result},
-    FieldId, FieldName, Tag,
-};
+use protos::models as fb_models;
+use serde::{Deserialize, Serialize};
+
+use crate::errors::{Error, Result};
+use crate::{FieldId, FieldName, Tag};
 
 const FIELD_NAME_MAX_LEN: usize = 512;
 

--- a/common/models/src/lib.rs
+++ b/common/models/src/lib.rs
@@ -17,13 +17,12 @@ pub mod limiter;
 pub mod object_reference;
 pub mod oid;
 pub mod predicate;
-pub use error_code;
-
-use parking_lot::RwLock;
 use std::sync::Arc;
 
+pub use error_code;
 pub use errors::{Error, Result};
 pub use field_info::{FieldInfo, ValueType};
+use parking_lot::RwLock;
 pub use points::*;
 pub use series_info::SeriesKey;
 pub use tag::Tag;

--- a/common/models/src/limiter.rs
+++ b/common/models/src/limiter.rs
@@ -1,11 +1,12 @@
+use std::fmt::Formatter;
+use std::ops::Deref;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use chrono::{DateTime, Utc};
 use parking_lot::Mutex;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt::Formatter;
-use std::ops::Deref;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[derive(Debug)]
 pub struct RateLimiter {

--- a/common/models/src/oid.rs
+++ b/common/models/src/oid.rs
@@ -1,4 +1,5 @@
-use std::{fmt::Display, hash::Hash};
+use std::fmt::Display;
+use std::hash::Hash;
 
 use uuid::Uuid;
 

--- a/common/models/src/predicate/domain.rs
+++ b/common/models/src/predicate/domain.rs
@@ -1,24 +1,22 @@
-use std::{
-    cmp::{self, Ordering},
-    collections::{BTreeMap, HashMap, HashSet},
-    hash::Hash,
-    io::{BufReader, Read},
-    ops::RangeBounds,
-    sync::Arc,
-};
+use std::cmp::{self, Ordering};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::hash::Hash;
+use std::io::{BufReader, Read};
+use std::ops::RangeBounds;
+use std::sync::Arc;
 
-use crate::schema::TskvTableSchema;
-use crate::{Error, Result};
 use arrow_schema::{Schema, SchemaRef};
-use datafusion::{
-    arrow::datatypes::DataType, logical_expr::Expr, optimizer::utils::conjunction, prelude::Column,
-    scalar::ScalarValue,
-};
-
+use datafusion::arrow::datatypes::DataType;
+use datafusion::logical_expr::Expr;
+use datafusion::optimizer::utils::conjunction;
+use datafusion::prelude::Column;
+use datafusion::scalar::ScalarValue;
 use datafusion_proto::bytes::Serializeable;
 use serde::{Deserialize, Serialize};
 
 use super::transformation::RowExpressionToDomainsVisitor;
+use crate::schema::TskvTableSchema;
+use crate::{Error, Result};
 
 pub type PredicateRef = Arc<Predicate>;
 
@@ -1082,8 +1080,9 @@ mod tests {
 
     #[test]
     fn test_shchema_encode_decode() {
-        use arrow_schema::*;
         use std::collections::HashMap;
+
+        use arrow_schema::*;
 
         let field_a = Field::new("a", DataType::Int64, false);
         let field_b = Field::new("b", DataType::Boolean, false);

--- a/common/models/src/predicate/transformation.rs
+++ b/common/models/src/predicate/transformation.rs
@@ -1,15 +1,12 @@
-use std::{collections::VecDeque, result};
+use std::collections::VecDeque;
+use std::result;
 
-use datafusion::{
-    arrow::datatypes::DataType,
-    error::DataFusionError,
-    logical_expr::{
-        expr_visitor::{ExprVisitable, ExpressionVisitor, Recursion},
-        BinaryExpr, Operator,
-    },
-    prelude::{Column, Expr},
-    scalar::ScalarValue,
-};
+use datafusion::arrow::datatypes::DataType;
+use datafusion::error::DataFusionError;
+use datafusion::logical_expr::expr_visitor::{ExprVisitable, ExpressionVisitor, Recursion};
+use datafusion::logical_expr::{BinaryExpr, Operator};
+use datafusion::prelude::{Column, Expr};
+use datafusion::scalar::ScalarValue;
 
 use super::domain::{ColumnDomains, Domain, Range};
 
@@ -328,13 +325,12 @@ impl RowExpressionToDomainsVisitor<'_> {
 mod tests {
     use std::ops::Add;
 
-    use super::*;
     use chrono::{Duration, NaiveDate};
+    use datafusion::logical_expr::expr_fn::col;
+    use datafusion::logical_expr::{binary_expr, Like};
+    use datafusion::prelude::{and, in_list, lit, or, random};
 
-    use datafusion::{
-        logical_expr::{binary_expr, expr_fn::col, Like},
-        prelude::{and, in_list, lit, or, random},
-    };
+    use super::*;
 
     /// resolves the domain of the specified expression
     fn get_domains(expr: &Expr) -> Result<ColumnDomains<Column>> {

--- a/common/models/src/schema.rs
+++ b/common/models/src/schema.rs
@@ -9,14 +9,9 @@
 
 use std::collections::HashMap;
 use std::fmt::{self, Display};
-use std::sync::Arc;
-
 use std::mem::size_of_val;
 use std::str::FromStr;
-
-use datafusion::logical_expr::TableSource;
-use derive_builder::Builder;
-use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use arrow_schema::DataType;
 use datafusion::arrow::datatypes::{
@@ -30,6 +25,9 @@ use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::file_format::FileFormat;
 use datafusion::datasource::listing::ListingOptions;
 use datafusion::error::Result as DataFusionResult;
+use datafusion::logical_expr::TableSource;
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
 
 use crate::codec::Encoding;
 pub use crate::limiter::LimiterConfig;

--- a/common/models/src/series_info.rs
+++ b/common/models/src/series_info.rs
@@ -1,11 +1,10 @@
-use crate::Error::InvalidFlatbufferMessage;
-use crate::{
-    errors::{Error, Result},
-    tag, SeriesId, Tag, TagValue,
-};
 use protos::models as fb_models;
 use serde::{Deserialize, Serialize};
 use utils::BkdrHasher;
+
+use crate::errors::{Error, Result};
+use crate::Error::InvalidFlatbufferMessage;
+use crate::{tag, SeriesId, Tag, TagValue};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SeriesKey {

--- a/common/models/src/tag.rs
+++ b/common/models/src/tag.rs
@@ -1,13 +1,12 @@
-use std::{cmp::Ordering, hash::Hash};
+use std::cmp::Ordering;
+use std::hash::Hash;
 
 use protos::models as fb_models;
 use serde::{Deserialize, Serialize};
 use utils::BkdrHasher;
 
-use crate::{
-    errors::{Error, Result},
-    TagKey, TagValue,
-};
+use crate::errors::{Error, Result};
+use crate::{TagKey, TagValue};
 
 const TAG_KEY_MAX_LEN: usize = 512;
 const TAG_VALUE_MAX_LEN: usize = 4096;

--- a/common/models/src/utils.rs
+++ b/common/models/src/utils.rs
@@ -1,7 +1,5 @@
-use std::{
-    sync::atomic::AtomicU64,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::sync::atomic::AtomicU64;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const LOW_32BIT_MASK: u64 = (0x01 << 32) - 1;
 const HIGH_32BIT_MASK: u64 = ((0x01 << 32) - 1) << 32;

--- a/common/trace/src/lib.rs
+++ b/common/trace/src/lib.rs
@@ -2,11 +2,13 @@ use std::sync::{Arc, Mutex, Once};
 
 use once_cell::sync::Lazy;
 pub use tracing::{debug, error, info, instrument, trace, warn};
-use tracing_appender::{non_blocking, non_blocking::WorkerGuard, rolling};
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::{non_blocking, rolling};
 use tracing_error::ErrorLayer;
-use tracing_subscriber::{
-    filter::EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt, Registry,
-};
+use tracing_subscriber::filter::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{fmt, Registry};
 
 /// only use for unit test
 /// parameter only use for first call

--- a/common/utils/src/dedup.rs
+++ b/common/utils/src/dedup.rs
@@ -1,4 +1,5 @@
-use std::{fmt::Debug, mem, ptr};
+use std::fmt::Debug;
+use std::{mem, ptr};
 
 /// Removes all but the last of consecutive elements in the vector that resolve to the same
 /// key.

--- a/config/src/duration.rs
+++ b/config/src/duration.rs
@@ -1,4 +1,5 @@
-use std::{error::Error, time::Duration};
+use std::error::Error;
+use std::time::Duration;
 
 use serde::{Deserialize, Deserializer, Serializer};
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1,7 +1,10 @@
 mod bytes_num;
 mod duration;
 
-use std::{fs::File, io::prelude::Read, path::Path, time::Duration};
+use std::fs::File;
+use std::io::prelude::Read;
+use std::path::Path;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 

--- a/coordinator/src/command.rs
+++ b/coordinator/src/command.rs
@@ -1,26 +1,24 @@
 #![allow(clippy::large_enum_variant)]
 use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::ipc::{reader::StreamReader, writer::StreamWriter};
+use datafusion::arrow::ipc::reader::StreamReader;
+use datafusion::arrow::ipc::writer::StreamWriter;
+use datafusion::arrow::record_batch::RecordBatch;
+// use std::net::{TcpListener, TcpStream};
+use models::meta_data::VnodeId;
 use models::predicate::domain::{PredicateRef, QueryArgs, QueryExpr};
 use models::schema::{TableColumn, TskvTableSchema};
 use protos::kv_service::WritePointsRequest;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc::Sender as MpscSender;
 use tokio::sync::oneshot::Sender as OneShotSender;
-
-use datafusion::arrow::record_batch::RecordBatch;
-
-// use std::net::{TcpListener, TcpStream};
-use models::meta_data::VnodeId;
-use tokio::net::{TcpListener, TcpStream};
 use trace::info;
-use tskv::{byte_utils, iterator::QueryOption};
+use tskv::byte_utils;
+use tskv::iterator::QueryOption;
 
-use crate::errors::{
-    CoordinatorError::{self, *},
-    CoordinatorResult,
-};
+use crate::errors::CoordinatorError::{self, *};
+use crate::errors::CoordinatorResult;
 
 /* **************************************************************************************** */
 /* ************************* tcp service command ****************************************** */

--- a/coordinator/src/errors.rs
+++ b/coordinator/src/errors.rs
@@ -1,10 +1,12 @@
+use std::fmt::Debug;
+use std::io;
+
 use datafusion::arrow::error::ArrowError;
 use datafusion::error::DataFusionError;
 use flatbuffers::InvalidFlatbuffer;
 use meta::error::MetaError;
 use models::error_code::{ErrorCode, ErrorCoder};
 use snafu::Snafu;
-use std::{fmt::Debug, io};
 
 #[derive(Snafu, Debug, ErrorCoder)]
 #[snafu(visibility(pub))]

--- a/coordinator/src/file_info.rs
+++ b/coordinator/src/file_info.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
 
-use crypto::{digest::Digest, md5::Md5};
+use crypto::digest::Digest;
+use crypto::md5::Md5;
 use serde::{Deserialize, Serialize};
-use tokio::{fs::File, io::AsyncReadExt};
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
 
 use crate::errors::CoordinatorResult;
 

--- a/coordinator/src/hh_queue.rs
+++ b/coordinator/src/hh_queue.rs
@@ -1,20 +1,16 @@
-use std::{
-    collections::HashMap,
-    io::SeekFrom,
-    marker::PhantomData,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::collections::HashMap;
+use std::io::SeekFrom;
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use config::HintedOffConfig;
 use protos::models as fb_models;
 use snafu::prelude::*;
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::oneshot::{self, Sender};
 use tokio::sync::RwLock;
-use tokio::{
-    sync::mpsc::Receiver,
-    sync::oneshot::{self, Sender},
-    time::{self, Duration},
-};
+use tokio::time::{self, Duration};
 use trace::{debug, error, info, warn};
 use tskv::file_system::file_manager::{self, list_dir_names, FileManager};
 use tskv::file_system::{AsyncFile, FileCursor, IFile};
@@ -486,11 +482,11 @@ impl HintedOffReader {
 mod test {
     use std::sync::Arc;
 
-    use super::*;
-    use tokio::time::{self, Duration};
-
     use tokio::sync::RwLock;
+    use tokio::time::{self, Duration};
     use trace::init_default_global_tracing;
+
+    use super::*;
 
     async fn test_hinted_off_file() {
         init_default_global_tracing("tskv_log", "tskv.log", "debug");

--- a/coordinator/src/reader.rs
+++ b/coordinator/src/reader.rs
@@ -1,30 +1,24 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
+use std::sync::Arc;
 
-use datafusion::arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
 use futures::future::ok;
-use tokio::sync::mpsc::{self, Receiver, Sender};
-
 use meta::MetaRef;
-use models::{
-    meta_data::VnodeInfo,
-    predicate::domain::{PredicateRef, QueryArgs, QueryExpr},
-    schema::TskvTableSchema,
-    utils::now_timestamp,
-};
+use models::meta_data::VnodeInfo;
+use models::predicate::domain::{PredicateRef, QueryArgs, QueryExpr};
+use models::schema::TskvTableSchema;
+use models::utils::now_timestamp;
+use tokio::sync::mpsc::{self, Receiver, Sender};
 use trace::info;
-use tskv::{
-    engine::EngineRef,
-    iterator::{filter_to_time_ranges, QueryOption, RowIterator, TableScanMetrics},
-    TimeRange,
-};
+use tskv::engine::EngineRef;
+use tskv::iterator::{filter_to_time_ranges, QueryOption, RowIterator, TableScanMetrics};
+use tskv::TimeRange;
 
-use crate::{
-    command::{
-        recv_command, send_command, CoordinatorTcpCmd, QueryRecordBatchRequest,
-        FAILED_RESPONSE_CODE,
-    },
-    errors::{CoordinatorError, CoordinatorResult},
+use crate::command::{
+    recv_command, send_command, CoordinatorTcpCmd, QueryRecordBatchRequest, FAILED_RESPONSE_CODE,
 };
+use crate::errors::{CoordinatorError, CoordinatorResult};
 
 #[derive(Debug)]
 pub struct ReaderIterator {

--- a/coordinator/src/service.rs
+++ b/coordinator/src/service.rs
@@ -2,15 +2,9 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use config::{ClusterConfig, HintedOffConfig};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
-use snafu::ResultExt;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
-use tokio::sync::mpsc::{self, Receiver, Sender};
-use tokio::sync::oneshot;
-
-use config::{ClusterConfig, HintedOffConfig};
 use meta::meta_client_mock::{MockMetaClient, MockMetaManager};
 use meta::meta_manager::RemoteMetaManager;
 use meta::{MetaClientRef, MetaRef};
@@ -20,6 +14,11 @@ use models::predicate::domain::{ColumnDomains, PredicateRef};
 use models::schema::{DatabaseSchema, TableSchema, TskvTableSchema};
 use models::*;
 use protos::kv_service::WritePointsRequest;
+use snafu::ResultExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::sync::oneshot;
 use trace::info;
 use tskv::engine::{EngineRef, MockEngine};
 use tskv::iterator::QueryOption;

--- a/coordinator/src/writer.rs
+++ b/coordinator/src/writer.rs
@@ -1,34 +1,30 @@
-use std::collections::HashMap;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
 use async_channel as channel;
 use flatbuffers::FlatBufferBuilder;
 use futures::future::ok;
-use parking_lot::{RwLock, RwLockReadGuard};
-use snafu::ResultExt;
-use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc::Sender;
-use tokio::sync::oneshot;
-
-use meta::{MetaClientRef, MetaRef};
 //use std::net::{TcpListener, TcpStream};
 use meta::meta_manager::RemoteMetaManager;
+use meta::{MetaClientRef, MetaRef};
 use models::auth::user::{ROOT, ROOT_PWD};
 use models::meta_data::*;
 use models::utils::now_timestamp;
 use models::RwLockRef;
+use parking_lot::{RwLock, RwLockReadGuard};
 use protos::kv_service::{Meta, WritePointsRequest, WritePointsResponse};
 use protos::models as fb_models;
 use protos::models::{FieldBuilder, PointArgs, Points, PointsArgs, TagBuilder};
-use trace::debug;
-use trace::info;
+use snafu::ResultExt;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc::Sender;
+use tokio::sync::oneshot;
+use trace::{debug, info};
 use tskv::engine::EngineRef;
 
 use crate::command::*;
 use crate::errors::*;
-use crate::hh_queue::HintedOffManager;
-use crate::hh_queue::{HintedOffBlock, HintedOffWriteReq};
+use crate::hh_queue::{HintedOffBlock, HintedOffManager, HintedOffWriteReq};
 
 pub struct VnodePoints<'a> {
     db: String,

--- a/e2e_test/src/http_api_tests.rs
+++ b/e2e_test/src/http_api_tests.rs
@@ -1,11 +1,9 @@
 #[cfg(test)]
 mod test {
-    use http_protocol::{
-        header::{HeaderValue, ACCEPT, CONTENT_TYPE},
-        http_client::HttpClient,
-        response::Response,
-        status_code,
-    };
+    use http_protocol::header::{HeaderValue, ACCEPT, CONTENT_TYPE};
+    use http_protocol::http_client::HttpClient;
+    use http_protocol::response::Response;
+    use http_protocol::status_code;
 
     fn client() -> HttpClient {
         HttpClient::from_addr("127.0.0.1".to_string(), 31001)

--- a/e2e_test/src/kv_service_tests.rs
+++ b/e2e_test/src/kv_service_tests.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 mod test {
     use protos::kv_service::tskv_service_client::TskvServiceClient;
-    use protos::{self, kv_service::*, models::*, models_helper};
+    use protos::kv_service::*;
+    use protos::models::*;
+    use protos::{self, models_helper};
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
     use tonic::transport::{Certificate, Channel, ClientTlsConfig};

--- a/main/examples/flight_rpc_server.rs
+++ b/main/examples/flight_rpc_server.rs
@@ -1,14 +1,13 @@
 use std::pin::Pin;
 
+use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
+use arrow_flight::{
+    Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
+    HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
+};
 use futures::Stream;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
-
-use arrow_flight::{
-    flight_service_server::FlightService, flight_service_server::FlightServiceServer, Action,
-    ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo, HandshakeRequest,
-    HandshakeResponse, PutResult, SchemaResult, Ticket,
-};
 
 #[derive(Clone)]
 pub struct FlightServiceImpl {}

--- a/main/examples/flight_sql_server.rs
+++ b/main/examples/flight_sql_server.rs
@@ -1,23 +1,21 @@
-use arrow_flight::sql::{ActionCreatePreparedStatementResult, SqlInfo};
-use arrow_flight::{Action, FlightData, HandshakeRequest, HandshakeResponse, Ticket};
-use futures::Stream;
 use std::pin::Pin;
+
+use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
+use arrow_flight::sql::server::FlightSqlService;
+use arrow_flight::sql::{
+    ActionClosePreparedStatementRequest, ActionCreatePreparedStatementRequest,
+    ActionCreatePreparedStatementResult, CommandGetCatalogs, CommandGetCrossReference,
+    CommandGetDbSchemas, CommandGetExportedKeys, CommandGetImportedKeys, CommandGetPrimaryKeys,
+    CommandGetSqlInfo, CommandGetTableTypes, CommandGetTables, CommandPreparedStatementQuery,
+    CommandPreparedStatementUpdate, CommandStatementQuery, CommandStatementUpdate, SqlInfo,
+    TicketStatementQuery,
+};
+use arrow_flight::{
+    Action, FlightData, FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse, Ticket,
+};
+use futures::Stream;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
-
-use arrow_flight::{
-    flight_service_server::FlightService,
-    flight_service_server::FlightServiceServer,
-    sql::{
-        server::FlightSqlService, ActionClosePreparedStatementRequest,
-        ActionCreatePreparedStatementRequest, CommandGetCatalogs, CommandGetCrossReference,
-        CommandGetDbSchemas, CommandGetExportedKeys, CommandGetImportedKeys, CommandGetPrimaryKeys,
-        CommandGetSqlInfo, CommandGetTableTypes, CommandGetTables, CommandPreparedStatementQuery,
-        CommandPreparedStatementUpdate, CommandStatementQuery, CommandStatementUpdate,
-        TicketStatementQuery,
-    },
-    FlightDescriptor, FlightInfo,
-};
 
 #[derive(Clone)]
 pub struct FlightSqlServiceImpl {}

--- a/main/src/flight_sql/auth_middleware/basic_call_header_authenticator.rs
+++ b/main/src/flight_sql/auth_middleware/basic_call_header_authenticator.rs
@@ -1,11 +1,12 @@
 use http_protocol::header;
 use spi::server::dbms::DBMSRef;
-use tonic::{metadata::MetadataMap, Status};
+use tonic::metadata::MetadataMap;
+use tonic::Status;
 use trace::debug;
 
-use crate::{flight_sql::utils, http::header::Header};
-
 use super::{CallHeaderAuthenticator, CommonAuthResult};
+use crate::flight_sql::utils;
+use crate::http::header::Header;
 
 #[derive(Clone)]
 pub struct BasicCallHeaderAuthenticator {
@@ -54,9 +55,8 @@ mod test {
     use spi::server::dbms::DatabaseManagerSystemMock;
     use tonic::metadata::{AsciiMetadataValue, MetadataMap};
 
-    use crate::flight_sql::auth_middleware::{AuthResult, CallHeaderAuthenticator};
-
     use super::BasicCallHeaderAuthenticator;
+    use crate::flight_sql::auth_middleware::{AuthResult, CallHeaderAuthenticator};
 
     #[tokio::test]
     async fn test() {

--- a/main/src/flight_sql/auth_middleware/generated_bearer_token_authenticator.rs
+++ b/main/src/flight_sql/auth_middleware/generated_bearer_token_authenticator.rs
@@ -1,19 +1,17 @@
 use std::time::Duration;
 
 use http_protocol::header::BEARER_PREFIX;
-use models::{
-    auth::user::{User, UserInfo},
-    oid::{MemoryOidGenerator, UuidGenerator},
-};
+use models::auth::user::{User, UserInfo};
+use models::oid::{MemoryOidGenerator, UuidGenerator};
 use moka::sync::Cache;
 use query::auth::auth_control::AccessControlImpl;
 use spi::server::dbms::DBMSRef;
-use tonic::{metadata::MetadataMap, Status};
+use tonic::metadata::MetadataMap;
+use tonic::Status;
 use trace::debug;
 
-use crate::flight_sql::utils;
-
 use super::{AuthResult, CallHeaderAuthenticator, CommonAuthResult};
+use crate::flight_sql::utils;
 
 /// Generates and caches bearer tokens from user credentials.
 #[derive(Clone)]
@@ -131,20 +129,16 @@ mod test {
     use std::sync::Arc;
 
     use http_protocol::header::{AUTHORIZATION, BEARER_PREFIX};
-    use models::auth::{
-        role::UserRole,
-        user::{User, UserDesc, UserInfo, UserOptionsBuilder},
-    };
+    use models::auth::role::UserRole;
+    use models::auth::user::{User, UserDesc, UserInfo, UserOptionsBuilder};
     use spi::server::dbms::DatabaseManagerSystemMock;
     use tonic::metadata::{AsciiMetadataValue, MetadataMap};
 
-    use crate::flight_sql::{
-        auth_middleware::{
-            generated_bearer_token_authenticator::GeneratedBearerTokenAuthenticator, AuthResult,
-            CallHeaderAuthenticator, CommonAuthResult,
-        },
-        utils,
+    use crate::flight_sql::auth_middleware::generated_bearer_token_authenticator::GeneratedBearerTokenAuthenticator;
+    use crate::flight_sql::auth_middleware::{
+        AuthResult, CallHeaderAuthenticator, CommonAuthResult,
     };
+    use crate::flight_sql::utils;
 
     #[derive(Clone)]
     struct CallHeaderAuthenticatorMock {}

--- a/main/src/flight_sql/auth_middleware/mod.rs
+++ b/main/src/flight_sql/auth_middleware/mod.rs
@@ -3,7 +3,9 @@ pub mod generated_bearer_token_authenticator;
 
 use async_trait::async_trait;
 use models::auth::user::{User, UserInfo};
-use tonic::{metadata::MetadataMap, service::Interceptor, Status};
+use tonic::metadata::MetadataMap;
+use tonic::service::Interceptor;
+use tonic::Status;
 
 /// Interface for Server side authentication handlers.
 #[async_trait]

--- a/main/src/flight_sql/mod.rs
+++ b/main/src/flight_sql/mod.rs
@@ -1,4 +1,5 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::net::SocketAddr;
+use std::sync::Arc;
 
 use arrow_flight::flight_service_server::FlightServiceServer;
 use config::TLSConfig;
@@ -8,15 +9,10 @@ use tonic::transport::{Identity, Server, ServerTlsConfig};
 use trace::info;
 use warp::trace::Info;
 
-use crate::{
-    flight_sql::auth_middleware::{
-        basic_call_header_authenticator::BasicCallHeaderAuthenticator,
-        generated_bearer_token_authenticator::GeneratedBearerTokenAuthenticator,
-    },
-    server::{Service, ServiceHandle},
-};
-
 use self::flight_sql_server::FlightSqlServiceImpl;
+use crate::flight_sql::auth_middleware::basic_call_header_authenticator::BasicCallHeaderAuthenticator;
+use crate::flight_sql::auth_middleware::generated_bearer_token_authenticator::GeneratedBearerTokenAuthenticator;
+use crate::server::{Service, ServiceHandle};
 
 mod auth_middleware;
 pub mod flight_sql_server;

--- a/main/src/flight_sql/utils.rs
+++ b/main/src/flight_sql/utils.rs
@@ -1,30 +1,20 @@
-use std::{
-    collections::HashMap,
-    fmt::{self, format},
-};
+use std::collections::HashMap;
+use std::fmt::{self, format};
 
-use arrow_flight::{
-    sql::{Any, ProstMessageExt},
-    FlightDescriptor, FlightEndpoint, Location, Ticket,
-};
-use datafusion::arrow::{
-    array::ArrayRef,
-    buffer::Buffer,
-    datatypes::SchemaRef,
-    ipc::{self, reader},
-    record_batch::RecordBatch,
-};
-use http_protocol::{
-    header::{AUTHORIZATION, BASIC_PREFIX},
-    status_code::OK,
-};
+use arrow_flight::sql::{Any, ProstMessageExt};
+use arrow_flight::{FlightDescriptor, FlightEndpoint, Location, Ticket};
+use datafusion::arrow::array::ArrayRef;
+use datafusion::arrow::buffer::Buffer;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::ipc::{self, reader};
+use datafusion::arrow::record_batch::RecordBatch;
+use http_protocol::header::{AUTHORIZATION, BASIC_PREFIX};
+use http_protocol::status_code::OK;
 use models::auth::user::UserInfo;
 use prost::Message;
 use spi::service::protocol::QueryId;
-use tonic::{
-    metadata::{AsciiMetadataValue, MetadataMap},
-    Request, Status,
-};
+use tonic::metadata::{AsciiMetadataValue, MetadataMap};
+use tonic::{Request, Status};
 
 use crate::http::header::Header;
 

--- a/main/src/http/header.rs
+++ b/main/src/http/header.rs
@@ -1,8 +1,8 @@
-use super::Error as HttpError;
+use http_protocol::header::{APPLICATION_CSV, BASIC_PREFIX};
 use models::auth::user::UserInfo;
 use warp::http::header::{HeaderName, HeaderValue};
 
-use http_protocol::header::{APPLICATION_CSV, BASIC_PREFIX};
+use super::Error as HttpError;
 
 #[derive(Debug, Clone)]
 pub struct Header {

--- a/main/src/http/mod.rs
+++ b/main/src/http/mod.rs
@@ -1,19 +1,17 @@
 use std::net::AddrParseError;
 
-use models::error_code::{ErrorCode, ErrorCoder, UnknownCode};
-use snafu::Snafu;
-use tokio::sync::mpsc::error::SendError;
-use tokio::sync::oneshot::error::RecvError;
-
 use coordinator::errors::CoordinatorError;
-use warp::reject;
-use warp::reply::Response;
-
 use http_protocol::response::ErrorResponse;
 use http_protocol::status_code::UNPROCESSABLE_ENTITY;
 use meta::error::MetaError;
+use models::error_code::{ErrorCode, ErrorCoder, UnknownCode};
+use snafu::Snafu;
 use spi::QueryError;
+use tokio::sync::mpsc::error::SendError;
+use tokio::sync::oneshot::error::RecvError;
 use tskv::TsKv;
+use warp::reject;
+use warp::reply::Response;
 
 use self::response::ResponseBuilder;
 
@@ -140,10 +138,10 @@ impl From<Error> for Response {
 
 #[cfg(test)]
 mod tests {
+    use http_protocol::header::APPLICATION_JSON;
+    use http_protocol::status_code::BAD_REQUEST;
     use spi::QueryError;
     use warp::http::header::{HeaderValue, CONTENT_TYPE};
-
-    use http_protocol::{header::APPLICATION_JSON, status_code::BAD_REQUEST};
 
     use super::*;
 

--- a/main/src/http/response.rs
+++ b/main/src/http/response.rs
@@ -1,19 +1,14 @@
+use http_protocol::header::{APPLICATION_JSON, CONTENT_TYPE};
+use http_protocol::status_code::{
+    BAD_REQUEST, INTERNAL_SERVER_ERROR, METHOD_NOT_ALLOWED, NOT_FOUND, OK, PAYLOAD_TOO_LARGE,
+};
 use serde::Serialize;
 use warp::http::header::HeaderMap;
-use warp::http::HeaderValue;
-use warp::http::StatusCode;
+use warp::http::{HeaderValue, StatusCode};
 use warp::reply::Response;
 use warp::Reply;
 
 use super::header::IntoHeaderPair;
-use http_protocol::header::APPLICATION_JSON;
-use http_protocol::header::CONTENT_TYPE;
-use http_protocol::status_code::BAD_REQUEST;
-use http_protocol::status_code::INTERNAL_SERVER_ERROR;
-use http_protocol::status_code::METHOD_NOT_ALLOWED;
-use http_protocol::status_code::NOT_FOUND;
-use http_protocol::status_code::OK;
-use http_protocol::status_code::PAYLOAD_TOO_LARGE;
 
 #[derive(Default)]
 pub struct ResponseBuilder {
@@ -94,9 +89,10 @@ impl ResponseBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use http_protocol::response::ErrorResponse;
     use models::error_code::{ErrorCode, UnknownCode};
+
+    use super::*;
 
     #[test]
     fn test_simple_response() {

--- a/main/src/http/result_format.rs
+++ b/main/src/http/result_format.rs
@@ -1,21 +1,21 @@
-use super::Error as HttpError;
+use std::str::FromStr;
+
 use datafusion::arrow::csv::writer::WriterBuilder;
 use datafusion::arrow::error::Result as ArrowResult;
 use datafusion::arrow::json::{ArrayWriter, LineDelimitedWriter};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::arrow::util::pretty::pretty_format_batches;
-use spi::query::execution::Output;
-use spi::service::protocol::QueryHandle;
-use std::str::FromStr;
-use warp::reply::Response;
-
-use crate::http::response::ResponseBuilder;
-
 use http_protocol::header::{
     APPLICATION_CSV, APPLICATION_JSON, APPLICATION_NDJSON, APPLICATION_PREFIX, APPLICATION_STAR,
     APPLICATION_TABLE, APPLICATION_TSV, CONTENT_TYPE, STAR_STAR,
 };
 use http_protocol::status_code::OK;
+use spi::query::execution::Output;
+use spi::service::protocol::QueryHandle;
+use warp::reply::Response;
+
+use super::Error as HttpError;
+use crate::http::response::ResponseBuilder;
 
 macro_rules! batches_to_json {
     ($WRITER: ident, $batches: expr) => {{
@@ -137,11 +137,13 @@ pub async fn fetch_record_batches(res: QueryHandle) -> ArrowResult<Vec<RecordBat
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::sync::Arc;
+
     use datafusion::arrow::array::Int32Array;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::from_slice::FromSlice;
-    use std::sync::Arc;
+
+    use super::*;
 
     #[test]
     fn test_format_batches_with_sep() {

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -1,11 +1,9 @@
 #![allow(dead_code, unused_imports, unused_variables)]
 
-use std::{net::SocketAddr, sync::Arc};
+use std::net::SocketAddr;
+use std::sync::Arc;
 
 use clap::{Parser, Subcommand};
-use once_cell::sync::Lazy;
-use tokio::runtime::Runtime;
-
 use coordinator::hh_queue::HintedOffManager;
 use coordinator::service::CoordService;
 use coordinator::writer::PointWriter;
@@ -14,7 +12,9 @@ use meta::meta_manager::RemoteMetaManager;
 use meta::{MetaClientRef, MetaRef};
 use metrics::init_tskv_metrics_recorder;
 use models::meta_data::NodeInfo;
+use once_cell::sync::Lazy;
 use query::instance::make_cnosdbms;
+use tokio::runtime::Runtime;
 use trace::{info, init_global_tracing};
 use tskv::TsKv;
 

--- a/main/src/report/mod.rs
+++ b/main/src/report/mod.rs
@@ -1,11 +1,13 @@
-use crate::server::Service;
-use crate::{server, VERSION};
-use lazy_static::lazy_static;
-use serde::Serialize;
 use std::fmt::Debug;
 use std::ops::Add;
+
+use lazy_static::lazy_static;
+use serde::Serialize;
 use tokio::task::JoinHandle;
 use trace::debug;
+
+use crate::server::Service;
+use crate::{server, VERSION};
 
 async fn get_country_code_and_regin_name() -> (String, String) {
     let client = reqwest::Client::new();

--- a/main/src/rpc/grpc_service.rs
+++ b/main/src/rpc/grpc_service.rs
@@ -1,11 +1,10 @@
 use std::net::SocketAddr;
 
-use tokio::sync::oneshot;
-use tonic::transport::{Identity, Server, ServerTlsConfig};
-
 use config::TLSConfig;
 use protos::kv_service::tskv_service_server::TskvServiceServer;
 use spi::server::dbms::DBMSRef;
+use tokio::sync::oneshot;
+use tonic::transport::{Identity, Server, ServerTlsConfig};
 use tskv::engine::EngineRef;
 
 use crate::rpc::tskv::TskvServiceImpl;

--- a/main/src/rpc/tskv.rs
+++ b/main/src/rpc/tskv.rs
@@ -1,17 +1,13 @@
 use std::pin::Pin;
 
 use futures::Stream;
+use protos::kv_service::tskv_service_server::TskvService;
+use protos::kv_service::{PingRequest, PingResponse, WritePointsRequest, WritePointsResponse};
+use protos::models::{PingBody, PingBodyBuilder};
 use tokio::sync::mpsc::{self};
-use tokio_stream::{wrappers::ReceiverStream, StreamExt};
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status, Streaming};
-
-use protos::{
-    kv_service::{
-        tskv_service_server::TskvService, PingRequest, PingResponse, WritePointsRequest,
-        WritePointsResponse,
-    },
-    models::{PingBody, PingBodyBuilder},
-};
 use trace::debug;
 use tskv::engine::EngineRef;
 

--- a/main/src/server.rs
+++ b/main/src/server.rs
@@ -1,8 +1,6 @@
-use snafu::Backtrace;
+use snafu::{Backtrace, Snafu};
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
-
-use snafu::Snafu;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Snafu)]

--- a/main/src/tcp/vnode_manager.rs
+++ b/main/src/tcp/vnode_manager.rs
@@ -1,12 +1,8 @@
 use std::path::Path;
 
 use coordinator::command::*;
-use coordinator::file_info::get_file_info;
-use coordinator::{
-    errors::{CoordinatorError, CoordinatorResult},
-    file_info::PathFilesMeta,
-};
-
+use coordinator::errors::{CoordinatorError, CoordinatorResult};
+use coordinator::file_info::{get_file_info, PathFilesMeta};
 use http_protocol::status_code::OK;
 use models::meta_data::{VnodeAllInfo, VnodeInfo};
 use models::schema;

--- a/meta/src/bin/main.rs
+++ b/meta/src/bin/main.rs
@@ -5,6 +5,9 @@
     clippy::field_reassign_with_default
 )]
 
+use std::sync::Arc;
+use std::time::Duration;
+
 use actix_web::middleware::Logger;
 use actix_web::web::Data;
 use actix_web::{middleware, App, HttpServer};
@@ -16,8 +19,6 @@ use meta::store::Store;
 use meta::{store, MetaApp, RaftStore};
 use openraft::{Config, Raft};
 use sled::Db;
-use std::sync::Arc;
-use std::time::Duration;
 use trace::init_global_tracing;
 
 #[actix_web::main]

--- a/meta/src/client.rs
+++ b/meta/src/client.rs
@@ -1,18 +1,10 @@
-use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
-use openraft::error::ClientWriteError;
-use openraft::error::ForwardToLeader;
-use openraft::AnyError;
-
-use openraft::error::NetworkError;
-use openraft::error::RPCError;
-use openraft::error::RemoteError;
+use openraft::error::{ClientWriteError, ForwardToLeader, NetworkError, RPCError, RemoteError};
 use openraft::raft::ClientWriteResponse;
-
+use openraft::AnyError;
 use serde::de::DeserializeOwned;
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::error::{MetaError, MetaResult};
 use crate::store::command::*;
@@ -191,17 +183,15 @@ impl MetaHttpClient {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        client::MetaHttpClient,
-        store::command::{self, UpdateVnodeReplSetArgs},
-    };
     use std::{thread, time};
 
-    use models::{
-        meta_data::{NodeInfo, VnodeInfo},
-        schema::DatabaseSchema,
-    };
-    use tokio::{sync::mpsc::channel, time::timeout};
+    use models::meta_data::{NodeInfo, VnodeInfo};
+    use models::schema::DatabaseSchema;
+    use tokio::sync::mpsc::channel;
+    use tokio::time::timeout;
+
+    use crate::client::MetaHttpClient;
+    use crate::store::command::{self, UpdateVnodeReplSetArgs};
 
     #[tokio::test]
     #[ignore]

--- a/meta/src/error.rs
+++ b/meta/src/error.rs
@@ -1,10 +1,11 @@
-use crate::{client, ClusterNodeId};
-use error_code::ErrorCode;
-use error_code::ErrorCoder;
-use openraft::{AnyError, ErrorSubject, ErrorVerb, StorageError, StorageIOError};
-use snafu::Snafu;
 use std::error::Error;
 use std::io;
+
+use error_code::{ErrorCode, ErrorCoder};
+use openraft::{AnyError, ErrorSubject, ErrorVerb, StorageError, StorageIOError};
+use snafu::Snafu;
+
+use crate::{client, ClusterNodeId};
 
 pub type StorageIOResult<T> = Result<T, StorageIOError<ClusterNodeId>>;
 pub type StorageResult<T> = Result<T, StorageError<ClusterNodeId>>;

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -1,16 +1,17 @@
+use std::fmt::Display;
+use std::sync::Arc;
+
+use meta_admin::AdminMeta;
+use meta_client::MetaClient;
+use meta_manager::MetaManager;
+use openraft::{Config, Raft};
+use tenant_manager::TenantManager;
+use user_manager::UserManager;
+
 use crate::service::connection::Connections;
 use crate::store::command::WriteCommand;
 use crate::store::state_machine::CommandResp;
 use crate::store::Store;
-use meta_admin::AdminMeta;
-use meta_client::MetaClient;
-use meta_manager::MetaManager;
-use openraft::Config;
-use openraft::Raft;
-use std::fmt::Display;
-use std::sync::Arc;
-use tenant_manager::TenantManager;
-use user_manager::UserManager;
 pub mod client;
 pub mod error;
 pub mod limiter;

--- a/meta/src/limiter.rs
+++ b/meta/src/limiter.rs
@@ -1,12 +1,12 @@
 // extern crate serde_derive;
 
-use crate::error::{MetaError, MetaResult};
 use std::fmt::{Debug, Formatter};
 
 use models::limiter::{CountLimiter, RateLimiter};
 use models::schema::{DatabaseSchema, LimiterConfig};
-
 use serde::{Deserialize, Serialize};
+
+use crate::error::{MetaError, MetaResult};
 
 pub trait Limiter: Send + Sync + Debug {
     fn check_create_db(&self, db_number: usize, db_schema: &mut DatabaseSchema) -> MetaResult<()>;

--- a/meta/src/meta_admin.rs
+++ b/meta/src/meta_admin.rs
@@ -1,20 +1,16 @@
 use std::collections::{HashMap, VecDeque};
+use std::fmt::Debug;
 
 use async_trait::async_trait;
 use config::ClusterConfig;
 use models::meta_data::*;
 use parking_lot::RwLock;
-use std::fmt::Debug;
 use tokio::net::TcpStream;
 
-use crate::{
-    client::MetaHttpClient,
-    error::{MetaError, MetaResult},
-    store::{
-        command::{self, EntryLog},
-        key_path,
-    },
-};
+use crate::client::MetaHttpClient;
+use crate::error::{MetaError, MetaResult};
+use crate::store::command::{self, EntryLog};
+use crate::store::key_path;
 
 #[async_trait]
 pub trait AdminMeta: Send + Sync + Debug {

--- a/meta/src/meta_client.rs
+++ b/meta/src/meta_client.rs
@@ -1,5 +1,14 @@
 #![allow(dead_code, unused_imports, unused_variables, clippy::if_same_then_else)]
 
+use std::borrow::BorrowMut;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt::Debug;
+use std::io;
+use std::ops::DerefMut;
+use std::sync::Arc;
+use std::thread::sleep;
+use std::time::Duration;
+
 use async_trait::async_trait;
 use client::MetaHttpClient;
 use config::ClusterConfig;
@@ -10,37 +19,27 @@ use models::auth::role::{
 use models::auth::user::{User, UserDesc};
 use models::meta_data::*;
 use models::oid::{Identifier, Oid};
-use models::utils::min_num;
-use parking_lot::RwLock;
-use rand::distributions::{Alphanumeric, DistString};
-use snafu::Snafu;
-use tokio::sync::mpsc::{self, Receiver};
-
-use std::borrow::BorrowMut;
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::ops::DerefMut;
-use std::sync::Arc;
-use std::thread::sleep;
-use std::time::Duration;
-use std::{fmt::Debug, io};
-use store::command;
-use tokio::net::TcpStream;
-
-use trace::{debug, error, info, warn};
-
-use crate::error::{MetaError, MetaResult};
-use crate::store::key_path;
 use models::schema::{
     DatabaseSchema, ExternalTableSchema, LimiterConfig, TableColumn, TableSchema, Tenant,
     TenantOptions, TskvTableSchema,
 };
+use models::utils::min_num;
+use parking_lot::RwLock;
+use rand::distributions::{Alphanumeric, DistString};
+use snafu::Snafu;
+use store::command;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc::{self, Receiver};
+use trace::{debug, error, info, warn};
 
+use crate::error::{MetaError, MetaResult};
 use crate::limiter::{Limiter, LimiterImpl, NoneLimiter};
 use crate::store::command::{
     EntryLog, META_REQUEST_FAILED, META_REQUEST_PRIVILEGE_EXIST, META_REQUEST_PRIVILEGE_NOT_FOUND,
     META_REQUEST_ROLE_EXIST, META_REQUEST_ROLE_NOT_FOUND, META_REQUEST_SUCCESS,
     META_REQUEST_TENANT_NOT_FOUND, META_REQUEST_USER_EXIST, META_REQUEST_USER_NOT_FOUND,
 };
+use crate::store::key_path;
 use crate::tenant_manager::RemoteTenantManager;
 use crate::user_manager::{RemoteUserManager, UserManager, UserManagerMock};
 use crate::{client, store};

--- a/meta/src/meta_client_mock.rs
+++ b/meta/src/meta_client_mock.rs
@@ -1,39 +1,30 @@
 #![allow(dead_code, unused_imports, unused_variables)]
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
-use models::{
-    auth::{
-        privilege::DatabasePrivilege,
-        role::{CustomTenantRole, SystemTenantRole, TenantRole, TenantRoleIdentifier},
-        user::UserDesc,
-    },
-    meta_data::{BucketInfo, DatabaseInfo, ExpiredBucketInfo, NodeInfo, ReplicationSet},
-    oid::Oid,
-    schema::{
-        DatabaseSchema, ExternalTableSchema, TableSchema, Tenant, TenantOptions, TskvTableSchema,
-    },
+use models::auth::privilege::DatabasePrivilege;
+use models::auth::role::{CustomTenantRole, SystemTenantRole, TenantRole, TenantRoleIdentifier};
+use models::auth::user::UserDesc;
+use models::limiter::LimiterConfig;
+use models::meta_data::{
+    BucketInfo, DatabaseInfo, ExpiredBucketInfo, NodeInfo, ReplicationSet, VnodeAllInfo, VnodeInfo,
 };
-use models::{limiter::LimiterConfig, meta_data::VnodeInfo};
-use models::{meta_data::VnodeAllInfo, oid::Identifier};
+use models::oid::{Identifier, Oid};
+use models::schema::{
+    DatabaseSchema, ExternalTableSchema, TableSchema, Tenant, TenantOptions, TskvTableSchema,
+};
 use tokio::net::TcpStream;
 
-use crate::{
-    error::{MetaError, MetaResult},
-    meta_admin::AdminMeta,
-    meta_manager::MetaManager,
-    store::command::EntryLog,
-    tenant_manager::TenantManager,
-    MetaClientRef, TenantManagerRef, UserManagerRef,
-};
-use crate::{
-    limiter::{Limiter, LimiterImpl},
-    AdminMetaRef,
-};
-use crate::{meta_client::MetaClient, user_manager::UserManagerMock};
+use crate::error::{MetaError, MetaResult};
+use crate::limiter::{Limiter, LimiterImpl};
+use crate::meta_admin::AdminMeta;
+use crate::meta_client::MetaClient;
+use crate::meta_manager::MetaManager;
+use crate::store::command::EntryLog;
+use crate::tenant_manager::TenantManager;
+use crate::user_manager::UserManagerMock;
+use crate::{AdminMetaRef, MetaClientRef, TenantManagerRef, UserManagerRef};
 
 #[derive(Default, Debug)]
 pub struct MockAdminMeta {}

--- a/meta/src/meta_manager.rs
+++ b/meta/src/meta_manager.rs
@@ -1,34 +1,26 @@
 #![allow(clippy::if_same_then_else)]
 
+use std::fmt::Debug;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use config::ClusterConfig;
-use models::{
-    auth::{role::UserRole, user::User},
-    meta_data::*,
-    utils::min_num,
-};
-use std::{
-    fmt::Debug,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-};
+use models::auth::role::{TenantRoleIdentifier, UserRole};
+use models::auth::user::User;
+use models::meta_data::*;
+use models::oid::Identifier;
+use models::utils::min_num;
 use tokio::sync::mpsc::{self, Receiver};
 use trace::info;
 
-use models::auth::role::TenantRoleIdentifier;
-use models::oid::Identifier;
-
-use crate::{
-    client::MetaHttpClient,
-    error::{MetaError, MetaResult},
-    meta_admin::RemoteAdminMeta,
-    store::{command, key_path},
-    tenant_manager::RemoteTenantManager,
-    user_manager::RemoteUserManager,
-    AdminMetaRef, TenantManagerRef, UserManagerRef,
-};
+use crate::client::MetaHttpClient;
+use crate::error::{MetaError, MetaResult};
+use crate::meta_admin::RemoteAdminMeta;
+use crate::store::{command, key_path};
+use crate::tenant_manager::RemoteTenantManager;
+use crate::user_manager::RemoteUserManager;
+use crate::{AdminMetaRef, TenantManagerRef, UserManagerRef};
 
 #[async_trait]
 pub trait MetaManager: Send + Sync + Debug {

--- a/meta/src/service/api.rs
+++ b/meta/src/service/api.rs
@@ -1,13 +1,11 @@
-use actix_web::get;
-use actix_web::post;
-use actix_web::web;
-use actix_web::web::Data;
-use actix_web::Responder;
-use openraft::error::Infallible;
-use pprof::protos::Message;
 use std::fs::File;
 use std::io::Write;
 use std::time::Duration;
+
+use actix_web::web::Data;
+use actix_web::{get, post, web, Responder};
+use openraft::error::Infallible;
+use pprof::protos::Message;
 use trace::info;
 use web::Json;
 

--- a/meta/src/service/connection.rs
+++ b/meta/src/service/connection.rs
@@ -1,21 +1,16 @@
-use crate::{ClusterNode, ClusterNodeId, TypeConfig};
 use async_trait::async_trait;
-use openraft::error::AppendEntriesError;
-use openraft::error::InstallSnapshotError;
-use openraft::error::NetworkError;
-use openraft::error::RPCError;
-use openraft::error::RemoteError;
-use openraft::error::VoteError;
-use openraft::raft::AppendEntriesRequest;
-use openraft::raft::AppendEntriesResponse;
-use openraft::raft::InstallSnapshotRequest;
-use openraft::raft::InstallSnapshotResponse;
-use openraft::raft::VoteRequest;
-use openraft::raft::VoteResponse;
-use openraft::RaftNetwork;
-use openraft::RaftNetworkFactory;
+use openraft::error::{
+    AppendEntriesError, InstallSnapshotError, NetworkError, RPCError, RemoteError, VoteError,
+};
+use openraft::raft::{
+    AppendEntriesRequest, AppendEntriesResponse, InstallSnapshotRequest, InstallSnapshotResponse,
+    VoteRequest, VoteResponse,
+};
+use openraft::{RaftNetwork, RaftNetworkFactory};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+
+use crate::{ClusterNode, ClusterNodeId, TypeConfig};
 
 pub struct Connections {
     // pub inner: Arc<HashMap<String,Channel>>,

--- a/meta/src/service/raft_api.rs
+++ b/meta/src/service/raft_api.rs
@@ -1,17 +1,13 @@
-use crate::{ClusterNode, ClusterNodeId, MetaApp, TypeConfig};
-use actix_web::get;
-use actix_web::post;
-use actix_web::web;
+use std::collections::{BTreeMap, BTreeSet};
+
 use actix_web::web::Data;
-use actix_web::Responder;
+use actix_web::{get, post, web, Responder};
 use openraft::error::Infallible;
-use openraft::raft::AppendEntriesRequest;
-use openraft::raft::InstallSnapshotRequest;
-use openraft::raft::VoteRequest;
+use openraft::raft::{AppendEntriesRequest, InstallSnapshotRequest, VoteRequest};
 use openraft::RaftMetrics;
-use std::collections::BTreeMap;
-use std::collections::BTreeSet;
 use web::Json;
+
+use crate::{ClusterNode, ClusterNodeId, MetaApp, TypeConfig};
 
 #[post("/raft-vote")]
 pub async fn vote(

--- a/meta/src/store/command.rs
+++ b/meta/src/store/command.rs
@@ -3,17 +3,13 @@
 use std::collections::HashMap;
 
 use models::auth::privilege::DatabasePrivilege;
-use models::auth::role::SystemTenantRole;
-use models::auth::role::TenantRoleIdentifier;
+use models::auth::role::{SystemTenantRole, TenantRoleIdentifier};
 use models::auth::user::UserOptions;
 use models::meta_data::*;
 use models::oid::Oid;
-use models::schema::TenantOptions;
-use models::schema::{DatabaseSchema, TableSchema};
-
+use models::schema::{DatabaseSchema, TableSchema, TenantOptions};
 use parking_lot::RwLock;
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
 use super::key_path::KeyPath;
@@ -441,9 +437,11 @@ impl Default for Watch {
 }
 
 mod test {
-    use crate::store::command::Watch;
     use std::sync::Arc;
+
     use tokio::sync::RwLock;
+
+    use crate::store::command::Watch;
 
     async fn _watch_data_test(watch: Arc<RwLock<Watch>>, cluster: &str, ver: u64) {
         println!("======== {}", cluster);

--- a/meta/src/store/mod.rs
+++ b/meta/src/store/mod.rs
@@ -5,31 +5,22 @@ use std::io::Cursor;
 use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 
+use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
+use openraft::async_trait::async_trait;
+use openraft::storage::{LogState, Snapshot};
+use openraft::{
+    AnyError, EffectiveMembership, Entry, EntryPayload, ErrorSubject, ErrorVerb, LogId,
+    RaftLogReader, RaftSnapshotBuilder, RaftStorage, SnapshotMeta, StorageError, StorageIOError,
+    Vote,
+};
+use tokio::sync::RwLock;
+use tracing::info;
+
 use crate::error::{
     l_r_err, l_w_err, s_r_err, s_w_err, sm_r_err, v_r_err, v_w_err, StorageIOResult, StorageResult,
 };
 use crate::store::state_machine::{CommandResp, StateMachineContent};
 use crate::{ClusterNode, ClusterNodeId, TypeConfig};
-use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
-use openraft::async_trait::async_trait;
-use openraft::storage::LogState;
-use openraft::storage::Snapshot;
-use openraft::AnyError;
-use openraft::EffectiveMembership;
-use openraft::Entry;
-use openraft::EntryPayload;
-use openraft::ErrorSubject;
-use openraft::ErrorVerb;
-use openraft::LogId;
-use openraft::RaftLogReader;
-use openraft::RaftSnapshotBuilder;
-use openraft::RaftStorage;
-use openraft::SnapshotMeta;
-use openraft::StorageError;
-use openraft::StorageIOError;
-use openraft::Vote;
-use tokio::sync::RwLock;
-use tracing::info;
 
 pub mod command;
 pub mod config;

--- a/meta/src/store/state_machine.rs
+++ b/meta/src/store/state_machine.rs
@@ -1,37 +1,24 @@
-use models::auth::privilege::DatabasePrivilege;
-use models::auth::role::CustomTenantRole;
-use models::auth::role::SystemTenantRole;
-use models::auth::role::TenantRoleIdentifier;
-use models::auth::user::UserDesc;
-use models::auth::user::UserOptions;
-use models::oid::Identifier;
-use models::oid::Oid;
-use models::oid::UuidGenerator;
-use models::schema::DatabaseSchema;
-use models::schema::TableSchema;
-use models::schema::Tenant;
-use models::schema::TenantOptions;
-
-use crate::{ClusterNode, ClusterNodeId};
-use openraft::EffectiveMembership;
-use openraft::LogId;
-use serde::Deserialize;
-use serde::Serialize;
-use serde_json::{from_slice, from_str};
-use trace::debug;
-
-use sled::Db;
-use std::collections::BTreeMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
-use trace::info;
 
-use crate::error::{l_r_err, sm_r_err, sm_w_err, StorageIOResult};
-use crate::store::key_path::KeyPath;
-use models::{meta_data::*, utils};
+use models::auth::privilege::DatabasePrivilege;
+use models::auth::role::{CustomTenantRole, SystemTenantRole, TenantRoleIdentifier};
+use models::auth::user::{UserDesc, UserOptions};
+use models::meta_data::*;
+use models::oid::{Identifier, Oid, UuidGenerator};
+use models::schema::{DatabaseSchema, TableSchema, Tenant, TenantOptions};
+use models::utils;
+use openraft::{EffectiveMembership, LogId};
+use serde::{Deserialize, Serialize};
+use serde_json::{from_slice, from_str};
+use sled::Db;
+use trace::{debug, info};
 
 use super::command::*;
 use super::key_path;
+use crate::error::{l_r_err, sm_r_err, sm_w_err, StorageIOResult};
+use crate::store::key_path::KeyPath;
+use crate::{ClusterNode, ClusterNodeId};
 
 pub type CommandResp = String;
 
@@ -1271,9 +1258,10 @@ impl StateMachine {
 
 #[cfg(test)]
 mod test {
-    use serde::{Deserialize, Serialize};
     use std::collections::BTreeMap;
     use std::println;
+
+    use serde::{Deserialize, Serialize};
 
     #[tokio::test]
     async fn test_btree_map() {

--- a/meta/src/tenant_manager.rs
+++ b/meta/src/tenant_manager.rs
@@ -1,30 +1,24 @@
 #![allow(dead_code, unused_imports, unused_variables, clippy::collapsible_match)]
+use std::collections::HashMap;
 use std::fmt::Debug;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use async_trait::async_trait;
-use models::schema::LimiterConfig;
-use models::{
-    meta_data::ExpiredBucketInfo,
-    oid::{Identifier, Oid},
-    schema::{Tenant, TenantOptions},
-};
-
+use models::meta_data::ExpiredBucketInfo;
+use models::oid::{Identifier, Oid};
+use models::schema::{LimiterConfig, Tenant, TenantOptions};
 use tokio::sync::mpsc::Sender;
 use tokio::sync::RwLock;
 use trace::info;
 
+use crate::client::MetaHttpClient;
 use crate::error::{MetaError, MetaResult};
 use crate::limiter::{Limiter, LimiterImpl, NoneLimiter};
-use crate::meta_client::MetaClient;
-use crate::MetaClientRef;
-use crate::{
-    client::MetaHttpClient,
-    meta_client::RemoteMetaClient,
-    store::command::{
-        self, META_REQUEST_FAILED, META_REQUEST_TENANT_EXIST, META_REQUEST_TENANT_NOT_FOUND,
-    },
+use crate::meta_client::{MetaClient, RemoteMetaClient};
+use crate::store::command::{
+    self, META_REQUEST_FAILED, META_REQUEST_TENANT_EXIST, META_REQUEST_TENANT_NOT_FOUND,
 };
+use crate::MetaClientRef;
 
 #[async_trait]
 pub trait TenantManager: Send + Sync + Debug {

--- a/meta/src/user_manager.rs
+++ b/meta/src/user_manager.rs
@@ -1,30 +1,24 @@
 #![allow(dead_code, unused_imports, unused_variables)]
 
-use std::{
-    collections::{HashMap, HashSet},
-    fmt::Debug,
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use dashmap::DashMap;
-use models::{
-    auth::{
-        privilege::DatabasePrivilege,
-        role::{CustomTenantRole, SystemTenantRole, TenantRole, TenantRoleIdentifier, UserRole},
-        user::{User, UserDesc, UserOptions, UserOptionsBuilder},
-        AuthError,
-    },
-    oid::{Identifier, Oid},
+use models::auth::privilege::DatabasePrivilege;
+use models::auth::role::{
+    CustomTenantRole, SystemTenantRole, TenantRole, TenantRoleIdentifier, UserRole,
 };
+use models::auth::user::{User, UserDesc, UserOptions, UserOptionsBuilder};
+use models::auth::AuthError;
+use models::oid::{Identifier, Oid};
 use trace::debug;
 
+use crate::client::MetaHttpClient;
 use crate::error::{MetaError, MetaResult};
-use crate::{
-    client::MetaHttpClient,
-    store::command::{
-        self, META_REQUEST_FAILED, META_REQUEST_USER_EXIST, META_REQUEST_USER_NOT_FOUND,
-    },
+use crate::store::command::{
+    self, META_REQUEST_FAILED, META_REQUEST_USER_EXIST, META_REQUEST_USER_NOT_FOUND,
 };
 
 #[async_trait]

--- a/meta/tests/cluster/main.rs
+++ b/meta/tests/cluster/main.rs
@@ -1,9 +1,9 @@
 // mod test_cluster;
 
-use meta::store::Store;
-
-use openraft::Config;
 use std::sync::Arc;
+
+use meta::store::Store;
+use openraft::Config;
 
 pub async fn new_async() -> Arc<Store> {
     let db_path = format!("{}/{}-{}.binlog", "./meta/journal", "test", "1");

--- a/query_server/query/benches/data_utils/mod.rs
+++ b/query_server/query/benches/data_utils/mod.rs
@@ -1,25 +1,21 @@
-use arrow::{
-    array::Float32Array,
-    array::Float64Array,
-    array::StringArray,
-    array::UInt64Array,
-    datatypes::{DataType, Field, Schema, SchemaRef},
-    record_batch::RecordBatch,
-};
-use datafusion::error::Result;
-use datafusion::from_slice::FromSlice;
-use datafusion::{arrow, datasource::MemTable};
-use rand::rngs::StdRng;
-use rand::seq::SliceRandom;
-use rand::{Rng, SeedableRng};
 use std::sync::Arc;
-use tokio::runtime::Runtime;
-use trace::warn;
 
+use arrow::array::{Float32Array, Float64Array, StringArray, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::record_batch::RecordBatch;
+use datafusion::arrow;
+use datafusion::datasource::MemTable;
+use datafusion::error::Result;
 use datafusion::execution::context::SessionContext;
+use datafusion::from_slice::FromSlice;
 use parking_lot::Mutex;
 use query::extension::expr::func_manager::DFSessionContextFuncAdapter;
 use query::extension::expr::load_all_functions;
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::{Rng, SeedableRng};
+use tokio::runtime::Runtime;
+use trace::warn;
 
 pub fn query(ctx: Arc<Mutex<SessionContext>>, sql: &str) {
     let rt = Runtime::new().unwrap();

--- a/query_server/query/src/auth/auth_control.rs
+++ b/query_server/query/src/auth/auth_control.rs
@@ -1,11 +1,7 @@
 use meta::MetaRef;
-use models::{
-    auth::{
-        user::{AuthType, User, UserInfo},
-        AuthError,
-    },
-    oid::{Identifier, Oid},
-};
+use models::auth::user::{AuthType, User, UserInfo};
+use models::auth::AuthError;
+use models::oid::{Identifier, Oid};
 use spi::query::auth::AccessControl;
 use trace::warn;
 

--- a/query_server/query/src/data_source/mod.rs
+++ b/query_server/query/src/data_source/mod.rs
@@ -1,18 +1,20 @@
 use std::sync::Arc;
 
-use crate::{extension::physical::plan_node::table_writer::TableWriterExec, table::ClusterTable};
 use async_trait::async_trait;
-use datafusion::{
-    arrow::record_batch::RecordBatch,
-    common::Result as DFResult,
-    datasource::{listing::ListingTable, TableProvider},
-    error::DataFusionError,
-    execution::context::SessionState,
-    physical_plan::{metrics::ExecutionPlanMetricsSet, ExecutionPlan, SendableRecordBatchStream},
-};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::Result as DFResult;
+use datafusion::datasource::listing::ListingTable;
+use datafusion::datasource::TableProvider;
+use datafusion::error::DataFusionError;
+use datafusion::execution::context::SessionState;
+use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
+use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 use futures::StreamExt;
 use spi::Result;
 use trace::warn;
+
+use crate::extension::physical::plan_node::table_writer::TableWriterExec;
+use crate::table::ClusterTable;
 
 pub mod sink;
 pub mod write_exec_ext;

--- a/query_server/query/src/data_source/sink/obj_store/mod.rs
+++ b/query_server/query/src/data_source/sink/obj_store/mod.rs
@@ -2,21 +2,18 @@ pub mod serializer;
 
 use std::sync::Arc;
 
-use crate::data_source::SinkMetadata;
-use crate::data_source::{RecordBatchSink, RecordBatchSinkProvider};
 use async_trait::async_trait;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::SendableRecordBatchStream;
-use datafusion::{
-    arrow::record_batch::RecordBatch, physical_plan::metrics::ExecutionPlanMetricsSet,
-};
 use object_store::path::Path;
 use object_store::DynObjectStore;
 use spi::query::datasource::WriteContext;
-use spi::QueryError;
-use spi::Result;
+use spi::{QueryError, Result};
 use trace::debug;
 
 use super::DynRecordBatchSerializer;
+use crate::data_source::{RecordBatchSink, RecordBatchSinkProvider, SinkMetadata};
 
 pub struct ObjectStoreSink {
     ctx: WriteContext,

--- a/query_server/query/src/data_source/sink/obj_store/serializer/csv.rs
+++ b/query_server/query/src/data_source/sink/obj_store/serializer/csv.rs
@@ -3,10 +3,12 @@ use bytes::Bytes;
 use datafusion::arrow::csv::WriterBuilder;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{pin_mut, TryStreamExt};
-use spi::{query::datasource::WriteContext, SerializeCsvSnafu};
-
-use crate::data_source::{sink::RecordBatchSerializer, Result};
 use snafu::ResultExt;
+use spi::query::datasource::WriteContext;
+use spi::SerializeCsvSnafu;
+
+use crate::data_source::sink::RecordBatchSerializer;
+use crate::data_source::Result;
 
 pub struct CsvRecordBatchSerializer {
     with_header: bool,

--- a/query_server/query/src/data_source/sink/obj_store/serializer/json.rs
+++ b/query_server/query/src/data_source/sink/obj_store/serializer/json.rs
@@ -1,4 +1,3 @@
-use crate::data_source::sink::RecordBatchSerializer;
 use async_trait::async_trait;
 use bytes::Bytes;
 use datafusion::arrow::json::LineDelimitedWriter;
@@ -7,6 +6,8 @@ use futures::{pin_mut, TryStreamExt};
 use snafu::ResultExt;
 use spi::query::datasource::WriteContext;
 use spi::{Result, SerializeJsonSnafu};
+
+use crate::data_source::sink::RecordBatchSerializer;
 
 pub struct NdJsonRecordBatchSerializer {}
 

--- a/query_server/query/src/data_source/sink/obj_store/serializer/parquet.rs
+++ b/query_server/query/src/data_source/sink/obj_store/serializer/parquet.rs
@@ -1,18 +1,15 @@
-use std::{io::Write, sync::Arc};
+use std::io::Write;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use datafusion::{
-    parquet::{self, arrow::ArrowWriter},
-    physical_plan::SendableRecordBatchStream,
-};
-use futures::pin_mut;
-use futures::TryStreamExt;
+use datafusion::parquet::arrow::ArrowWriter;
+use datafusion::parquet::{self};
+use datafusion::physical_plan::SendableRecordBatchStream;
+use futures::{pin_mut, TryStreamExt};
 use snafu::ResultExt;
-use spi::{
-    query::datasource::WriteContext, BuildParquetArrowWriterSnafu, CloseParquetWriterSnafu, Result,
-    SerializeParquetSnafu,
-};
+use spi::query::datasource::WriteContext;
+use spi::{BuildParquetArrowWriterSnafu, CloseParquetWriterSnafu, Result, SerializeParquetSnafu};
 
 use crate::data_source::sink::RecordBatchSerializer;
 

--- a/query_server/query/src/data_source/sink/tskv.rs
+++ b/query_server/query/src/data_source/sink/tskv.rs
@@ -1,19 +1,14 @@
 use async_trait::async_trait;
-
 use coordinator::service::CoordinatorRef;
 use datafusion::arrow::record_batch::RecordBatch;
-
 use datafusion::physical_plan::metrics::{self, ExecutionPlanMetricsSet, MetricBuilder};
 use models::consistency_level::ConsistencyLevel;
-
-use spi::Result;
-
 use models::schema::TskvTableSchemaRef;
 use protos::kv_service::WritePointsRequest;
-
-use crate::utils::point_util::record_batch_to_points_flat_buffer;
+use spi::Result;
 
 use crate::data_source::{RecordBatchSink, RecordBatchSinkProvider, SinkMetadata};
+use crate::utils::point_util::record_batch_to_points_flat_buffer;
 
 pub struct TskvRecordBatchSink {
     coord: CoordinatorRef,

--- a/query_server/query/src/data_source/write_exec_ext/external_table.rs
+++ b/query_server/query/src/data_source/write_exec_ext/external_table.rs
@@ -1,35 +1,25 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::{
-    datasource::{
-        file_format::{csv::CsvFormat, json::JsonFormat, parquet::ParquetFormat, FileFormat},
-        listing::ListingTable,
-    },
-    error::DataFusionError,
-    execution::context::SessionState,
-    physical_plan::ExecutionPlan,
-};
+use datafusion::datasource::file_format::csv::CsvFormat;
+use datafusion::datasource::file_format::json::JsonFormat;
+use datafusion::datasource::file_format::parquet::ParquetFormat;
+use datafusion::datasource::file_format::FileFormat;
+use datafusion::datasource::listing::ListingTable;
+use datafusion::error::DataFusionError;
+use datafusion::execution::context::SessionState;
+use datafusion::physical_plan::ExecutionPlan;
 use object_store::path::Path;
 use trace::debug;
 use url::Url;
 
-use crate::{
-    data_source::{
-        sink::{
-            obj_store::{
-                serializer::{
-                    csv::CsvRecordBatchSerializer, json::NdJsonRecordBatchSerializer,
-                    parquet::ParquetRecordBatchSerializer,
-                },
-                ObjectStoreSinkProvider,
-            },
-            DynRecordBatchSerializer,
-        },
-        WriteExecExt,
-    },
-    extension::physical::plan_node::table_writer::TableWriterExec,
-};
+use crate::data_source::sink::obj_store::serializer::csv::CsvRecordBatchSerializer;
+use crate::data_source::sink::obj_store::serializer::json::NdJsonRecordBatchSerializer;
+use crate::data_source::sink::obj_store::serializer::parquet::ParquetRecordBatchSerializer;
+use crate::data_source::sink::obj_store::ObjectStoreSinkProvider;
+use crate::data_source::sink::DynRecordBatchSerializer;
+use crate::data_source::WriteExecExt;
+use crate::extension::physical::plan_node::table_writer::TableWriterExec;
 
 #[async_trait]
 impl WriteExecExt for ListingTable {
@@ -104,16 +94,14 @@ mod tests {
     use std::io::Write;
 
     use bytes::Bytes;
-    use object_store::{
-        aws::AmazonS3Builder, azure::MicrosoftAzureBuilder, gcp::GoogleCloudStorageBuilder,
-        path::Path, ObjectStore,
-    };
-
-    use spi::query::datasource::{
-        azure::AzblobStorageConfig,
-        gcs::{GcsStorageConfig, ServiceAccountCredentialsBuilder},
-        s3::S3StorageConfig,
-    };
+    use object_store::aws::AmazonS3Builder;
+    use object_store::azure::MicrosoftAzureBuilder;
+    use object_store::gcp::GoogleCloudStorageBuilder;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+    use spi::query::datasource::azure::AzblobStorageConfig;
+    use spi::query::datasource::gcs::{GcsStorageConfig, ServiceAccountCredentialsBuilder};
+    use spi::query::datasource::s3::S3StorageConfig;
 
     #[tokio::test]
     #[ignore = "no environment"]

--- a/query_server/query/src/dispatcher/manager.rs
+++ b/query_server/query/src/dispatcher/manager.rs
@@ -4,34 +4,23 @@ use async_trait::async_trait;
 use coordinator::service::CoordinatorRef;
 use meta::error::MetaError;
 use models::oid::Oid;
-
-use spi::query::dispatcher::{QueryInfo, QueryStatus};
-use spi::query::execution::Output;
+use spi::query::ast::ExtStatement;
+use spi::query::dispatcher::{QueryDispatcher, QueryInfo, QueryStatus};
+use spi::query::execution::{Output, QueryExecutionFactory, QueryStateMachine};
+use spi::query::logical_planner::LogicalPlanner;
+use spi::query::optimizer::Optimizer;
+use spi::query::parser::Parser;
 use spi::query::scheduler::SchedulerRef;
-use spi::{
-    query::{
-        ast::ExtStatement,
-        dispatcher::QueryDispatcher,
-        execution::{QueryExecutionFactory, QueryStateMachine},
-        logical_planner::LogicalPlanner,
-        optimizer::Optimizer,
-        parser::Parser,
-        session::IsiphoSessionCtxFactory,
-    },
-    service::protocol::{Query, QueryId},
-    QueryError,
-};
+use spi::query::session::IsiphoSessionCtxFactory;
+use spi::service::protocol::{Query, QueryId};
+use spi::{QueryError, Result};
 
-use spi::Result;
-
+use super::query_tracker::QueryTracker;
+use crate::execution::factory::SqlQueryExecutionFactory;
 use crate::extension::expr::load_all_functions;
 use crate::function::simple_func_manager::SimpleFunctionMetadataManager;
 use crate::metadata::{ContextProviderExtension, MetadataProvider};
-use crate::{
-    execution::factory::SqlQueryExecutionFactory, sql::logical::planner::DefaultLogicalPlanner,
-};
-
-use super::query_tracker::QueryTracker;
+use crate::sql::logical::planner::DefaultLogicalPlanner;
 
 #[derive(Clone)]
 pub struct SimpleQueryDispatcher {

--- a/query_server/query/src/dispatcher/query_tracker.rs
+++ b/query_server/query/src/dispatcher/query_tracker.rs
@@ -1,7 +1,11 @@
-use std::{collections::HashMap, ops::Deref, sync::Arc};
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::sync::Arc;
 
 use parking_lot::RwLock;
-use spi::{query::execution::QueryExecution, service::protocol::QueryId, QueryError};
+use spi::query::execution::QueryExecution;
+use spi::service::protocol::QueryId;
+use spi::QueryError;
 use tokio::sync::{Semaphore, SemaphorePermit, TryAcquireError};
 use trace::{debug, warn};
 
@@ -110,18 +114,14 @@ impl Drop for TrackedQuery<'_> {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
     use async_trait::async_trait;
     use models::auth::user::{UserDesc, UserOptions};
-    use spi::{
-        query::{
-            dispatcher::{QueryInfo, QueryStatus},
-            execution::{Output, QueryExecution, QueryState, RUNNING},
-        },
-        service::protocol::QueryId,
-        QueryError,
-    };
-    use std::time::Duration;
+    use spi::query::dispatcher::{QueryInfo, QueryStatus};
+    use spi::query::execution::{Output, QueryExecution, QueryState, RUNNING};
+    use spi::service::protocol::QueryId;
+    use spi::QueryError;
 
     use super::QueryTracker;
 

--- a/query_server/query/src/execution/ddl/alter_database.rs
+++ b/query_server/query/src/execution/ddl/alter_database.rs
@@ -1,10 +1,11 @@
-use crate::execution::ddl::DDLDefinitionTask;
 use async_trait::async_trait;
 use meta::error::MetaError;
 use models::schema::DatabaseOptions;
 use spi::query::execution::{Output, QueryStateMachineRef};
 use spi::query::logical_planner::AlterDatabase;
 use spi::Result;
+
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct AlterDatabaseTask {
     stmt: AlterDatabase,

--- a/query_server/query/src/execution/ddl/alter_table.rs
+++ b/query_server/query/src/execution/ddl/alter_table.rs
@@ -1,14 +1,15 @@
 use std::sync::Arc;
-// use crate::execution::ddl::query::spi::MetaSnafu;
-use crate::execution::ddl::DDLDefinitionTask;
+
 use async_trait::async_trait;
 use coordinator::command;
 use meta::error::MetaError;
 use models::schema::TableSchema;
-use spi::Result;
-
 use spi::query::execution::{Output, QueryStateMachineRef};
 use spi::query::logical_planner::{AlterTable, AlterTableAction};
+use spi::Result;
+
+// use crate::execution::ddl::query::spi::MetaSnafu;
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct AlterTableTask {
     stmt: AlterTable,

--- a/query_server/query/src/execution/ddl/alter_tenant.rs
+++ b/query_server/query/src/execution/ddl/alter_tenant.rs
@@ -1,4 +1,3 @@
-use crate::execution::ddl::DDLDefinitionTask;
 use async_trait::async_trait;
 use meta::error::MetaError;
 use spi::query::execution::{Output, QueryStateMachineRef};
@@ -7,6 +6,8 @@ use spi::query::logical_planner::{
 };
 use spi::QueryError;
 use trace::debug;
+
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct AlterTenantTask {
     stmt: AlterTenant,

--- a/query_server/query/src/execution/ddl/alter_user.rs
+++ b/query_server/query/src/execution/ddl/alter_user.rs
@@ -1,4 +1,3 @@
-use crate::execution::ddl::DDLDefinitionTask;
 use async_trait::async_trait;
 use spi::query::execution::{
     // ExecutionError, MetaSnafu,
@@ -8,6 +7,8 @@ use spi::query::execution::{
 use spi::query::logical_planner::{AlterUser, AlterUserAction};
 use spi::Result;
 use trace::debug;
+
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct AlterUserTask {
     stmt: AlterUser,

--- a/query_server/query/src/execution/ddl/checksum_group.rs
+++ b/query_server/query/src/execution/ddl/checksum_group.rs
@@ -1,15 +1,10 @@
 use async_trait::async_trait;
-
-use spi::query::{
-    execution::{Output, QueryStateMachineRef},
-    logical_planner::ChecksumGroup,
-};
+use meta::error::MetaError;
+use spi::query::execution::{Output, QueryStateMachineRef};
+use spi::query::logical_planner::ChecksumGroup;
+use spi::{QueryError, Result};
 
 use super::DDLDefinitionTask;
-use meta::error::MetaError;
-
-use spi::QueryError;
-use spi::Result;
 
 pub struct ChecksumGroupTask {
     stmt: ChecksumGroup,

--- a/query_server/query/src/execution/ddl/compact_vnode.rs
+++ b/query_server/query/src/execution/ddl/compact_vnode.rs
@@ -1,13 +1,10 @@
 use async_trait::async_trait;
-
+use meta::error::MetaError;
 use spi::query::execution::{Output, QueryStateMachineRef};
+use spi::query::logical_planner::CompactVnode;
+use spi::{QueryError, Result};
 
 use super::DDLDefinitionTask;
-use meta::error::MetaError;
-
-use spi::query::logical_planner::CompactVnode;
-use spi::QueryError;
-use spi::Result;
 
 pub struct CompactVnodeTask {
     stmt: CompactVnode,

--- a/query_server/query/src/execution/ddl/copy_vnode.rs
+++ b/query_server/query/src/execution/ddl/copy_vnode.rs
@@ -1,13 +1,9 @@
 use async_trait::async_trait;
-
-use spi::query::{
-    execution::{Output, QueryStateMachineRef},
-    logical_planner::CopyVnode,
-};
+use spi::query::execution::{Output, QueryStateMachineRef};
+use spi::query::logical_planner::CopyVnode;
+use spi::Result;
 
 use super::DDLDefinitionTask;
-
-use spi::Result;
 
 pub struct CopyVnodeTask {
     stmt: CopyVnode,

--- a/query_server/query/src/execution/ddl/create_database.rs
+++ b/query_server/query/src/execution/ddl/create_database.rs
@@ -1,11 +1,11 @@
-use crate::execution::ddl::DDLDefinitionTask;
 use async_trait::async_trait;
 use meta::error::MetaError;
 use models::schema::DatabaseSchema;
-use spi::Result;
-
 use spi::query::execution::{Output, QueryStateMachineRef};
 use spi::query::logical_planner::CreateDatabase;
+use spi::Result;
+
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct CreateDatabaseTask {
     stmt: CreateDatabase,

--- a/query_server/query/src/execution/ddl/create_role.rs
+++ b/query_server/query/src/execution/ddl/create_role.rs
@@ -1,4 +1,3 @@
-use crate::execution::ddl::DDLDefinitionTask;
 use async_trait::async_trait;
 use meta::error::MetaError;
 use snafu::ResultExt;
@@ -7,11 +6,11 @@ use spi::query::execution::{
     Output,
     QueryStateMachineRef,
 };
-use spi::Result;
-
 use spi::query::logical_planner::CreateRole;
-use spi::QueryError;
+use spi::{QueryError, Result};
 use trace::debug;
+
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct CreateRoleTask {
     stmt: CreateRole,

--- a/query_server/query/src/execution/ddl/create_table.rs
+++ b/query_server/query/src/execution/ddl/create_table.rs
@@ -1,13 +1,14 @@
-use crate::execution::ddl::DDLDefinitionTask;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use meta::error::MetaError;
 use models::schema::{TableSchema, TskvTableSchema};
 use snafu::ResultExt;
 use spi::query::execution::{Output, QueryStateMachineRef};
-use spi::Result;
-use std::sync::Arc;
-
 use spi::query::logical_planner::CreateTable;
+use spi::Result;
+
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct CreateTableTask {
     stmt: CreateTable,

--- a/query_server/query/src/execution/ddl/create_tenant.rs
+++ b/query_server/query/src/execution/ddl/create_tenant.rs
@@ -1,11 +1,11 @@
-use crate::execution::ddl::DDLDefinitionTask;
 use async_trait::async_trait;
 use meta::error::MetaError;
-use spi::Result;
-
 use spi::query::execution::{Output, QueryStateMachineRef};
 use spi::query::logical_planner::CreateTenant;
+use spi::Result;
 use trace::debug;
+
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct CreateTenantTask {
     stmt: CreateTenant,

--- a/query_server/query/src/execution/ddl/create_user.rs
+++ b/query_server/query/src/execution/ddl/create_user.rs
@@ -1,13 +1,12 @@
-use crate::execution::ddl::DDLDefinitionTask;
 use async_trait::async_trait;
 use meta::error::MetaError;
 use snafu::ResultExt;
-use spi::MetaSnafu;
-use spi::Result;
-
 use spi::query::execution::{Output, QueryStateMachineRef};
 use spi::query::logical_planner::CreateUser;
+use spi::{MetaSnafu, Result};
 use trace::debug;
+
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct CreateUserTask {
     stmt: CreateUser,

--- a/query_server/query/src/execution/ddl/describe_database.rs
+++ b/query_server/query/src/execution/ddl/describe_database.rs
@@ -1,14 +1,15 @@
-use crate::execution::ddl::DDLDefinitionTask;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use datafusion::arrow::array::StringArray;
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
-use spi::Result;
-
 use meta::error::MetaError;
 use spi::query::execution::{Output, QueryStateMachineRef};
 use spi::query::logical_planner::DescribeDatabase;
-use std::sync::Arc;
+use spi::Result;
+
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct DescribeDatabaseTask {
     stmt: DescribeDatabase,

--- a/query_server/query/src/execution/ddl/describe_table.rs
+++ b/query_server/query/src/execution/ddl/describe_table.rs
@@ -1,16 +1,17 @@
-use crate::execution::ddl::DDLDefinitionTask;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use datafusion::arrow::array::StringBuilder;
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
+use meta::error::MetaError;
 use models::object_reference::ResolvedTable;
 use models::schema::TableSchema;
-use spi::Result;
-
-use meta::error::MetaError;
 use spi::query::execution::{Output, QueryStateMachineRef};
 use spi::query::logical_planner::DescribeTable;
-use std::sync::Arc;
+use spi::Result;
+
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct DescribeTableTask {
     stmt: DescribeTable,

--- a/query_server/query/src/execution/ddl/drop_database_object.rs
+++ b/query_server/query/src/execution/ddl/drop_database_object.rs
@@ -1,17 +1,13 @@
 use async_trait::async_trait;
 use coordinator::command;
+use meta::error::MetaError;
 use snafu::ResultExt;
-use spi::query::{
-    execution::{Output, QueryStateMachineRef},
-    logical_planner::{DatabaseObjectType, DropDatabaseObject},
-};
-use spi::MetaSnafu;
-use spi::Result;
-
+use spi::query::execution::{Output, QueryStateMachineRef};
+use spi::query::logical_planner::{DatabaseObjectType, DropDatabaseObject};
+use spi::{MetaSnafu, Result};
 use trace::info;
 
 use super::DDLDefinitionTask;
-use meta::error::MetaError;
 
 pub struct DropDatabaseObjectTask {
     stmt: DropDatabaseObject,

--- a/query_server/query/src/execution/ddl/drop_global_object.rs
+++ b/query_server/query/src/execution/ddl/drop_global_object.rs
@@ -1,16 +1,11 @@
 use async_trait::async_trait;
-use spi::query::{
-    execution::{Output, QueryStateMachineRef},
-    logical_planner::{DropGlobalObject, GlobalObjectType},
-};
-use spi::Result;
-
+use meta::error::MetaError;
+use spi::query::execution::{Output, QueryStateMachineRef};
+use spi::query::logical_planner::{DropGlobalObject, GlobalObjectType};
+use spi::{QueryError, Result};
 use trace::debug;
 
 use super::DDLDefinitionTask;
-
-use meta::error::MetaError;
-use spi::QueryError;
 
 pub struct DropGlobalObjectTask {
     stmt: DropGlobalObject,

--- a/query_server/query/src/execution/ddl/drop_tenant_object.rs
+++ b/query_server/query/src/execution/ddl/drop_tenant_object.rs
@@ -1,16 +1,12 @@
 use async_trait::async_trait;
 use coordinator::command;
-use spi::query::{
-    execution::{Output, QueryStateMachineRef},
-    logical_planner::{DropTenantObject, TenantObjectType},
-};
-
+use meta::error::MetaError;
+use spi::query::execution::{Output, QueryStateMachineRef};
+use spi::query::logical_planner::{DropTenantObject, TenantObjectType};
+use spi::{QueryError, Result};
 use trace::debug;
 
 use super::DDLDefinitionTask;
-use meta::error::MetaError;
-use spi::QueryError;
-use spi::Result;
 
 pub struct DropTenantObjectTask {
     stmt: DropTenantObject,

--- a/query_server/query/src/execution/ddl/drop_vnode.rs
+++ b/query_server/query/src/execution/ddl/drop_vnode.rs
@@ -1,13 +1,9 @@
 use async_trait::async_trait;
-
-use spi::query::{
-    execution::{Output, QueryStateMachineRef},
-    logical_planner::DropVnode,
-};
+use spi::query::execution::{Output, QueryStateMachineRef};
+use spi::query::logical_planner::DropVnode;
+use spi::Result;
 
 use super::DDLDefinitionTask;
-
-use spi::Result;
 
 pub struct DropVnodeTask {
     stmt: DropVnode,

--- a/query_server/query/src/execution/ddl/grant_revoke.rs
+++ b/query_server/query/src/execution/ddl/grant_revoke.rs
@@ -1,11 +1,11 @@
-use crate::execution::ddl::DDLDefinitionTask;
 use async_trait::async_trait;
 use meta::error::MetaError;
 use spi::query::execution::{Output, QueryStateMachineRef};
 use spi::query::logical_planner::GrantRevoke;
-use spi::QueryError;
-use spi::Result;
+use spi::{QueryError, Result};
 use trace::debug;
+
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct GrantRevokeTask {
     stmt: GrantRevoke,

--- a/query_server/query/src/execution/ddl/mod.rs
+++ b/query_server/query/src/execution/ddl/mod.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-
 use spi::query::dispatcher::{QueryInfo, QueryStatus};
 use spi::query::execution::{Output, QueryExecution, QueryStateMachineRef};
 use spi::query::logical_planner::DDLPlan;
@@ -7,10 +6,12 @@ use spi::Result;
 
 use self::alter_tenant::AlterTenantTask;
 use self::alter_user::AlterUserTask;
+use self::create_external_table::CreateExternalTableTask;
 use self::create_role::CreateRoleTask;
 use self::create_table::CreateTableTask;
 use self::create_tenant::CreateTenantTask;
 use self::create_user::CreateUserTask;
+use self::drop_database_object::DropDatabaseObjectTask;
 use self::drop_global_object::DropGlobalObjectTask;
 use self::drop_tenant_object::DropTenantObjectTask;
 use self::grant_revoke::GrantRevokeTask;
@@ -26,9 +27,6 @@ use crate::execution::ddl::drop_vnode::DropVnodeTask;
 use crate::execution::ddl::move_node::MoveVnodeTask;
 use crate::execution::ddl::show_database::ShowDatabasesTask;
 use crate::execution::ddl::show_table::ShowTablesTask;
-
-use self::create_external_table::CreateExternalTableTask;
-use self::drop_database_object::DropDatabaseObjectTask;
 
 mod alter_database;
 mod alter_table;

--- a/query_server/query/src/execution/ddl/move_node.rs
+++ b/query_server/query/src/execution/ddl/move_node.rs
@@ -1,13 +1,9 @@
 use async_trait::async_trait;
-
-use spi::query::{
-    execution::{Output, QueryStateMachineRef},
-    logical_planner::MoveVnode,
-};
+use spi::query::execution::{Output, QueryStateMachineRef};
+use spi::query::logical_planner::MoveVnode;
+use spi::Result;
 
 use super::DDLDefinitionTask;
-
-use spi::Result;
 
 pub struct MoveVnodeTask {
     stmt: MoveVnode,

--- a/query_server/query/src/execution/ddl/show_database.rs
+++ b/query_server/query/src/execution/ddl/show_database.rs
@@ -1,10 +1,9 @@
-use crate::execution::ddl::DDLDefinitionTask;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use datafusion::arrow::array::StringArray;
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
-use spi::Result;
-
 use meta::error::MetaError;
 // use spi::query::execution::spi::DatafusionSnafu;
 // use spi::query::spi::MetaSnafu;
@@ -13,7 +12,9 @@ use spi::query::execution::{
     Output,
     QueryStateMachineRef,
 };
-use std::sync::Arc;
+use spi::Result;
+
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct ShowDatabasesTask {}
 

--- a/query_server/query/src/execution/ddl/show_table.rs
+++ b/query_server/query/src/execution/ddl/show_table.rs
@@ -1,10 +1,9 @@
-use crate::execution::ddl::DDLDefinitionTask;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use datafusion::arrow::array::StringArray;
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
-use spi::Result;
-
 use meta::error::MetaError;
 // use spi::query::execution::spi::DatafusionSnafu;
 // use spi::query::spi::MetaSnafu;
@@ -13,7 +12,9 @@ use spi::query::execution::{
     Output,
     QueryStateMachineRef,
 };
-use std::sync::Arc;
+use spi::Result;
+
+use crate::execution::ddl::DDLDefinitionTask;
 
 pub struct ShowTablesTask {
     database_name: Option<String>,

--- a/query_server/query/src/execution/factory.rs
+++ b/query_server/query/src/execution/factory.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
-use crate::{dispatcher::query_tracker::QueryTracker, execution::ddl::DDLExecution};
-use spi::query::{
-    execution::{QueryExecution, QueryExecutionFactory, QueryStateMachineRef},
-    logical_planner::Plan,
-    optimizer::Optimizer,
-    scheduler::SchedulerRef,
-};
+use spi::query::execution::{QueryExecution, QueryExecutionFactory, QueryStateMachineRef};
+use spi::query::logical_planner::Plan;
+use spi::query::optimizer::Optimizer;
+use spi::query::scheduler::SchedulerRef;
 
-use super::{query::SqlQueryExecution, sys::SystemExecution};
+use super::query::SqlQueryExecution;
+use super::sys::SystemExecution;
+use crate::dispatcher::query_tracker::QueryTracker;
+use crate::execution::ddl::DDLExecution;
 
 pub struct SqlQueryExecutionFactory {
     optimizer: Arc<dyn Optimizer + Send + Sync>,

--- a/query_server/query/src/execution/query.rs
+++ b/query_server/query/src/execution/query.rs
@@ -5,14 +5,10 @@ use futures::stream::AbortHandle;
 use futures::TryStreamExt;
 use parking_lot::Mutex;
 use spi::query::dispatcher::{QueryInfo, QueryStatus};
-use spi::query::execution::Output;
+use spi::query::execution::{Output, QueryExecution, QueryStateMachineRef};
+use spi::query::logical_planner::QueryPlan;
+use spi::query::optimizer::Optimizer;
 use spi::query::scheduler::SchedulerRef;
-use spi::query::{
-    execution::{QueryExecution, QueryStateMachineRef},
-    logical_planner::QueryPlan,
-    optimizer::Optimizer,
-};
-
 use spi::{QueryError, Result};
 use trace::debug;
 

--- a/query_server/query/src/execution/scheduler.rs
+++ b/query_server/query/src/execution/scheduler.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
-use datafusion::{
-    common::Result,
-    execution::context::TaskContext,
-    physical_plan::{coalesce_partitions::CoalescePartitionsExec, ExecutionPlan},
-};
+use datafusion::common::Result;
+use datafusion::execution::context::TaskContext;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::ExecutionPlan;
 use spi::query::scheduler::{ExecutionResults, Scheduler};
 
 pub struct LocalScheduler {}

--- a/query_server/query/src/execution/sys/kill_query.rs
+++ b/query_server/query/src/execution/sys/kill_query.rs
@@ -1,16 +1,12 @@
-use spi::Result;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use spi::{
-    query::execution::{Output, QueryStateMachineRef},
-    service::protocol::QueryId,
-    QueryError,
-};
-
-use crate::dispatcher::query_tracker::QueryTracker;
+use spi::query::execution::{Output, QueryStateMachineRef};
+use spi::service::protocol::QueryId;
+use spi::{QueryError, Result};
 
 use super::SystemTask;
+use crate::dispatcher::query_tracker::QueryTracker;
 
 pub struct KillQueryTask {
     query_tracker: Arc<QueryTracker>,

--- a/query_server/query/src/execution/sys/mod.rs
+++ b/query_server/query/src/execution/sys/mod.rs
@@ -4,17 +4,14 @@ mod show_queries;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use spi::query::{
-    dispatcher::{QueryInfo, QueryStatus},
-    execution::{Output, QueryExecution, QueryStateMachineRef},
-    logical_planner::SYSPlan,
-};
+use spi::query::dispatcher::{QueryInfo, QueryStatus};
+use spi::query::execution::{Output, QueryExecution, QueryStateMachineRef};
+use spi::query::logical_planner::SYSPlan;
 use spi::Result;
-
-use crate::dispatcher::query_tracker::QueryTracker;
 
 use self::kill_query::KillQueryTask;
 use self::show_queries::ShowQueriesTask;
+use crate::dispatcher::query_tracker::QueryTracker;
 
 pub struct SystemExecution {
     task_factory: SystemTaskFactory,

--- a/query_server/query/src/execution/sys/show_queries.rs
+++ b/query_server/query/src/execution/sys/show_queries.rs
@@ -1,22 +1,17 @@
 use std::sync::Arc;
-
-use async_trait::async_trait;
-use datafusion::arrow::{
-    array::{StringBuilder, UInt64Builder},
-    datatypes::{DataType, Field, Schema, SchemaRef},
-    error::ArrowError,
-    record_batch::RecordBatch,
-};
-use spi::Result;
-use spi::{
-    query::execution::{Output, QueryState, QueryStateMachineRef},
-    service::protocol::QueryId,
-};
 use std::time::Duration;
 
-use crate::dispatcher::query_tracker::QueryTracker;
+use async_trait::async_trait;
+use datafusion::arrow::array::{StringBuilder, UInt64Builder};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::error::ArrowError;
+use datafusion::arrow::record_batch::RecordBatch;
+use spi::query::execution::{Output, QueryState, QueryStateMachineRef};
+use spi::service::protocol::QueryId;
+use spi::Result;
 
 use super::SystemTask;
+use crate::dispatcher::query_tracker::QueryTracker;
 
 pub struct ShowQueriesTask {
     query_tracker: Arc<QueryTracker>,

--- a/query_server/query/src/extension/expr/aggregate_function/example.rs
+++ b/query_server/query/src/extension/expr/aggregate_function/example.rs
@@ -1,11 +1,8 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::datatypes::DataType,
-    logical_expr::create_udaf,
-    logical_expr::{AggregateUDF, Volatility},
-    physical_plan::expressions::AvgAccumulator,
-};
+use datafusion::arrow::datatypes::DataType;
+use datafusion::logical_expr::{create_udaf, AggregateUDF, Volatility};
+use datafusion::physical_plan::expressions::AvgAccumulator;
 use spi::query::function::FunctionMetadataManager;
 use spi::Result;
 

--- a/query_server/query/src/extension/expr/aggregate_function/mod.rs
+++ b/query_server/query/src/extension/expr/aggregate_function/mod.rs
@@ -13,9 +13,8 @@ pub fn register_udafs(_func_manager: &mut dyn FunctionMetadataManager) -> Result
 
 #[cfg(test)]
 mod tests {
-    use crate::function::simple_func_manager::SimpleFunctionMetadataManager;
-
     use super::*;
+    use crate::function::simple_func_manager::SimpleFunctionMetadataManager;
 
     #[tokio::test]
     async fn test_example() {

--- a/query_server/query/src/extension/expr/expr_utils.rs
+++ b/query_server/query/src/extension/expr/expr_utils.rs
@@ -1,7 +1,6 @@
+use datafusion::error::Result;
 use datafusion::logical_expr::expr_visitor::{ExprVisitable, ExpressionVisitor, Recursion};
 use datafusion::prelude::Expr;
-
-use datafusion::error::Result;
 
 use super::selector_function::{BOTTOM, TOPK};
 

--- a/query_server/query/src/extension/expr/func_manager.rs
+++ b/query_server/query/src/extension/expr/func_manager.rs
@@ -2,8 +2,8 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use datafusion::execution::FunctionRegistry;
-use datafusion::logical_expr::AggregateUDF;
-use datafusion::{logical_expr::ScalarUDF, prelude::SessionContext};
+use datafusion::logical_expr::{AggregateUDF, ScalarUDF};
+use datafusion::prelude::SessionContext;
 use spi::query::function::*;
 use spi::{QueryError, Result};
 

--- a/query_server/query/src/extension/expr/scalar_function/example.rs
+++ b/query_server/query/src/extension/expr/scalar_function/example.rs
@@ -1,12 +1,10 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::{array::ArrayRef, datatypes::DataType},
-    logical_expr::{ScalarUDF, Volatility},
-    physical_expr::functions::make_scalar_function,
-    prelude::create_udf,
-};
-
+use datafusion::arrow::array::ArrayRef;
+use datafusion::arrow::datatypes::DataType;
+use datafusion::logical_expr::{ScalarUDF, Volatility};
+use datafusion::physical_expr::functions::make_scalar_function;
+use datafusion::prelude::create_udf;
 use spi::query::function::FunctionMetadataManager;
 use spi::Result;
 

--- a/query_server/query/src/extension/expr/scalar_function/mod.rs
+++ b/query_server/query/src/extension/expr/scalar_function/mod.rs
@@ -13,9 +13,10 @@ pub fn register_udfs(_func_manager: &mut dyn FunctionMetadataManager) -> Result<
 
 #[cfg(test)]
 mod tests {
+    use spi::query::function::FunctionMetadataManager;
+
     use super::example;
     use crate::function::simple_func_manager::SimpleFunctionMetadataManager;
-    use spi::query::function::FunctionMetadataManager;
 
     #[tokio::test]
     async fn test_example() {

--- a/query_server/query/src/extension/expr/selector_function/bottom.rs
+++ b/query_server/query/src/extension/expr/selector_function/bottom.rs
@@ -1,15 +1,13 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::{array::ArrayRef, datatypes::DataType},
-    error::DataFusionError,
-    logical_expr::{
-        type_coercion::aggregates::{DATES, NUMERICS, STRINGS, TIMESTAMPS},
-        ReturnTypeFunction, ScalarUDF, Signature, TypeSignature, Volatility,
-    },
-    physical_expr::functions::make_scalar_function,
+use datafusion::arrow::array::ArrayRef;
+use datafusion::arrow::datatypes::DataType;
+use datafusion::error::DataFusionError;
+use datafusion::logical_expr::type_coercion::aggregates::{DATES, NUMERICS, STRINGS, TIMESTAMPS};
+use datafusion::logical_expr::{
+    ReturnTypeFunction, ScalarUDF, Signature, TypeSignature, Volatility,
 };
-
+use datafusion::physical_expr::functions::make_scalar_function;
 use spi::query::function::FunctionMetadataManager;
 use spi::Result;
 

--- a/query_server/query/src/extension/expr/selector_function/topk.rs
+++ b/query_server/query/src/extension/expr/selector_function/topk.rs
@@ -1,15 +1,13 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::{array::ArrayRef, datatypes::DataType},
-    error::DataFusionError,
-    logical_expr::{
-        type_coercion::aggregates::{DATES, NUMERICS, STRINGS, TIMESTAMPS},
-        ReturnTypeFunction, ScalarUDF, Signature, TypeSignature, Volatility,
-    },
-    physical_expr::functions::make_scalar_function,
+use datafusion::arrow::array::ArrayRef;
+use datafusion::arrow::datatypes::DataType;
+use datafusion::error::DataFusionError;
+use datafusion::logical_expr::type_coercion::aggregates::{DATES, NUMERICS, STRINGS, TIMESTAMPS};
+use datafusion::logical_expr::{
+    ReturnTypeFunction, ScalarUDF, Signature, TypeSignature, Volatility,
 };
-
+use datafusion::physical_expr::functions::make_scalar_function;
 use spi::query::function::FunctionMetadataManager;
 use spi::Result;
 

--- a/query_server/query/src/extension/logical/optimizer_rule/implicit_type_conversion.rs
+++ b/query_server/query/src/extension/logical/optimizer_rule/implicit_type_conversion.rs
@@ -1,18 +1,19 @@
-use std::{mem, sync::Arc};
+use std::mem;
+use std::sync::Arc;
 
+use datafusion::arrow::compute;
+use datafusion::arrow::compute::kernels::cast_utils::string_to_timestamp_nanos;
 use datafusion::arrow::compute::CastOptions;
-use datafusion::arrow::datatypes::TimeUnit;
-use datafusion::arrow::{compute, compute::kernels::cast_utils::string_to_timestamp_nanos};
+use datafusion::arrow::datatypes::{DataType, TimeUnit};
 use datafusion::common::DFSchemaRef;
+use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::expr_rewriter::{ExprRewritable, ExprRewriter};
-use datafusion::logical_expr::{utils, Between, BinaryExpr, ExprSchemable};
-use datafusion::{
-    arrow::datatypes::DataType,
-    error::{DataFusionError, Result},
-    logical_expr::{Expr, Filter, LogicalPlan, Operator, TableScan},
-    optimizer::{optimizer::OptimizerRule, OptimizerConfig},
-    scalar::ScalarValue,
+use datafusion::logical_expr::{
+    utils, Between, BinaryExpr, Expr, ExprSchemable, Filter, LogicalPlan, Operator, TableScan,
 };
+use datafusion::optimizer::optimizer::OptimizerRule;
+use datafusion::optimizer::OptimizerConfig;
+use datafusion::scalar::ScalarValue;
 use trace::debug;
 
 /// Optimizer that cast literal value to target column's type
@@ -326,7 +327,6 @@ mod tests {
     use std::collections::HashMap;
 
     use datafusion::arrow::datatypes::TimeUnit;
-
     use datafusion::common::{DFField, DFSchema};
     use datafusion::logical_expr::expr_rewriter::ExprRewritable;
     use datafusion::prelude::col;

--- a/query_server/query/src/extension/logical/optimizer_rule/merge_limit_with_sort.rs
+++ b/query_server/query/src/extension/logical/optimizer_rule/merge_limit_with_sort.rs
@@ -1,15 +1,10 @@
 use std::sync::Arc;
 
-use datafusion::{
-    logical_expr::{
-        Limit, LogicalPlan, {Extension, Sort},
-    },
-    optimizer::{OptimizerConfig, OptimizerRule},
-};
+use datafusion::error::Result;
+use datafusion::logical_expr::{Extension, Limit, LogicalPlan, Sort};
+use datafusion::optimizer::{OptimizerConfig, OptimizerRule};
 
 use super::super::plan_node::topk::TopKPlanNode;
-
-use datafusion::error::Result;
 
 pub struct MergeLimitWithSortRule {}
 

--- a/query_server/query/src/extension/logical/optimizer_rule/push_down_projection.rs
+++ b/query_server/query/src/extension/logical/optimizer_rule/push_down_projection.rs
@@ -1,6 +1,9 @@
 //! Projection Push Down optimizer rule ensures that only referenced columns are
 //! loaded into memory
 
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::sync::Arc;
+
 use datafusion::arrow::datatypes::Field;
 use datafusion::arrow::error::Result as ArrowResult;
 use datafusion::common::{
@@ -17,12 +20,6 @@ use datafusion::logical_expr::{
 };
 use datafusion::optimizer::{OptimizerConfig, OptimizerRule};
 use datafusion::prelude::Expr;
-
-use std::collections::HashMap;
-use std::{
-    collections::{BTreeSet, HashSet},
-    sync::Arc,
-};
 
 use crate::table::ClusterTable;
 

--- a/query_server/query/src/extension/logical/optimizer_rule/reject_cross_join.rs
+++ b/query_server/query/src/extension/logical/optimizer_rule/reject_cross_join.rs
@@ -1,10 +1,6 @@
-use datafusion::{
-    error::DataFusionError,
-    logical_expr::LogicalPlan,
-    optimizer::{OptimizerConfig, OptimizerRule},
-};
-
-use datafusion::error::Result;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::optimizer::{OptimizerConfig, OptimizerRule};
 
 pub struct RejectCrossJoin {}
 

--- a/query_server/query/src/extension/logical/optimizer_rule/rewrite_tag_scan.rs
+++ b/query_server/query/src/extension/logical/optimizer_rule/rewrite_tag_scan.rs
@@ -2,15 +2,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use datafusion::common::{DFField, DFSchema};
-use datafusion::{
-    datasource::source_as_provider,
-    logical_expr::{Extension, LogicalPlan, LogicalPlanBuilder, TableScan},
-    optimizer::{OptimizerConfig, OptimizerRule},
-};
-
-use crate::{extension::logical::plan_node::tag_scan::TagScanPlanNode, table::ClusterTable};
-
+use datafusion::datasource::source_as_provider;
 use datafusion::error::Result;
+use datafusion::logical_expr::{Extension, LogicalPlan, LogicalPlanBuilder, TableScan};
+use datafusion::optimizer::{OptimizerConfig, OptimizerRule};
+
+use crate::extension::logical::plan_node::tag_scan::TagScanPlanNode;
+use crate::table::ClusterTable;
 
 /// Convert query statement to query tag operation
 ///

--- a/query_server/query/src/extension/logical/optimizer_rule/transform_bottom_func_to_topk_node.rs
+++ b/query_server/query/src/extension/logical/optimizer_rule/transform_bottom_func_to_topk_node.rs
@@ -1,18 +1,13 @@
 use std::sync::Arc;
 
-use datafusion::{
-    error::DataFusionError,
-    logical_expr::{
-        expr, LogicalPlan, {Projection, Sort},
-    },
-    optimizer::{OptimizerConfig, OptimizerRule},
-    prelude::Expr,
-    scalar::ScalarValue,
-};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::{expr, LogicalPlan, Projection, Sort};
+use datafusion::optimizer::{OptimizerConfig, OptimizerRule};
+use datafusion::prelude::Expr;
+use datafusion::scalar::ScalarValue;
 
-use crate::extension::expr::{expr_utils, selector_function::BOTTOM};
-
-use datafusion::error::Result;
+use crate::extension::expr::expr_utils;
+use crate::extension::expr::selector_function::BOTTOM;
 
 const INVALID_EXPRS: &str = "1. There cannot be nested selection functions. 2. There cannot be multiple selection functions.";
 const INVALID_ARGUMENTS: &str =

--- a/query_server/query/src/extension/logical/optimizer_rule/transform_topk_func_to_topk_node.rs
+++ b/query_server/query/src/extension/logical/optimizer_rule/transform_topk_func_to_topk_node.rs
@@ -1,18 +1,13 @@
 use std::sync::Arc;
 
-use datafusion::{
-    error::DataFusionError,
-    logical_expr::{
-        expr, LogicalPlan, {Projection, Sort},
-    },
-    optimizer::{OptimizerConfig, OptimizerRule},
-    prelude::Expr,
-    scalar::ScalarValue,
-};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::{expr, LogicalPlan, Projection, Sort};
+use datafusion::optimizer::{OptimizerConfig, OptimizerRule};
+use datafusion::prelude::Expr;
+use datafusion::scalar::ScalarValue;
 
-use crate::extension::expr::{expr_utils, selector_function::TOPK};
-
-use datafusion::error::Result;
+use crate::extension::expr::expr_utils;
+use crate::extension::expr::selector_function::TOPK;
 
 const INVALID_EXPRS: &str = "1. There cannot be nested selection functions. 2. There cannot be multiple selection functions.";
 const INVALID_ARGUMENTS: &str =

--- a/query_server/query/src/extension/logical/plan_node/table_writer.rs
+++ b/query_server/query/src/extension/logical/plan_node/table_writer.rs
@@ -1,16 +1,12 @@
-use std::{
-    any::Any,
-    fmt::{self, Debug},
-    sync::Arc,
-};
+use std::any::Any;
+use std::fmt::{self, Debug};
+use std::sync::Arc;
 
-use datafusion::{
-    common::{DFSchema, DFSchemaRef},
-    error::DataFusionError,
-    logical_expr::TableSource,
-    logical_expr::{utils::exprlist_to_fields, LogicalPlan, UserDefinedLogicalNode},
-    prelude::Expr,
-};
+use datafusion::common::{DFSchema, DFSchemaRef};
+use datafusion::error::DataFusionError;
+use datafusion::logical_expr::utils::exprlist_to_fields;
+use datafusion::logical_expr::{LogicalPlan, TableSource, UserDefinedLogicalNode};
+use datafusion::prelude::Expr;
 
 #[derive(Clone)]
 pub struct TableWriterPlanNode {

--- a/query_server/query/src/extension/logical/plan_node/tag_scan.rs
+++ b/query_server/query/src/extension/logical/plan_node/tag_scan.rs
@@ -1,14 +1,10 @@
-use std::{
-    any::Any,
-    fmt::{self, Debug},
-    sync::Arc,
-};
+use std::any::Any;
+use std::fmt::{self, Debug};
+use std::sync::Arc;
 
-use datafusion::{
-    common::DFSchemaRef,
-    logical_expr::{LogicalPlan, UserDefinedLogicalNode},
-    prelude::Expr,
-};
+use datafusion::common::DFSchemaRef;
+use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
+use datafusion::prelude::Expr;
 
 use crate::table::ClusterTable;
 

--- a/query_server/query/src/extension/logical/plan_node/topk.rs
+++ b/query_server/query/src/extension/logical/plan_node/topk.rs
@@ -1,14 +1,10 @@
-use std::{
-    any::Any,
-    fmt::{self, Debug, Display},
-    sync::Arc,
-};
+use std::any::Any;
+use std::fmt::{self, Debug, Display};
+use std::sync::Arc;
 
-use datafusion::{
-    common::DFSchemaRef,
-    logical_expr::{LogicalPlan, UserDefinedLogicalNode},
-    prelude::Expr,
-};
+use datafusion::common::DFSchemaRef;
+use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
+use datafusion::prelude::Expr;
 
 #[derive(Debug, Clone, Copy)]
 pub enum TopKStep {

--- a/query_server/query/src/extension/physical/plan_node/table_writer.rs
+++ b/query_server/query/src/extension/physical/plan_node/table_writer.rs
@@ -1,26 +1,25 @@
+use std::any::Any;
+use std::fmt::Debug;
+use std::sync::Arc;
+
 use async_trait::async_trait;
-use datafusion::{
-    arrow::{
-        array::UInt64Array,
-        datatypes::{Field, Schema, SchemaRef},
-        record_batch::RecordBatch,
-    },
-    error::DataFusionError,
-    execution::context::TaskContext,
-    physical_expr::PhysicalSortExpr,
-    physical_plan::{
-        memory::MemoryStream,
-        metrics::{self, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet},
-        stream::RecordBatchStreamAdapter,
-        DisplayFormatType, Distribution, ExecutionPlan, Partitioning, SendableRecordBatchStream,
-        Statistics,
-    },
+use datafusion::arrow::array::UInt64Array;
+use datafusion::arrow::datatypes::{Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::context::TaskContext;
+use datafusion::physical_expr::PhysicalSortExpr;
+use datafusion::physical_plan::memory::MemoryStream;
+use datafusion::physical_plan::metrics::{
+    self, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
+};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayFormatType, Distribution, ExecutionPlan, Partitioning, SendableRecordBatchStream,
+    Statistics,
 };
 use futures::TryStreamExt;
 use spi::query::AFFECTED_ROWS;
-use std::{any::Any, fmt::Debug, sync::Arc};
-
-use datafusion::error::Result;
 use trace::debug;
 
 use crate::data_source::{RecordBatchSink, RecordBatchSinkProvider, SinkMetadata};

--- a/query_server/query/src/extension/physical/plan_node/tag_scan.rs
+++ b/query_server/query/src/extension/physical/plan_node/tag_scan.rs
@@ -1,34 +1,29 @@
-use std::{
-    any::Any,
-    fmt::{Display, Formatter},
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-};
+use std::any::Any;
+use std::fmt::{Display, Formatter};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use coordinator::service::CoordinatorRef;
-use datafusion::error::DataFusionError;
-use datafusion::{
-    arrow::{array::ArrayBuilder, datatypes::SchemaRef, record_batch::RecordBatch},
-    arrow::{array::ArrayRef, error::Result as ArrowResult},
-    error::Result,
-    execution::context::TaskContext,
-    physical_expr::PhysicalSortExpr,
-    physical_plan::{
-        metrics::{BaselineMetrics, ExecutionPlanMetricsSet},
-        DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
-        SendableRecordBatchStream, Statistics,
-    },
+use datafusion::arrow::array::{ArrayBuilder, ArrayRef};
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::error::Result as ArrowResult;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::context::TaskContext;
+use datafusion::physical_expr::PhysicalSortExpr;
+use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet};
+use datafusion::physical_plan::{
+    DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream, SendableRecordBatchStream,
+    Statistics,
 };
-use futures::{executor::block_on, Stream};
+use futures::executor::block_on;
+use futures::Stream;
 use meta::error::MetaError;
-use models::arrow_array::WriteArrow;
-use models::{
-    arrow_array::build_arrow_array_builders,
-    predicate::domain::{ColumnDomains, PredicateRef},
-    schema::{ColumnType, TskvTableSchemaRef},
-    SeriesKey, TagValue,
-};
+use models::arrow_array::{build_arrow_array_builders, WriteArrow};
+use models::predicate::domain::{ColumnDomains, PredicateRef};
+use models::schema::{ColumnType, TskvTableSchemaRef};
+use models::{SeriesKey, TagValue};
 use spi::QueryError;
 use trace::debug;
 

--- a/query_server/query/src/extension/physical/transform_rule/table_writer.rs
+++ b/query_server/query/src/extension/physical/transform_rule/table_writer.rs
@@ -1,21 +1,18 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::{
-    datasource::source_as_provider,
-    execution::context::SessionState,
-    logical_expr::{LogicalPlan, UserDefinedLogicalNode},
-    physical_plan::{displayable, planner::ExtensionPlanner, ExecutionPlan, PhysicalPlanner},
-};
-use trace::debug;
-use trace::trace;
-
-use crate::{
-    data_source::WriteExecExt,
-    extension::logical::plan_node::table_writer::{as_table_writer_plan_node, TableWriterPlanNode},
-};
-
+use datafusion::datasource::source_as_provider;
 use datafusion::error::Result;
+use datafusion::execution::context::SessionState;
+use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
+use datafusion::physical_plan::planner::ExtensionPlanner;
+use datafusion::physical_plan::{displayable, ExecutionPlan, PhysicalPlanner};
+use trace::{debug, trace};
+
+use crate::data_source::WriteExecExt;
+use crate::extension::logical::plan_node::table_writer::{
+    as_table_writer_plan_node, TableWriterPlanNode,
+};
 
 /// Physical planner for TableWriter nodes
 pub struct TableWriterPlanner {}

--- a/query_server/query/src/extension/physical/transform_rule/tag_scan.rs
+++ b/query_server/query/src/extension/physical/transform_rule/tag_scan.rs
@@ -1,15 +1,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::{
-    execution::context::SessionState,
-    logical_expr::{LogicalPlan, UserDefinedLogicalNode},
-    physical_plan::{planner::ExtensionPlanner, ExecutionPlan, PhysicalPlanner},
-};
+use datafusion::error::Result;
+use datafusion::execution::context::SessionState;
+use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
+use datafusion::physical_plan::planner::ExtensionPlanner;
+use datafusion::physical_plan::{ExecutionPlan, PhysicalPlanner};
 
 use crate::extension::logical::plan_node::tag_scan::TagScanPlanNode;
-
-use datafusion::error::Result;
 
 /// Physical planner for TopK nodes
 pub struct TagScanPlanner {}

--- a/query_server/query/src/function/simple_func_manager.rs
+++ b/query_server/query/src/function/simple_func_manager.rs
@@ -1,10 +1,9 @@
-use std::collections::HashSet;
-use std::{collections::HashMap, sync::Arc};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use datafusion::logical_expr::{AggregateUDF, ScalarUDF};
 use spi::query::function::*;
-use spi::QueryError;
-use spi::Result;
+use spi::{QueryError, Result};
 
 #[derive(Debug, Default)]
 pub struct SimpleFunctionMetadataManager {

--- a/query_server/query/src/instance.rs
+++ b/query_server/query/src/instance.rs
@@ -1,40 +1,28 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use derive_builder::Builder;
-use snafu::ResultExt;
-
 use coordinator::service::CoordinatorRef;
+use derive_builder::Builder;
 use meta::error::MetaError;
-use models::schema::{DatabaseSchema, DEFAULT_CATALOG, DEFAULT_DATABASE};
-use models::{
-    auth::{
-        role::{SystemTenantRole, TenantRoleIdentifier},
-        user::{User, UserInfo, UserOptionsBuilder, ROOT},
-    },
-    oid::Identifier,
-    schema::TenantOptionsBuilder,
-};
-use spi::AuthSnafu;
-use spi::Result;
-use spi::{
-    query::{
-        auth::AccessControlRef, dispatcher::QueryDispatcher, session::IsiphoSessionCtxFactory,
-    },
-    server::dbms::DatabaseManagerSystem,
-    service::protocol::{Query, QueryHandle, QueryId},
-    QueryError,
-};
+use models::auth::role::{SystemTenantRole, TenantRoleIdentifier};
+use models::auth::user::{User, UserInfo, UserOptionsBuilder, ROOT};
+use models::oid::Identifier;
+use models::schema::{DatabaseSchema, TenantOptionsBuilder, DEFAULT_CATALOG, DEFAULT_DATABASE};
+use snafu::ResultExt;
+use spi::query::auth::AccessControlRef;
+use spi::query::dispatcher::QueryDispatcher;
+use spi::query::session::IsiphoSessionCtxFactory;
+use spi::server::dbms::DatabaseManagerSystem;
+use spi::service::protocol::{Query, QueryHandle, QueryId};
+use spi::{AuthSnafu, QueryError, Result};
 use trace::{debug, info};
 use tskv::kv_option::Options;
 
+use crate::auth::auth_control::{AccessControlImpl, AccessControlNoCheck};
 use crate::dispatcher::manager::SimpleQueryDispatcherBuilder;
+use crate::execution::scheduler::LocalScheduler;
 use crate::sql::optimizer::CascadeOptimizerBuilder;
 use crate::sql::parser::DefaultParser;
-use crate::{
-    auth::auth_control::{AccessControlImpl, AccessControlNoCheck},
-    execution::scheduler::LocalScheduler,
-};
 
 #[derive(Builder)]
 pub struct Cnosdbms<D> {
@@ -227,10 +215,10 @@ mod tests {
     use std::ops::DerefMut;
 
     use chrono::Utc;
-    use datafusion::arrow::{record_batch::RecordBatch, util::pretty::pretty_format_batches};
-
     use config::get_config;
     use coordinator::service::MockCoordinator;
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::arrow::util::pretty::pretty_format_batches;
     use models::auth::user::UserInfo;
     use models::schema::DEFAULT_CATALOG;
     use spi::service::protocol::ContextBuilder;

--- a/query_server/query/src/metadata/cluster_schema_provider/builder/tenants.rs
+++ b/query_server/query/src/metadata/cluster_schema_provider/builder/tenants.rs
@@ -1,15 +1,10 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::{
-        array::StringBuilder,
-        datatypes::{DataType, Field, Schema, SchemaRef},
-        record_batch::RecordBatch,
-    },
-    datasource::MemTable,
-    error::DataFusionError,
-};
-
+use datafusion::arrow::array::StringBuilder;
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use datafusion::error::DataFusionError;
 use lazy_static::lazy_static;
 
 lazy_static! {

--- a/query_server/query/src/metadata/cluster_schema_provider/builder/users.rs
+++ b/query_server/query/src/metadata/cluster_schema_provider/builder/users.rs
@@ -1,15 +1,10 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::{
-        array::{BooleanBuilder, StringBuilder},
-        datatypes::{DataType, Field, Schema, SchemaRef},
-        record_batch::RecordBatch,
-    },
-    datasource::MemTable,
-    error::DataFusionError,
-};
-
+use datafusion::arrow::array::{BooleanBuilder, StringBuilder};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use datafusion::error::DataFusionError;
 use lazy_static::lazy_static;
 
 lazy_static! {

--- a/query_server/query/src/metadata/cluster_schema_provider/factory/tenants.rs
+++ b/query_server/query/src/metadata/cluster_schema_provider/factory/tenants.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
 use datafusion::datasource::MemTable;
-use meta::{error::MetaError, MetaRef};
-use models::{auth::user::User, oid::Identifier};
+use meta::error::MetaError;
+use meta::MetaRef;
+use models::auth::user::User;
+use models::oid::Identifier;
 
-use crate::metadata::cluster_schema_provider::{
-    builder::tenants::ClusterSchemaTenantsBuilder, ClusterSchemaTableFactory,
-};
+use crate::metadata::cluster_schema_provider::builder::tenants::ClusterSchemaTenantsBuilder;
+use crate::metadata::cluster_schema_provider::ClusterSchemaTableFactory;
 
 const INFORMATION_SCHEMA_TENANTS: &str = "TENANTS";
 

--- a/query_server/query/src/metadata/cluster_schema_provider/factory/users.rs
+++ b/query_server/query/src/metadata/cluster_schema_provider/factory/users.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
 use datafusion::datasource::MemTable;
-use meta::{error::MetaError, MetaRef};
-use models::{auth::user::User, oid::Identifier};
+use meta::error::MetaError;
+use meta::MetaRef;
+use models::auth::user::User;
+use models::oid::Identifier;
 
-use crate::metadata::cluster_schema_provider::{
-    builder::users::ClusterSchemaUsersBuilder, ClusterSchemaTableFactory,
-};
+use crate::metadata::cluster_schema_provider::builder::users::ClusterSchemaUsersBuilder;
+use crate::metadata::cluster_schema_provider::ClusterSchemaTableFactory;
 
 const INFORMATION_SCHEMA_USERS: &str = "USERS";
 

--- a/query_server/query/src/metadata/cluster_schema_provider/mod.rs
+++ b/query_server/query/src/metadata/cluster_schema_provider/mod.rs
@@ -1,15 +1,17 @@
 mod builder;
 mod factory;
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use datafusion::datasource::MemTable;
-use meta::{error::MetaError, MetaRef};
+use meta::error::MetaError;
+use meta::MetaRef;
 use models::auth::user::User;
 
-use self::factory::{tenants::ClusterSchemaTenantsFactory, users::ClusterSchemaUsersFactory};
-
+use self::factory::tenants::ClusterSchemaTenantsFactory;
+use self::factory::users::ClusterSchemaUsersFactory;
 use super::CLUSTER_SCHEMA;
 
 pub struct ClusterSchemaProvider {

--- a/query_server/query/src/metadata/information_schema_provider/builder/columns.rs
+++ b/query_server/query/src/metadata/information_schema_provider/builder/columns.rs
@@ -1,15 +1,10 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::{
-        array::{BooleanBuilder, StringBuilder, UInt64Builder},
-        datatypes::{DataType, Field, Schema, SchemaRef},
-        record_batch::RecordBatch,
-    },
-    datasource::MemTable,
-    error::DataFusionError,
-};
-
+use datafusion::arrow::array::{BooleanBuilder, StringBuilder, UInt64Builder};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use datafusion::error::DataFusionError;
 use lazy_static::lazy_static;
 
 lazy_static! {

--- a/query_server/query/src/metadata/information_schema_provider/builder/database_privileges.rs
+++ b/query_server/query/src/metadata/information_schema_provider/builder/database_privileges.rs
@@ -1,15 +1,10 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::{
-        array::StringBuilder,
-        datatypes::{DataType, Field, Schema, SchemaRef},
-        record_batch::RecordBatch,
-    },
-    datasource::MemTable,
-    error::DataFusionError,
-};
-
+use datafusion::arrow::array::StringBuilder;
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use datafusion::error::DataFusionError;
 use lazy_static::lazy_static;
 
 lazy_static! {

--- a/query_server/query/src/metadata/information_schema_provider/builder/databases.rs
+++ b/query_server/query/src/metadata/information_schema_provider/builder/databases.rs
@@ -1,15 +1,10 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::{
-        array::{StringBuilder, UInt64Builder},
-        datatypes::{DataType, Field, Schema, SchemaRef},
-        record_batch::RecordBatch,
-    },
-    datasource::MemTable,
-    error::DataFusionError,
-};
-
+use datafusion::arrow::array::{StringBuilder, UInt64Builder};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use datafusion::error::DataFusionError;
 use lazy_static::lazy_static;
 
 lazy_static! {

--- a/query_server/query/src/metadata/information_schema_provider/builder/enabled_roles.rs
+++ b/query_server/query/src/metadata/information_schema_provider/builder/enabled_roles.rs
@@ -1,15 +1,10 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::{
-        array::StringBuilder,
-        datatypes::{DataType, Field, Schema, SchemaRef},
-        record_batch::RecordBatch,
-    },
-    datasource::MemTable,
-    error::DataFusionError,
-};
-
+use datafusion::arrow::array::StringBuilder;
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use datafusion::error::DataFusionError;
 use lazy_static::lazy_static;
 
 lazy_static! {

--- a/query_server/query/src/metadata/information_schema_provider/builder/members.rs
+++ b/query_server/query/src/metadata/information_schema_provider/builder/members.rs
@@ -1,15 +1,10 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::{
-        array::StringBuilder,
-        datatypes::{DataType, Field, Schema, SchemaRef},
-        record_batch::RecordBatch,
-    },
-    datasource::MemTable,
-    error::DataFusionError,
-};
-
+use datafusion::arrow::array::StringBuilder;
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use datafusion::error::DataFusionError;
 use lazy_static::lazy_static;
 
 lazy_static! {

--- a/query_server/query/src/metadata/information_schema_provider/builder/queries.rs
+++ b/query_server/query/src/metadata/information_schema_provider/builder/queries.rs
@@ -1,15 +1,10 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::{
-        array::{Float64Builder, StringBuilder},
-        datatypes::{DataType, Field, Schema, SchemaRef},
-        record_batch::RecordBatch,
-    },
-    datasource::MemTable,
-    error::DataFusionError,
-};
-
+use datafusion::arrow::array::{Float64Builder, StringBuilder};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use datafusion::error::DataFusionError;
 use lazy_static::lazy_static;
 
 lazy_static! {

--- a/query_server/query/src/metadata/information_schema_provider/builder/roles.rs
+++ b/query_server/query/src/metadata/information_schema_provider/builder/roles.rs
@@ -1,15 +1,10 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::{
-        array::StringBuilder,
-        datatypes::{DataType, Field, Schema, SchemaRef},
-        record_batch::RecordBatch,
-    },
-    datasource::MemTable,
-    error::DataFusionError,
-};
-
+use datafusion::arrow::array::StringBuilder;
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use datafusion::error::DataFusionError;
 use lazy_static::lazy_static;
 
 lazy_static! {

--- a/query_server/query/src/metadata/information_schema_provider/builder/tables.rs
+++ b/query_server/query/src/metadata/information_schema_provider/builder/tables.rs
@@ -1,16 +1,11 @@
 use std::sync::Arc;
 
-use datafusion::{
-    arrow::{
-        array::StringBuilder,
-        datatypes::{DataType, Field, Schema, SchemaRef},
-        record_batch::RecordBatch,
-    },
-    datasource::MemTable,
-    error::DataFusionError,
-    logical_expr::TableType,
-};
-
+use datafusion::arrow::array::StringBuilder;
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use datafusion::error::DataFusionError;
+use datafusion::logical_expr::TableType;
 use lazy_static::lazy_static;
 
 lazy_static! {

--- a/query_server/query/src/metadata/information_schema_provider/factory/columns.rs
+++ b/query_server/query/src/metadata/information_schema_provider/factory/columns.rs
@@ -1,20 +1,16 @@
 use std::sync::Arc;
 
 use datafusion::datasource::MemTable;
-use meta::{error::MetaError, MetaClientRef};
-use models::{
-    auth::user::User,
-    oid::Identifier,
-    schema::{ColumnType, ExternalTableSchema, TableSchema, TskvTableSchema},
-    ValueType,
-};
+use meta::error::MetaError;
+use meta::MetaClientRef;
+use models::auth::user::User;
+use models::oid::Identifier;
+use models::schema::{ColumnType, ExternalTableSchema, TableSchema, TskvTableSchema};
+use models::ValueType;
 
-use crate::{
-    dispatcher::query_tracker::QueryTracker,
-    metadata::information_schema_provider::{
-        builder::columns::InformationSchemaColumnsBuilder, InformationSchemaTableFactory,
-    },
-};
+use crate::dispatcher::query_tracker::QueryTracker;
+use crate::metadata::information_schema_provider::builder::columns::InformationSchemaColumnsBuilder;
+use crate::metadata::information_schema_provider::InformationSchemaTableFactory;
 
 const INFORMATION_SCHEMA_COLUMNS: &str = "COLUMNS";
 

--- a/query_server/query/src/metadata/information_schema_provider/factory/database_privileges.rs
+++ b/query_server/query/src/metadata/information_schema_provider/factory/database_privileges.rs
@@ -1,20 +1,16 @@
 use std::sync::Arc;
 
 use datafusion::datasource::MemTable;
-use meta::{error::MetaError, MetaClientRef};
-use models::{
-    auth::{role::TenantRoleIdentifier, user::User},
-    oid::Identifier,
-};
+use meta::error::MetaError;
+use meta::MetaClientRef;
+use models::auth::role::TenantRoleIdentifier;
+use models::auth::user::User;
+use models::oid::Identifier;
 use trace::error;
 
-use crate::{
-    dispatcher::query_tracker::QueryTracker,
-    metadata::information_schema_provider::{
-        builder::database_privileges::InformationSchemaDatabasePrivilegesBuilder,
-        InformationSchemaTableFactory,
-    },
-};
+use crate::dispatcher::query_tracker::QueryTracker;
+use crate::metadata::information_schema_provider::builder::database_privileges::InformationSchemaDatabasePrivilegesBuilder;
+use crate::metadata::information_schema_provider::InformationSchemaTableFactory;
 
 const INFORMATION_SCHEMA_DATABASE_PRIVILEGES: &str = "DATABASE_PRIVILEGES";
 

--- a/query_server/query/src/metadata/information_schema_provider/factory/databases.rs
+++ b/query_server/query/src/metadata/information_schema_provider/factory/databases.rs
@@ -1,15 +1,14 @@
 use std::sync::Arc;
 
 use datafusion::datasource::MemTable;
-use meta::{error::MetaError, MetaClientRef};
-use models::{auth::user::User, oid::Identifier};
+use meta::error::MetaError;
+use meta::MetaClientRef;
+use models::auth::user::User;
+use models::oid::Identifier;
 
-use crate::{
-    dispatcher::query_tracker::QueryTracker,
-    metadata::information_schema_provider::{
-        builder::databases::InformationSchemaDatabasesBuilder, InformationSchemaTableFactory,
-    },
-};
+use crate::dispatcher::query_tracker::QueryTracker;
+use crate::metadata::information_schema_provider::builder::databases::InformationSchemaDatabasesBuilder;
+use crate::metadata::information_schema_provider::InformationSchemaTableFactory;
 
 const INFORMATION_SCHEMA_DATABASES: &str = "DATABASES";
 

--- a/query_server/query/src/metadata/information_schema_provider/factory/enabled_roles.rs
+++ b/query_server/query/src/metadata/information_schema_provider/factory/enabled_roles.rs
@@ -1,15 +1,14 @@
 use std::sync::Arc;
 
 use datafusion::datasource::MemTable;
-use meta::{error::MetaError, MetaClientRef};
-use models::{auth::user::User, oid::Identifier};
+use meta::error::MetaError;
+use meta::MetaClientRef;
+use models::auth::user::User;
+use models::oid::Identifier;
 
-use crate::{
-    dispatcher::query_tracker::QueryTracker,
-    metadata::information_schema_provider::{
-        builder::enabled_roles::InformationSchemaEnabledRolesBuilder, InformationSchemaTableFactory,
-    },
-};
+use crate::dispatcher::query_tracker::QueryTracker;
+use crate::metadata::information_schema_provider::builder::enabled_roles::InformationSchemaEnabledRolesBuilder;
+use crate::metadata::information_schema_provider::InformationSchemaTableFactory;
 
 const INFORMATION_SCHEMA_ENABLED_ROLES: &str = "ENABLED_ROLES";
 

--- a/query_server/query/src/metadata/information_schema_provider/factory/members.rs
+++ b/query_server/query/src/metadata/information_schema_provider/factory/members.rs
@@ -1,15 +1,13 @@
 use std::sync::Arc;
 
 use datafusion::datasource::MemTable;
-use meta::{error::MetaError, MetaClientRef};
+use meta::error::MetaError;
+use meta::MetaClientRef;
 use models::auth::user::User;
 
-use crate::{
-    dispatcher::query_tracker::QueryTracker,
-    metadata::information_schema_provider::{
-        builder::members::InformationSchemaMembersBuilder, InformationSchemaTableFactory,
-    },
-};
+use crate::dispatcher::query_tracker::QueryTracker;
+use crate::metadata::information_schema_provider::builder::members::InformationSchemaMembersBuilder;
+use crate::metadata::information_schema_provider::InformationSchemaTableFactory;
 
 const INFORMATION_SCHEMA_MEMBERS: &str = "MEMBERS";
 

--- a/query_server/query/src/metadata/information_schema_provider/factory/queries.rs
+++ b/query_server/query/src/metadata/information_schema_provider/factory/queries.rs
@@ -1,15 +1,14 @@
 use std::sync::Arc;
 
 use datafusion::datasource::MemTable;
-use meta::{error::MetaError, MetaClientRef};
-use models::{auth::user::User, oid::Identifier};
+use meta::error::MetaError;
+use meta::MetaClientRef;
+use models::auth::user::User;
+use models::oid::Identifier;
 
-use crate::{
-    dispatcher::query_tracker::QueryTracker,
-    metadata::information_schema_provider::{
-        builder::queries::InformationSchemaQueriesBuilder, InformationSchemaTableFactory,
-    },
-};
+use crate::dispatcher::query_tracker::QueryTracker;
+use crate::metadata::information_schema_provider::builder::queries::InformationSchemaQueriesBuilder;
+use crate::metadata::information_schema_provider::InformationSchemaTableFactory;
 
 const INFORMATION_SCHEMA_QUERIES: &str = "QUERIES";
 

--- a/query_server/query/src/metadata/information_schema_provider/factory/roles.rs
+++ b/query_server/query/src/metadata/information_schema_provider/factory/roles.rs
@@ -1,18 +1,15 @@
 use std::sync::Arc;
 
 use datafusion::datasource::MemTable;
-use meta::{error::MetaError, MetaClientRef};
-use models::{
-    auth::{role::SystemTenantRole, user::User},
-    oid::Identifier,
-};
+use meta::error::MetaError;
+use meta::MetaClientRef;
+use models::auth::role::SystemTenantRole;
+use models::auth::user::User;
+use models::oid::Identifier;
 
-use crate::{
-    dispatcher::query_tracker::QueryTracker,
-    metadata::information_schema_provider::{
-        builder::roles::InformationSchemaRolesBuilder, InformationSchemaTableFactory,
-    },
-};
+use crate::dispatcher::query_tracker::QueryTracker;
+use crate::metadata::information_schema_provider::builder::roles::InformationSchemaRolesBuilder;
+use crate::metadata::information_schema_provider::InformationSchemaTableFactory;
 
 const INFORMATION_SCHEMA_ROLES: &str = "ROLES";
 

--- a/query_server/query/src/metadata/information_schema_provider/factory/tables.rs
+++ b/query_server/query/src/metadata/information_schema_provider/factory/tables.rs
@@ -1,15 +1,15 @@
 use std::sync::Arc;
 
-use datafusion::{datasource::MemTable, logical_expr::TableType};
-use meta::{error::MetaError, MetaClientRef};
-use models::{auth::user::User, oid::Identifier};
+use datafusion::datasource::MemTable;
+use datafusion::logical_expr::TableType;
+use meta::error::MetaError;
+use meta::MetaClientRef;
+use models::auth::user::User;
+use models::oid::Identifier;
 
-use crate::{
-    dispatcher::query_tracker::QueryTracker,
-    metadata::information_schema_provider::{
-        builder::tables::InformationSchemaTablesBuilder, InformationSchemaTableFactory,
-    },
-};
+use crate::dispatcher::query_tracker::QueryTracker;
+use crate::metadata::information_schema_provider::builder::tables::InformationSchemaTablesBuilder;
+use crate::metadata::information_schema_provider::InformationSchemaTableFactory;
 
 const INFORMATION_SCHEMA_TABLES: &str = "TABLES";
 

--- a/query_server/query/src/metadata/information_schema_provider/mod.rs
+++ b/query_server/query/src/metadata/information_schema_provider/mod.rs
@@ -1,22 +1,25 @@
 mod builder;
 mod factory;
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use datafusion::datasource::MemTable;
-use meta::{error::MetaError, MetaClientRef};
+use meta::error::MetaError;
+use meta::MetaClientRef;
 use models::auth::user::User;
 
-use crate::dispatcher::query_tracker::QueryTracker;
-
-use self::factory::{
-    columns::ColumnsFactory, database_privileges::DatabasePrivilegesFactory,
-    databases::DatabasesFactory, enabled_roles::EnabledRolesFactory, members::MembersFactory,
-    queries::QueriesFactory, roles::RolesFactory, tables::TablesFactory,
-};
-
+use self::factory::columns::ColumnsFactory;
+use self::factory::database_privileges::DatabasePrivilegesFactory;
+use self::factory::databases::DatabasesFactory;
+use self::factory::enabled_roles::EnabledRolesFactory;
+use self::factory::members::MembersFactory;
+use self::factory::queries::QueriesFactory;
+use self::factory::roles::RolesFactory;
+use self::factory::tables::TablesFactory;
 use super::INFORMATION_SCHEMA;
+use crate::dispatcher::query_tracker::QueryTracker;
 
 pub struct InformationSchemaProvider {
     query_tracker: Arc<QueryTracker>,

--- a/query_server/query/src/metadata/mod.rs
+++ b/query_server/query/src/metadata/mod.rs
@@ -1,38 +1,32 @@
 mod cluster_schema_provider;
 mod information_schema_provider;
 
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use coordinator::service::CoordinatorRef;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::config::ConfigOptions;
-use datafusion::sql::ResolvedTableReference;
-use datafusion::{
-    error::DataFusionError,
-    logical_expr::{AggregateUDF, ScalarUDF, TableSource},
-    sql::{planner::ContextProvider, TableReference},
-};
-
+use datafusion::datasource::listing::{ListingTable, ListingTableConfig, ListingTableUrl};
+use datafusion::datasource::provider_as_source;
+use datafusion::error::DataFusionError;
+use datafusion::logical_expr::{AggregateUDF, ScalarUDF, TableSource};
+use datafusion::sql::planner::ContextProvider;
+use datafusion::sql::{ResolvedTableReference, TableReference};
+use meta::error::MetaError;
 use meta::MetaClientRef;
 use models::auth::user::UserDesc;
 use models::schema::{TableSchema, TableSourceAdapter, Tenant, DEFAULT_CATALOG};
-
 use parking_lot::RwLock;
-use spi::query::session::IsiphoSessionCtx;
-
-use crate::dispatcher::query_tracker::QueryTracker;
-use crate::table::ClusterTable;
-use datafusion::datasource::listing::{ListingTable, ListingTableConfig, ListingTableUrl};
-use datafusion::datasource::provider_as_source;
-
-use meta::error::MetaError;
 use spi::query::function::FuncMetaManagerRef;
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
-
-use crate::function::simple_func_manager::SimpleFunctionMetadataManager;
+use spi::query::session::IsiphoSessionCtx;
 
 use self::cluster_schema_provider::ClusterSchemaProvider;
 use self::information_schema_provider::InformationSchemaProvider;
+use crate::dispatcher::query_tracker::QueryTracker;
+use crate::function::simple_func_manager::SimpleFunctionMetadataManager;
+use crate::table::ClusterTable;
 
 pub const CLUSTER_SCHEMA: &str = "CLUSTER_SCHEMA";
 pub const INFORMATION_SCHEMA: &str = "INFORMATION_SCHEMA";

--- a/query_server/query/src/prom/remote_server.rs
+++ b/query_server/query/src/prom/remote_server.rs
@@ -4,13 +4,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use coordinator::service::CoordinatorRef;
 use datafusion::arrow::datatypes::ToByteSlice;
 use flatbuffers::FlatBufferBuilder;
-use regex::Regex;
-use snap::raw::{decompress_len, max_compress_len, Decoder, Encoder};
-use snap::Result as SnapResult;
-
-use coordinator::service::CoordinatorRef;
 use line_protocol::{line_to_point, FieldValue, Line};
 use meta::error::MetaError;
 use meta::{MetaClientRef, MetaRef};
@@ -24,12 +20,13 @@ use protos::prompb::remote::{
 };
 use protos::prompb::types::label_matcher::Type;
 use protos::prompb::types::TimeSeries;
-use spi::service::protocol::{Query, QueryHandle};
-use spi::{
-    server::{dbms::DBMSRef, prom::PromRemoteServer},
-    service::protocol::Context,
-    QueryError, Result,
-};
+use regex::Regex;
+use snap::raw::{decompress_len, max_compress_len, Decoder, Encoder};
+use snap::Result as SnapResult;
+use spi::server::dbms::DBMSRef;
+use spi::server::prom::PromRemoteServer;
+use spi::service::protocol::{Context, Query, QueryHandle};
+use spi::{QueryError, Result};
 use trace::{debug, warn};
 
 use super::time_series::writer::WriterBuilder;
@@ -409,23 +406,17 @@ impl SnappyCodec {
 
 #[cfg(test)]
 mod test {
-    use std::{sync::Arc, vec};
+    use std::sync::Arc;
+    use std::vec;
 
-    use datafusion::{
-        arrow::{
-            array::{Float64Array, StringArray, TimestampNanosecondArray},
-            datatypes::{DataType, Field, Schema, TimeUnit},
-            record_batch::RecordBatch,
-        },
-        from_slice::FromSlice,
-    };
-
+    use datafusion::arrow::array::{Float64Array, StringArray, TimestampNanosecondArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::from_slice::FromSlice;
     use models::auth::user::{User, UserDesc, UserOptions};
     use protos::prompb::types::{Label, Sample, TimeSeries};
-    use spi::{
-        query::execution::Output,
-        service::protocol::{ContextBuilder, Query, QueryHandle, QueryId},
-    };
+    use spi::query::execution::Output;
+    use spi::service::protocol::{ContextBuilder, Query, QueryHandle, QueryId};
 
     use crate::prom::remote_server::transform_time_series;
 

--- a/query_server/query/src/prom/time_series/writer.rs
+++ b/query_server/query/src/prom/time_series/writer.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use datafusion::arrow::array::{ArrayRef, PrimitiveArray, StringArray};
 use datafusion::arrow::datatypes::{
     DataType, Float16Type, Float32Type, Float64Type, SchemaRef, TimeUnit, TimestampMicrosecondType,
@@ -6,9 +8,7 @@ use datafusion::arrow::datatypes::{
 use datafusion::arrow::record_batch::RecordBatch;
 use models::schema::TIME_FIELD_NAME;
 use protos::prompb::types::{Label, Sample, TimeSeries};
-use spi::QueryError;
-use spi::Result;
-use std::collections::HashMap;
+use spi::{QueryError, Result};
 use trace::debug;
 
 use crate::prom::METRIC_SAMPLE_COLUMN_NAME;

--- a/query_server/query/src/sql/logical/optimizer.rs
+++ b/query_server/query/src/sql/logical/optimizer.rs
@@ -1,32 +1,35 @@
 use std::sync::Arc;
 
-use datafusion::{
-    logical_expr::LogicalPlan,
-    optimizer::{
-        common_subexpr_eliminate::CommonSubexprEliminate,
-        decorrelate_where_exists::DecorrelateWhereExists, decorrelate_where_in::DecorrelateWhereIn,
-        eliminate_cross_join::EliminateCrossJoin, eliminate_filter::EliminateFilter,
-        eliminate_limit::EliminateLimit, eliminate_outer_join::EliminateOuterJoin,
-        extract_equijoin_predicate::ExtractEquijoinPredicate,
-        filter_null_join_keys::FilterNullJoinKeys, inline_table_scan::InlineTableScan,
-        propagate_empty_relation::PropagateEmptyRelation, push_down_filter::PushDownFilter,
-        push_down_limit::PushDownLimit, rewrite_disjunctive_predicate::RewriteDisjunctivePredicate,
-        scalar_subquery_to_join::ScalarSubqueryToJoin, simplify_expressions::SimplifyExpressions,
-        single_distinct_to_groupby::SingleDistinctToGroupBy, type_coercion::TypeCoercion,
-        unwrap_cast_in_comparison::UnwrapCastInComparison, OptimizerRule,
-    },
-};
-
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::optimizer::common_subexpr_eliminate::CommonSubexprEliminate;
+use datafusion::optimizer::decorrelate_where_exists::DecorrelateWhereExists;
+use datafusion::optimizer::decorrelate_where_in::DecorrelateWhereIn;
+use datafusion::optimizer::eliminate_cross_join::EliminateCrossJoin;
+use datafusion::optimizer::eliminate_filter::EliminateFilter;
+use datafusion::optimizer::eliminate_limit::EliminateLimit;
+use datafusion::optimizer::eliminate_outer_join::EliminateOuterJoin;
+use datafusion::optimizer::extract_equijoin_predicate::ExtractEquijoinPredicate;
+use datafusion::optimizer::filter_null_join_keys::FilterNullJoinKeys;
+use datafusion::optimizer::inline_table_scan::InlineTableScan;
+use datafusion::optimizer::propagate_empty_relation::PropagateEmptyRelation;
+use datafusion::optimizer::push_down_filter::PushDownFilter;
+use datafusion::optimizer::push_down_limit::PushDownLimit;
+use datafusion::optimizer::rewrite_disjunctive_predicate::RewriteDisjunctivePredicate;
+use datafusion::optimizer::scalar_subquery_to_join::ScalarSubqueryToJoin;
+use datafusion::optimizer::simplify_expressions::SimplifyExpressions;
+use datafusion::optimizer::single_distinct_to_groupby::SingleDistinctToGroupBy;
+use datafusion::optimizer::type_coercion::TypeCoercion;
+use datafusion::optimizer::unwrap_cast_in_comparison::UnwrapCastInComparison;
+use datafusion::optimizer::OptimizerRule;
 use spi::query::session::IsiphoSessionCtx;
 use spi::Result;
 
-use crate::extension::logical::optimizer_rule::{
-    implicit_type_conversion::ImplicitTypeConversion,
-    push_down_projection::PushDownProjectionAdapter, reject_cross_join::RejectCrossJoin,
-    rewrite_tag_scan::RewriteTagScan,
-    transform_bottom_func_to_topk_node::TransformBottomFuncToTopkNodeRule,
-    transform_topk_func_to_topk_node::TransformTopkFuncToTopkNodeRule,
-};
+use crate::extension::logical::optimizer_rule::implicit_type_conversion::ImplicitTypeConversion;
+use crate::extension::logical::optimizer_rule::push_down_projection::PushDownProjectionAdapter;
+use crate::extension::logical::optimizer_rule::reject_cross_join::RejectCrossJoin;
+use crate::extension::logical::optimizer_rule::rewrite_tag_scan::RewriteTagScan;
+use crate::extension::logical::optimizer_rule::transform_bottom_func_to_topk_node::TransformBottomFuncToTopkNodeRule;
+use crate::extension::logical::optimizer_rule::transform_topk_func_to_topk_node::TransformTopkFuncToTopkNodeRule;
 
 pub trait LogicalOptimizer: Send + Sync {
     fn optimize(&self, plan: &LogicalPlan, session: &IsiphoSessionCtx) -> Result<LogicalPlan>;

--- a/query_server/query/src/sql/logical/planner.rs
+++ b/query_server/query/src/sql/logical/planner.rs
@@ -1,22 +1,18 @@
-use crate::sql::planner::SqlPlaner;
 use std::sync::Arc;
 
-use datafusion::{
-    common::DFField,
-    error::DataFusionError,
-    logical_expr::{Extension, LogicalPlan, LogicalPlanBuilder, Projection, TableSource},
-    prelude::{cast, lit, Expr},
-    scalar::ScalarValue,
+use datafusion::common::{DFField, Result as DFResult};
+use datafusion::error::DataFusionError;
+use datafusion::logical_expr::{
+    Extension, LogicalPlan, LogicalPlanBuilder, Projection, TableSource,
 };
-use spi::{
-    query::logical_planner::{affected_row_expr, merge_affected_row_expr},
-    QueryError,
-};
-
-use datafusion::common::Result as DFResult;
+use datafusion::prelude::{cast, lit, Expr};
+use datafusion::scalar::ScalarValue;
+use spi::query::logical_planner::{affected_row_expr, merge_affected_row_expr};
+use spi::QueryError;
 use trace::debug;
 
 use crate::extension::logical::plan_node::table_writer::TableWriterPlanNode;
+use crate::sql::planner::SqlPlaner;
 
 pub type DefaultLogicalPlanner<'a, S> = SqlPlaner<'a, S>;
 

--- a/query_server/query/src/sql/optimizer.rs
+++ b/query_server/query/src/sql/optimizer.rs
@@ -1,18 +1,17 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::physical_plan::displayable;
-use datafusion::{logical_expr::LogicalPlan, physical_plan::ExecutionPlan};
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_plan::{displayable, ExecutionPlan};
+use spi::query::optimizer::Optimizer;
+use spi::query::physical_planner::PhysicalPlanner;
 use spi::query::session::IsiphoSessionCtx;
-use spi::query::{optimizer::Optimizer, physical_planner::PhysicalPlanner};
-
 use spi::Result;
 use trace::debug;
 
-use super::{
-    logical::optimizer::{DefaultLogicalOptimizer, LogicalOptimizer},
-    physical::{optimizer::PhysicalOptimizer, planner::DefaultPhysicalPlanner},
-};
+use super::logical::optimizer::{DefaultLogicalOptimizer, LogicalOptimizer};
+use super::physical::optimizer::PhysicalOptimizer;
+use super::physical::planner::DefaultPhysicalPlanner;
 
 pub struct CascadeOptimizer {
     logical_optimizer: Arc<dyn LogicalOptimizer + Send + Sync>,

--- a/query_server/query/src/sql/parser.rs
+++ b/query_server/query/src/sql/parser.rs
@@ -1,39 +1,28 @@
 use std::collections::VecDeque;
 use std::fmt::Display;
 use std::ops::Not;
-
 use std::str::FromStr;
 
 use datafusion::common::parsers::CompressionTypeVariant;
 use datafusion::sql::parser::CreateExternalTable;
-use datafusion::sql::sqlparser::ast::Expr;
-use datafusion::sql::sqlparser::ast::Ident;
-use datafusion::sql::sqlparser::ast::SqlOption;
-use datafusion::sql::sqlparser::ast::TableFactor;
-use datafusion::sql::sqlparser::ast::{Offset, OrderByExpr};
-use datafusion::sql::sqlparser::parser::IsOptional;
-use datafusion::sql::sqlparser::tokenizer::TokenWithLocation;
-use datafusion::sql::sqlparser::{
-    ast::{DataType, ObjectName},
-    dialect::{keywords::Keyword, Dialect, GenericDialect},
-    parser::{Parser, ParserError},
-    tokenizer::{Token, Tokenizer},
+use datafusion::sql::sqlparser::ast::{
+    DataType, Expr, Ident, ObjectName, Offset, OrderByExpr, SqlOption, TableFactor,
 };
+use datafusion::sql::sqlparser::dialect::keywords::Keyword;
+use datafusion::sql::sqlparser::dialect::{Dialect, GenericDialect};
+use datafusion::sql::sqlparser::parser::{IsOptional, Parser, ParserError};
+use datafusion::sql::sqlparser::tokenizer::{Token, TokenWithLocation, Tokenizer};
 use models::codec::Encoding;
 use models::meta_data::{NodeId, ReplicationSetId, VnodeId};
 use snafu::ResultExt;
 use spi::query::ast;
-use spi::query::ast::CopyIntoLocation;
-use spi::query::ast::CopyIntoTable;
-use spi::query::ast::CopyTarget;
-use spi::query::ast::UriLocation;
 use spi::query::ast::{
     parse_string_value, Action, AlterDatabase, AlterTable, AlterTableAction, AlterTenant,
     AlterTenantOperation, AlterUser, AlterUserOperation, ChecksumGroup, ColumnOption, CompactVnode,
-    CopyVnode, CreateDatabase, CreateRole, CreateTable, CreateTenant, CreateUser, DatabaseOptions,
-    DescribeDatabase, DescribeTable, DropDatabaseObject, DropGlobalObject, DropTenantObject,
-    DropVnode, Explain, ExtStatement, GrantRevoke, MoveVnode, Privilege, ShowSeries, ShowTagBody,
-    ShowTagValues, With,
+    CopyIntoLocation, CopyIntoTable, CopyTarget, CopyVnode, CreateDatabase, CreateRole,
+    CreateTable, CreateTenant, CreateUser, DatabaseOptions, DescribeDatabase, DescribeTable,
+    DropDatabaseObject, DropGlobalObject, DropTenantObject, DropVnode, Explain, ExtStatement,
+    GrantRevoke, MoveVnode, Privilege, ShowSeries, ShowTagBody, ShowTagValues, UriLocation, With,
 };
 use spi::query::logical_planner::{DatabaseObjectType, GlobalObjectType, TenantObjectType};
 use spi::query::parser::Parser as CnosdbParser;
@@ -1459,8 +1448,7 @@ mod tests {
     use datafusion::sql::sqlparser::ast::{
         Ident, ObjectName, SetExpr, Statement, TableFactor, Value,
     };
-    use spi::query::ast::{AlterTable, UriLocation};
-    use spi::query::ast::{DropDatabaseObject, ExtStatement};
+    use spi::query::ast::{AlterTable, DropDatabaseObject, ExtStatement, UriLocation};
     use spi::query::logical_planner::{DatabaseObjectType, TenantObjectType};
 
     use super::*;

--- a/query_server/query/src/sql/physical/optimizer.rs
+++ b/query_server/query/src/sql/physical/optimizer.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use datafusion::{physical_optimizer::PhysicalOptimizerRule, physical_plan::ExecutionPlan};
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::ExecutionPlan;
 use spi::query::session::IsiphoSessionCtx;
 use spi::Result;
 

--- a/query_server/query/src/sql/physical/planner.rs
+++ b/query_server/query/src/sql/physical/planner.rs
@@ -1,29 +1,28 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::{
-    logical_expr::LogicalPlan,
-    physical_optimizer::{
-        aggregate_statistics::AggregateStatistics, coalesce_batches::CoalesceBatches,
-        dist_enforcement::EnforceDistribution, global_sort_selection::GlobalSortSelection,
-        join_selection::JoinSelection, pipeline_checker::PipelineChecker,
-        pipeline_fixer::PipelineFixer, repartition::Repartition, sort_enforcement::EnforceSorting,
-        PhysicalOptimizerRule,
-    },
-    physical_plan::{
-        planner::{DefaultPhysicalPlanner as DFDefaultPhysicalPlanner, ExtensionPlanner},
-        ExecutionPlan, PhysicalPlanner as DFPhysicalPlanner,
-    },
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_optimizer::aggregate_statistics::AggregateStatistics;
+use datafusion::physical_optimizer::coalesce_batches::CoalesceBatches;
+use datafusion::physical_optimizer::dist_enforcement::EnforceDistribution;
+use datafusion::physical_optimizer::global_sort_selection::GlobalSortSelection;
+use datafusion::physical_optimizer::join_selection::JoinSelection;
+use datafusion::physical_optimizer::pipeline_checker::PipelineChecker;
+use datafusion::physical_optimizer::pipeline_fixer::PipelineFixer;
+use datafusion::physical_optimizer::repartition::Repartition;
+use datafusion::physical_optimizer::sort_enforcement::EnforceSorting;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::planner::{
+    DefaultPhysicalPlanner as DFDefaultPhysicalPlanner, ExtensionPlanner,
 };
+use datafusion::physical_plan::{ExecutionPlan, PhysicalPlanner as DFPhysicalPlanner};
 use spi::query::physical_planner::PhysicalPlanner;
 use spi::query::session::IsiphoSessionCtx;
 use spi::Result;
 
-use crate::extension::physical::transform_rule::{
-    table_writer::TableWriterPlanner, tag_scan::TagScanPlanner,
-};
-
 use super::optimizer::PhysicalOptimizer;
+use crate::extension::physical::transform_rule::table_writer::TableWriterPlanner;
+use crate::extension::physical::transform_rule::tag_scan::TagScanPlanner;
 
 pub struct DefaultPhysicalPlanner {
     ext_physical_transform_rules: Vec<Arc<dyn ExtensionPlanner + Send + Sync>>,

--- a/query_server/query/src/stream.rs
+++ b/query_server/query/src/stream.rs
@@ -1,20 +1,16 @@
 #![allow(clippy::too_many_arguments)]
-use coordinator::{reader::ReaderIterator, service::CoordinatorRef};
 use std::task::Poll;
 
-use datafusion::{
-    arrow::{datatypes::SchemaRef, record_batch::RecordBatch},
-    error::DataFusionError,
-    physical_plan::RecordBatchStream,
-};
+use coordinator::reader::ReaderIterator;
+use coordinator::service::CoordinatorRef;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::error::DataFusionError;
+use datafusion::physical_plan::RecordBatchStream;
 use futures::{FutureExt, Stream};
 use models::codec::Encoding;
-use models::schema::TskvTableSchemaRef;
-use models::{
-    predicate::domain::PredicateRef,
-    schema::{ColumnType, TableColumn, TskvTableSchema, TIME_FIELD},
-};
-
+use models::predicate::domain::PredicateRef;
+use models::schema::{ColumnType, TableColumn, TskvTableSchema, TskvTableSchemaRef, TIME_FIELD};
 use spi::{QueryError, Result};
 use tskv::iterator::{QueryOption, TableScanMetrics};
 

--- a/query_server/query/src/table.rs
+++ b/query_server/query/src/table.rs
@@ -1,25 +1,24 @@
-use std::{any::Any, sync::Arc};
+use std::any::Any;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use coordinator::service::CoordinatorRef;
-use datafusion::{
-    arrow::datatypes::SchemaRef,
-    common::DFSchemaRef,
-    datasource::{TableProvider, TableType},
-    error::{DataFusionError, Result},
-    execution::context::SessionState,
-    logical_expr::{Expr, TableProviderFilterPushDown},
-    physical_plan::{project_schema, ExecutionPlan},
-};
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::DFSchemaRef;
+use datafusion::datasource::{TableProvider, TableType};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::context::SessionState;
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use datafusion::physical_plan::{project_schema, ExecutionPlan};
 use meta::error::MetaError;
 use models::predicate::domain::{Predicate, PredicateRef};
 use models::schema::{TskvTableSchema, TskvTableSchemaRef};
 
-use crate::{
-    data_source::{sink::tskv::TskvRecordBatchSinkProvider, WriteExecExt},
-    extension::physical::plan_node::{table_writer::TableWriterExec, tag_scan::TagScanExec},
-    tskv_exec::TskvExec,
-};
+use crate::data_source::sink::tskv::TskvRecordBatchSinkProvider;
+use crate::data_source::WriteExecExt;
+use crate::extension::physical::plan_node::table_writer::TableWriterExec;
+use crate::extension::physical::plan_node::tag_scan::TagScanExec;
+use crate::tskv_exec::TskvExec;
 
 #[derive(Clone)]
 pub struct ClusterTable {

--- a/query_server/query/src/tskv_exec.rs
+++ b/query_server/query/src/tskv_exec.rs
@@ -1,26 +1,22 @@
-use std::{
-    any::Any,
-    fmt::{Display, Formatter},
-    sync::Arc,
-};
+use std::any::Any;
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 
 use coordinator::service::CoordinatorRef;
-use datafusion::{
-    arrow::datatypes::SchemaRef,
-    error::{DataFusionError, Result},
-    execution::context::TaskContext,
-    physical_expr::PhysicalSortExpr,
-    physical_plan::{
-        metrics::ExecutionPlanMetricsSet, DisplayFormatType, ExecutionPlan, Partitioning,
-        SendableRecordBatchStream, Statistics,
-    },
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::context::TaskContext;
+use datafusion::physical_expr::PhysicalSortExpr;
+use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
+use datafusion::physical_plan::{
+    DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
 };
 use models::predicate::domain::PredicateRef;
 use models::schema::TskvTableSchemaRef;
 use trace::debug;
+use tskv::iterator::TableScanMetrics;
 
 use crate::stream::TableScanStream;
-use tskv::iterator::TableScanMetrics;
 
 #[derive(Debug, Clone)]
 pub struct TskvExec {

--- a/query_server/query/src/utils/point_util.rs
+++ b/query_server/query/src/utils/point_util.rs
@@ -1,22 +1,18 @@
-use datafusion::arrow::{
-    array::{
-        Array, ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray,
-        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
-        TimestampSecondArray, UInt64Array,
-    },
-    datatypes::{DataType as ArrowDataType, Field, TimeUnit},
-    record_batch::RecordBatch,
+use datafusion::arrow::array::{
+    Array, ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray,
+    TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+    TimestampSecondArray, UInt64Array,
 };
+use datafusion::arrow::datatypes::{DataType as ArrowDataType, Field, TimeUnit};
+use datafusion::arrow::record_batch::RecordBatch;
 use flatbuffers::{self, FlatBufferBuilder, Vector, WIPOffset};
 use models::schema::{
     is_time_column, ColumnType, TableColumn, TskvTableSchemaRef, TIME_FIELD_NAME,
 };
 use models::ValueType;
 use paste::paste;
-use protos::models::Point;
-use protos::models::{FieldBuilder, FieldType, PointArgs, Points, PointsArgs, TagBuilder};
-use spi::QueryError;
-use spi::Result;
+use protos::models::{FieldBuilder, FieldType, Point, PointArgs, Points, PointsArgs, TagBuilder};
+use spi::{QueryError, Result};
 
 type Datum<'fbb> = WIPOffset<Vector<'fbb, u8>>;
 

--- a/query_server/query/tests/datafusion.rs
+++ b/query_server/query/tests/datafusion.rs
@@ -1,25 +1,24 @@
-use std::{result, sync::Arc, time::Duration};
+use std::result;
+use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
-use datafusion::{
-    arrow::{
-        array::{ArrayRef, Float32Array, Int32Array, StringArray},
-        datatypes::{DataType, Field, Schema, SchemaRef},
-        record_batch::RecordBatch,
-    },
-    common::{DFSchemaRef, DataFusionError, ToDFSchema},
-    datasource::{self, TableProvider},
-    execution::context::{SessionState, TaskContext},
-    logical_expr::TableType,
-    logical_expr::{LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNode},
-    physical_expr::{planner, PhysicalSortExpr},
-    physical_plan::{
-        filter::FilterExec, ExecutionPlan, Partitioning, RecordBatchStream,
-        SendableRecordBatchStream, Statistics,
-    },
-    prelude::*,
-    scalar::ScalarValue,
+use datafusion::arrow::array::{ArrayRef, Float32Array, Int32Array, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::{DFSchemaRef, DataFusionError, ToDFSchema};
+use datafusion::datasource::{self, TableProvider};
+use datafusion::execution::context::{SessionState, TaskContext};
+use datafusion::logical_expr::{
+    LogicalPlan, LogicalPlanBuilder, TableType, UserDefinedLogicalNode,
 };
+use datafusion::physical_expr::{planner, PhysicalSortExpr};
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::{
+    ExecutionPlan, Partitioning, RecordBatchStream, SendableRecordBatchStream, Statistics,
+};
+use datafusion::prelude::*;
+use datafusion::scalar::ScalarValue;
 use futures::Stream;
 use tokio::time;
 

--- a/query_server/spi/src/lib.rs
+++ b/query_server/spi/src/lib.rs
@@ -1,6 +1,5 @@
 use std::error;
 
-use crate::service::protocol::QueryId;
 use coordinator::errors::CoordinatorError;
 use datafusion::arrow::error::ArrowError;
 use datafusion::common::DataFusionError;
@@ -14,6 +13,8 @@ use models::define_result;
 use models::error_code::ErrorCode;
 use models::schema::TIME_FIELD_NAME;
 use snafu::Snafu;
+
+use crate::service::protocol::QueryId;
 
 pub mod query;
 pub mod server;

--- a/query_server/spi/src/query/ast.rs
+++ b/query_server/spi/src/query/ast.rs
@@ -1,11 +1,11 @@
 use std::fmt;
 
+use datafusion::sql::parser::CreateExternalTable;
 use datafusion::sql::sqlparser::ast::{
-    AnalyzeFormat, DataType, Expr, Ident, ObjectName, Offset, OrderByExpr, Value,
+    AnalyzeFormat, DataType, Expr, Ident, ObjectName, Offset, OrderByExpr, SqlOption, Statement,
+    TableFactor, Value,
 };
-use datafusion::sql::sqlparser::ast::{SqlOption, TableFactor};
 use datafusion::sql::sqlparser::parser::ParserError;
-use datafusion::sql::{parser::CreateExternalTable, sqlparser::ast::Statement};
 use models::codec::Encoding;
 use models::meta_data::{NodeId, ReplicationSetId, VnodeId};
 

--- a/query_server/spi/src/query/auth.rs
+++ b/query_server/spi/src/query/auth.rs
@@ -1,13 +1,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use models::{
-    auth::{
-        user::{User, UserInfo},
-        AuthError,
-    },
-    oid::Oid,
-};
+use models::auth::user::{User, UserInfo};
+use models::auth::AuthError;
+use models::oid::Oid;
 
 pub type Result<T> = std::result::Result<T, AuthError>;
 

--- a/query_server/spi/src/query/datasource/mod.rs
+++ b/query_server/spi/src/query/datasource/mod.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
-use object_store::{
-    aws::AmazonS3Builder, azure::MicrosoftAzureBuilder, gcp::GoogleCloudStorageBuilder, path::Path,
-    ObjectStore,
-};
+use object_store::aws::AmazonS3Builder;
+use object_store::azure::MicrosoftAzureBuilder;
+use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::path::Path;
+use object_store::ObjectStore;
 
 use super::logical_planner::ConnectionOptions;
 

--- a/query_server/spi/src/query/dispatcher.rs
+++ b/query_server/spi/src/query/dispatcher.rs
@@ -1,12 +1,12 @@
 use std::time::Duration;
 
-use crate::query::execution::Output;
-use crate::service::protocol::{Query, QueryId};
 use async_trait::async_trait;
 use models::auth::user::UserDesc;
 use models::oid::{Identifier, Oid};
 
 use super::execution::QueryState;
+use crate::query::execution::Output;
+use crate::service::protocol::{Query, QueryId};
 use crate::Result;
 
 #[async_trait]

--- a/query_server/spi/src/query/execution.rs
+++ b/query_server/spi/src/query/execution.rs
@@ -6,13 +6,12 @@ use async_trait::async_trait;
 use coordinator::service::CoordinatorRef;
 use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
-
-use crate::service::protocol::Query;
-use crate::service::protocol::QueryId;
 use meta::MetaRef;
 
 use super::dispatcher::{QueryInfo, QueryStatus};
-use super::{logical_planner::Plan, session::IsiphoSessionCtx};
+use super::logical_planner::Plan;
+use super::session::IsiphoSessionCtx;
+use crate::service::protocol::{Query, QueryId};
 use crate::Result;
 
 #[async_trait]

--- a/query_server/spi/src/query/function.rs
+++ b/query_server/spi/src/query/function.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
+use std::sync::Arc;
 
 use datafusion::logical_expr::{AggregateUDF, ScalarUDF};
 

--- a/query_server/spi/src/query/optimizer.rs
+++ b/query_server/spi/src/query/optimizer.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::{logical_expr::LogicalPlan, physical_plan::ExecutionPlan};
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_plan::ExecutionPlan;
 
 use super::session::IsiphoSessionCtx;
-
 use crate::Result;
 
 #[async_trait]

--- a/query_server/spi/src/query/physical_planner.rs
+++ b/query_server/spi/src/query/physical_planner.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::{
-    logical_expr::LogicalPlan,
-    physical_plan::{planner::ExtensionPlanner, ExecutionPlan},
-};
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_plan::planner::ExtensionPlanner;
+use datafusion::physical_plan::ExecutionPlan;
 
 use super::session::IsiphoSessionCtx;
 use crate::Result;

--- a/query_server/spi/src/query/scheduler.rs
+++ b/query_server/spi/src/query/scheduler.rs
@@ -1,10 +1,8 @@
 use std::sync::Arc;
 
-use datafusion::{
-    common::Result,
-    execution::context::TaskContext,
-    physical_plan::{ExecutionPlan, SendableRecordBatchStream},
-};
+use datafusion::common::Result;
+use datafusion::execution::context::TaskContext;
+use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 
 pub type SchedulerRef = Arc<dyn Scheduler + Send + Sync>;
 

--- a/query_server/spi/src/query/session.rs
+++ b/query_server/spi/src/query/session.rs
@@ -1,8 +1,7 @@
-use datafusion::{
-    execution::context,
-    prelude::{SessionConfig, SessionContext},
-};
-use models::{auth::user::User, oid::Oid};
+use datafusion::execution::context;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use models::auth::user::User;
+use models::oid::Oid;
 
 use crate::service::protocol::Context;
 

--- a/query_server/spi/src/server/dbms.rs
+++ b/query_server/spi/src/server/dbms.rs
@@ -1,24 +1,15 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::{
-    arrow::{
-        array::{Float32Array, Float64Array},
-        datatypes::{DataType, Field, Schema},
-        record_batch::RecordBatch,
-    },
-    from_slice::FromSlice,
-};
-use models::auth::{
-    role::UserRole,
-    user::{User, UserDesc, UserInfo, UserOptionsBuilder},
-};
+use datafusion::arrow::array::{Float32Array, Float64Array};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::from_slice::FromSlice;
+use models::auth::role::UserRole;
+use models::auth::user::{User, UserDesc, UserInfo, UserOptionsBuilder};
 
-use crate::{
-    query::execution::Output,
-    service::protocol::{Query, QueryHandle, QueryId},
-};
-
+use crate::query::execution::Output;
+use crate::service::protocol::{Query, QueryHandle, QueryId};
 use crate::Result;
 
 pub type DBMSRef = Arc<dyn DatabaseManagerSystem + Send + Sync>;

--- a/query_server/spi/src/server/prom.rs
+++ b/query_server/spi/src/server/prom.rs
@@ -5,7 +5,8 @@ use bytes::Bytes;
 use coordinator::service::CoordinatorRef;
 use meta::MetaRef;
 
-use crate::{service::protocol::Context, Result};
+use crate::service::protocol::Context;
+use crate::Result;
 
 pub type PromRemoteServerRef = Arc<dyn PromRemoteServer + Send + Sync>;
 

--- a/query_server/test/src/client.rs
+++ b/query_server/test/src/client.rs
@@ -1,6 +1,6 @@
-use reqwest::{Method, Request};
-use reqwest::{Response, Url};
 use std::time::Duration;
+
+use reqwest::{Method, Request, Response, Url};
 use tokio::time::timeout;
 
 use crate::db_request::{DBRequest, Instruction, LineProtocol, Query};

--- a/query_server/test/src/db_request.rs
+++ b/query_server/test/src/db_request.rs
@@ -1,6 +1,6 @@
-use nom::branch::alt;
 use std::str::FromStr;
 
+use nom::branch::alt;
 use nom::bytes::complete::{tag, tag_no_case};
 use nom::character::complete::{alpha1, alphanumeric1, none_of, space0};
 use nom::combinator::{map_parser, map_res, recognize};

--- a/query_server/test/src/main.rs
+++ b/query_server/test/src/main.rs
@@ -2,10 +2,9 @@ use std::env::current_exe;
 use std::path::PathBuf;
 
 use clap::Parser;
+use groups::TestGroups;
 use lazy_static::lazy_static;
 use reqwest::Url;
-
-use groups::TestGroups;
 
 use crate::client::Client;
 use crate::error::{Error, Result};

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,3 +4,6 @@ edition = "2021"
 ignore = [
      "docs",
 ]
+
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"

--- a/tskv/benches/kvcore_bench.rs
+++ b/tskv/benches/kvcore_bench.rs
@@ -1,13 +1,14 @@
 use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use meta::{meta_manager::RemoteMetaManager, MetaRef};
+use meta::meta_manager::RemoteMetaManager;
+use meta::MetaRef;
 use parking_lot::Mutex;
-
+use protos::kv_service::WritePointsRequest;
+use protos::models_helper;
 use tokio::runtime::{self, Runtime};
-
-use protos::{kv_service::WritePointsRequest, models_helper};
-use tskv::{engine::Engine, TsKv};
+use tskv::engine::Engine;
+use tskv::TsKv;
 
 async fn get_tskv() -> TsKv {
     let mut global_config = config::get_config("../config/config.toml");

--- a/tskv/src/compaction/check.rs
+++ b/tskv/src/compaction/check.rs
@@ -1,24 +1,21 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    fmt::{Display, Write},
-    rc::Rc,
-    sync::Arc,
-};
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::{Display, Write};
+use std::rc::Rc;
+use std::sync::Arc;
 
 use blake3::Hasher;
 use chrono::{Duration, DurationRound, NaiveDateTime};
-use models::{schema::ColumnType, utils, ColumnId, FieldId, Timestamp};
+use models::schema::ColumnType;
+use models::{utils, ColumnId, FieldId, Timestamp};
 use snafu::ResultExt;
 use trace::warn;
 
-use crate::{
-    compaction::{CompactIterator, CompactingBlock},
-    database::Database,
-    error::{self, Error, Result},
-    schema::schemas::DBschemas,
-    tsm::{DataBlock, TsmReader},
-    TimeRange, TseriesFamilyId,
-};
+use crate::compaction::{CompactIterator, CompactingBlock};
+use crate::database::Database;
+use crate::error::{self, Error, Result};
+use crate::schema::schemas::DBschemas;
+use crate::tsm::{DataBlock, TsmReader};
+use crate::{TimeRange, TseriesFamilyId};
 
 pub type Hash = [u8; 32];
 
@@ -425,51 +422,41 @@ async fn read_from_compact_iterator(
 
 #[cfg(test)]
 mod test {
-    use std::{
-        collections::{BTreeMap, HashMap},
-        default,
-        rc::Rc,
-        sync::Arc,
-    };
+    use std::collections::{BTreeMap, HashMap};
+    use std::default;
+    use std::rc::Rc;
+    use std::sync::Arc;
 
     use blake3::Hasher;
     use chrono::{Duration, NaiveDateTime};
     use meta::meta_manager::RemoteMetaManager;
     use meta::MetaRef;
     use minivec::MiniVec;
-    use models::{
-        codec::Encoding,
-        schema::{
-            ColumnType, DatabaseOptions, DatabaseSchema, TableColumn, TableSchema, TenantOptions,
-            TskvTableSchema,
-        },
-        Timestamp, ValueType,
+    use models::codec::Encoding;
+    use models::schema::{
+        ColumnType, DatabaseOptions, DatabaseSchema, TableColumn, TableSchema, TenantOptions,
+        TskvTableSchema,
     };
-    use protos::kv_service::Meta;
-    use protos::{
-        kv_service::WritePointsRequest,
-        models::{self as fb_models, FieldType},
-        models_helper,
-    };
-    use tokio::{runtime, sync::mpsc};
-
-    use crate::{
-        compaction::{
-            check::{
-                get_default_time_range, hash_to_string, ColumnHashTreeNode, TimeRangeHashTreeNode,
-            },
-            FlushReq,
-        },
-        engine::Engine,
-        tsm::{codec::DataBlockEncoding, DataBlock},
-        version_set::VersionSet,
-        Options, TimeRange, TsKv, TseriesFamilyId,
-    };
+    use models::{Timestamp, ValueType};
+    use protos::kv_service::{Meta, WritePointsRequest};
+    use protos::models::{self as fb_models, FieldType};
+    use protos::models_helper;
+    use tokio::runtime;
+    use tokio::sync::mpsc;
 
     use super::{
         calc_block_partial_time_range, find_timestamp, hash_partial_datablock, Hash,
         TableHashTreeNode,
     };
+    use crate::compaction::check::{
+        get_default_time_range, hash_to_string, ColumnHashTreeNode, TimeRangeHashTreeNode,
+    };
+    use crate::compaction::FlushReq;
+    use crate::engine::Engine;
+    use crate::tsm::codec::DataBlockEncoding;
+    use crate::tsm::DataBlock;
+    use crate::version_set::VersionSet;
+    use crate::{Options, TimeRange, TsKv, TseriesFamilyId};
 
     fn parse_nanos(datetime: &str) -> Timestamp {
         NaiveDateTime::parse_from_str(datetime, "%Y-%m-%d %H:%M:%S")

--- a/tskv/src/compaction/compact.rs
+++ b/tskv/src/compaction/compact.rs
@@ -1,9 +1,7 @@
-use std::{
-    collections::{BinaryHeap, HashMap, VecDeque},
-    path::PathBuf,
-    pin::Pin,
-    sync::Arc,
-};
+use std::collections::{BinaryHeap, HashMap, VecDeque};
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::Arc;
 
 use evmap::new;
 use lru_cache::ShardedCache;
@@ -12,24 +10,20 @@ use snafu::ResultExt;
 use trace::{debug, error, info, trace};
 use utils::BloomFilter;
 
-use crate::{
-    compaction::CompactReq,
-    context::GlobalContext,
-    error::{self, Result},
-    file_system::file_manager::{self, get_file_manager},
-    file_utils,
-    kv_option::Options,
-    memcache::DataType,
-    summary::{CompactMeta, VersionEdit},
-    tseries_family::{ColumnFile, TimeRange},
-    tsm::{
-        self, BlockMeta, BlockMetaIterator, ColumnReader, DataBlock, Index, IndexIterator,
-        IndexMeta, IndexReader, TsmReader, TsmWriter,
-    },
-    ColumnFileId, Error, LevelId, TseriesFamilyId,
-};
-
 use super::iterator::BufferedIterator;
+use crate::compaction::CompactReq;
+use crate::context::GlobalContext;
+use crate::error::{self, Result};
+use crate::file_system::file_manager::{self, get_file_manager};
+use crate::kv_option::Options;
+use crate::memcache::DataType;
+use crate::summary::{CompactMeta, VersionEdit};
+use crate::tseries_family::{ColumnFile, TimeRange};
+use crate::tsm::{
+    self, BlockMeta, BlockMetaIterator, ColumnReader, DataBlock, Index, IndexIterator, IndexMeta,
+    IndexReader, TsmReader, TsmWriter,
+};
+use crate::{file_utils, ColumnFileId, Error, LevelId, TseriesFamilyId};
 
 /// Temporary compacting data block meta
 struct CompactingBlockMeta {
@@ -663,33 +657,27 @@ fn new_compact_meta(
 #[cfg(test)]
 pub mod test {
     use core::panic;
+    use std::collections::HashMap;
+    use std::default;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64};
+    use std::sync::Arc;
+
     use lru_cache::ShardedCache;
     use minivec::MiniVec;
-    use parking_lot::RwLock;
-    use std::{
-        collections::HashMap,
-        default,
-        path::{Path, PathBuf},
-        sync::{
-            atomic::{AtomicBool, AtomicU32, AtomicU64},
-            Arc,
-        },
-    };
-
     use models::{FieldId, Timestamp, ValueType};
+    use parking_lot::RwLock;
     use utils::BloomFilter;
 
-    use crate::{
-        compaction::{run_compaction_job, CompactReq},
-        context::GlobalContext,
-        file_system::file_manager,
-        file_utils,
-        kv_option::Options,
-        summary::VersionEdit,
-        tseries_family::{ColumnFile, LevelInfo, TimeRange, Version},
-        tsm::{self, codec::DataBlockEncoding, DataBlock, Tombstone, TsmReader, TsmTombstone},
-        TseriesFamilyId,
-    };
+    use crate::compaction::{run_compaction_job, CompactReq};
+    use crate::context::GlobalContext;
+    use crate::file_system::file_manager;
+    use crate::kv_option::Options;
+    use crate::summary::VersionEdit;
+    use crate::tseries_family::{ColumnFile, LevelInfo, TimeRange, Version};
+    use crate::tsm::codec::DataBlockEncoding;
+    use crate::tsm::{self, DataBlock, Tombstone, TsmReader, TsmTombstone};
+    use crate::{file_utils, TseriesFamilyId};
 
     async fn write_data_blocks_to_column_file(
         dir: impl AsRef<Path>,

--- a/tskv/src/compaction/flush.rs
+++ b/tskv/src/compaction/flush.rs
@@ -1,12 +1,10 @@
-use std::{
-    cmp::max,
-    collections::HashMap,
-    iter::Peekable,
-    path::{Path, PathBuf},
-    rc::Rc,
-    slice,
-    sync::Arc,
-};
+use std::cmp::max;
+use std::collections::HashMap;
+use std::iter::Peekable;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::slice;
+use std::sync::Arc;
 
 use models::codec::Encoding;
 use models::schema::TskvTableSchema;
@@ -18,31 +16,28 @@ use models::{
 use parking_lot::{Mutex, RwLock};
 use regex::internal::Input;
 use snafu::{NoneError, OptionExt, ResultExt};
-use tokio::{
-    select,
-    sync::{
-        mpsc::{self, Sender},
-        oneshot,
-        oneshot::Sender as OneShotSender,
-    },
-};
+use tokio::select;
+use tokio::sync::mpsc::{self, Sender};
+use tokio::sync::oneshot;
+use tokio::sync::oneshot::Sender as OneShotSender;
 use trace::{debug, error, info, log_error, warn};
 use utils::BloomFilter;
 
-use crate::{
-    compaction::FlushReq,
-    context::GlobalContext,
-    database::Database,
-    error::{self, Error, Result},
-    index::IndexResult,
-    kv_option::Options,
-    memcache::{DataType, FieldVal, MemCache, SeriesData},
-    summary::{CompactMeta, CompactMetaBuilder, SummaryTask, VersionEdit, WriteSummaryRequest},
-    tseries_family::{LevelInfo, Version},
-    tsm::{self, codec::DataBlockEncoding, DataBlock, TsmWriter},
-    version_set::VersionSet,
-    ColumnFileId, TseriesFamilyId,
+use crate::compaction::FlushReq;
+use crate::context::GlobalContext;
+use crate::database::Database;
+use crate::error::{self, Error, Result};
+use crate::index::IndexResult;
+use crate::kv_option::Options;
+use crate::memcache::{DataType, FieldVal, MemCache, SeriesData};
+use crate::summary::{
+    CompactMeta, CompactMetaBuilder, SummaryTask, VersionEdit, WriteSummaryRequest,
 };
+use crate::tseries_family::{LevelInfo, Version};
+use crate::tsm::codec::DataBlockEncoding;
+use crate::tsm::{self, DataBlock, TsmWriter};
+use crate::version_set::VersionSet;
+use crate::{ColumnFileId, TseriesFamilyId};
 
 struct FlushingBlock {
     pub field_id: FieldId,
@@ -444,24 +439,20 @@ pub mod flush_tests {
     use parking_lot::RwLock;
     use utils::dedup_front_by_key;
 
-    use crate::file_system::file_manager;
-    use crate::memcache::test::put_rows_to_cache;
-    use crate::summary::{CompactMeta, VersionEdit};
-    use crate::tseries_family::{LevelInfo, Version};
-    use crate::tsm::tsm_reader_tests::read_and_check;
-    use crate::tsm::{codec::DataBlockEncoding, DataBlock, TsmReader};
-    use crate::{
-        compaction::FlushReq,
-        context::GlobalContext,
-        file_utils,
-        kv_option::Options,
-        memcache::{DataType, FieldVal, MemCache},
-        tseries_family,
-        tseries_family::FLUSH_REQ,
-        version_set::VersionSet,
-    };
-
     use super::FlushTask;
+    use crate::compaction::FlushReq;
+    use crate::context::GlobalContext;
+    use crate::file_system::file_manager;
+    use crate::kv_option::Options;
+    use crate::memcache::test::put_rows_to_cache;
+    use crate::memcache::{DataType, FieldVal, MemCache};
+    use crate::summary::{CompactMeta, VersionEdit};
+    use crate::tseries_family::{LevelInfo, Version, FLUSH_REQ};
+    use crate::tsm::codec::DataBlockEncoding;
+    use crate::tsm::tsm_reader_tests::read_and_check;
+    use crate::tsm::{DataBlock, TsmReader};
+    use crate::version_set::VersionSet;
+    use crate::{file_utils, tseries_family};
 
     pub fn default_with_field_id(ids: Vec<ColumnId>) -> TskvTableSchema {
         let fields = ids

--- a/tskv/src/compaction/job.rs
+++ b/tskv/src/compaction/job.rs
@@ -1,27 +1,21 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
+use std::time::Duration;
 
 use datafusion::arrow::compute::kernels::limit;
-use tokio::{
-    runtime::Runtime,
-    sync::{
-        broadcast,
-        mpsc::{Receiver, Sender},
-        oneshot, RwLock, Semaphore,
-    },
-    task::JoinHandle,
-    time::Instant,
-};
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::{broadcast, oneshot, RwLock, Semaphore};
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
 use trace::{error, info, warn};
 
-use crate::{
-    compaction::{LevelCompactionPicker, Picker},
-    context::GlobalContext,
-    error::Result,
-    kv_option::StorageOptions,
-    summary::SummaryTask,
-    version_set::VersionSet,
-    TseriesFamilyId,
-};
+use crate::compaction::{LevelCompactionPicker, Picker};
+use crate::context::GlobalContext;
+use crate::error::Result;
+use crate::kv_option::StorageOptions;
+use crate::summary::SummaryTask;
+use crate::version_set::VersionSet;
+use crate::TseriesFamilyId;
 
 pub fn run(
     storage_opt: Arc<StorageOptions>,

--- a/tskv/src/compaction/mod.rs
+++ b/tskv/src/compaction/mod.rs
@@ -5,21 +5,18 @@ mod iterator;
 pub mod job;
 mod picker;
 
-pub use compact::*;
-pub use flush::*;
-pub use picker::*;
-
 use std::sync::Arc;
 
+pub use compact::*;
+pub use flush::*;
 use parking_lot::RwLock;
+pub use picker::*;
 
-use crate::{
-    kv_option::StorageOptions,
-    memcache::MemCache,
-    summary::VersionEdit,
-    tseries_family::{ColumnFile, Version},
-    LevelId, TseriesFamilyId,
-};
+use crate::kv_option::StorageOptions;
+use crate::memcache::MemCache;
+use crate::summary::VersionEdit;
+use crate::tseries_family::{ColumnFile, Version};
+use crate::{LevelId, TseriesFamilyId};
 
 pub struct CompactReq {
     pub ts_family_id: TseriesFamilyId,

--- a/tskv/src/compaction/picker.rs
+++ b/tskv/src/compaction/picker.rs
@@ -1,13 +1,9 @@
+use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::fmt::Debug;
-use std::{
-    cmp::Ordering,
-    collections::HashMap,
-    ops::{Add, Div},
-    sync::{
-        atomic::{self, AtomicBool},
-        Arc,
-    },
-};
+use std::ops::{Add, Div};
+use std::sync::atomic::{self, AtomicBool};
+use std::sync::Arc;
 
 use chrono::{
     DateTime, Datelike, Duration, DurationRound, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc,
@@ -17,13 +13,11 @@ use models::Timestamp;
 use parking_lot::RwLock;
 use trace::{debug, error, info};
 
-use crate::{
-    compaction::CompactReq,
-    error::Result,
-    kv_option::{Options, StorageOptions},
-    tseries_family::{ColumnFile, LevelInfo, TseriesFamily, Version},
-    LevelId, TimeRange, TseriesFamilyId,
-};
+use crate::compaction::CompactReq;
+use crate::error::Result;
+use crate::kv_option::{Options, StorageOptions};
+use crate::tseries_family::{ColumnFile, LevelInfo, TseriesFamily, Version};
+use crate::{LevelId, TimeRange, TseriesFamilyId};
 
 pub trait Picker: Send + Sync + Debug {
     fn pick_compaction(&self, version: Arc<Version>) -> Option<CompactReq>;
@@ -415,21 +409,20 @@ impl LevelCompatContext {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use lru_cache::ShardedCache;
     use parking_lot::RwLock;
-    use std::sync::Arc;
     use tokio::sync::mpsc;
 
     use crate::compaction::test::create_options;
     use crate::compaction::{LevelCompactionPicker, Picker};
+    use crate::file_utils::make_tsm_file_name;
+    use crate::kv_option::{Options, StorageOptions};
     use crate::kvcore::COMPACT_REQ_CHANNEL_CAP;
-    use crate::{
-        file_utils::make_tsm_file_name,
-        kv_option::{Options, StorageOptions},
-        memcache::MemCache,
-        tseries_family::{ColumnFile, LevelInfo, TseriesFamily, Version},
-        TimeRange,
-    };
+    use crate::memcache::MemCache;
+    use crate::tseries_family::{ColumnFile, LevelInfo, TseriesFamily, Version};
+    use crate::TimeRange;
 
     type ColumnFilesSketch = (u64, i64, i64, u64, bool);
     type LevelsSketch = Vec<(u32, i64, i64, Vec<ColumnFilesSketch>)>;

--- a/tskv/src/context.rs
+++ b/tskv/src/context.rs
@@ -1,10 +1,6 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::{
-        atomic::{AtomicU32, AtomicU64, Ordering},
-        Arc,
-    },
-};
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::Arc;
 
 use parking_lot::RwLock;
 use tokio::runtime::Runtime;

--- a/tskv/src/engine.rs
+++ b/tskv/src/engine.rs
@@ -4,14 +4,13 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use datafusion::prelude::Column;
-use parking_lot::RwLock;
-
 use models::codec::Encoding;
 use models::predicate::domain::{ColumnDomains, PredicateRef};
 use models::schema::{DatabaseSchema, TableColumn, TableSchema, TskvTableSchema};
 use models::{ColumnId, FieldId, FieldInfo, SeriesId, SeriesKey, Tag, Timestamp, ValueType};
-use protos::kv_service::WritePointsResponse;
-use protos::{kv_service::WritePointsRequest, models as fb_models};
+use parking_lot::RwLock;
+use protos::kv_service::{WritePointsRequest, WritePointsResponse};
+use protos::models as fb_models;
 use trace::{debug, info};
 
 use crate::database::Database;

--- a/tskv/src/error.rs
+++ b/tskv/src/error.rs
@@ -1,16 +1,14 @@
-use error_code::ErrorCode;
-use error_code::ErrorCoder;
+use std::path::{Path, PathBuf};
+
+use error_code::{ErrorCode, ErrorCoder};
 use meta::error::MetaError;
 use models::SeriesId;
 use snafu::Snafu;
-use std::path::{Path, PathBuf};
 
 use crate::index::IndexError;
 use crate::schema::error::SchemaError;
-use crate::{
-    tsm::{ReadTsmError, WriteTsmError},
-    wal,
-};
+use crate::tsm::{ReadTsmError, WriteTsmError};
+use crate::wal;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 

--- a/tskv/src/file_system/file/async_file.rs
+++ b/tskv/src/file_system/file/async_file.rs
@@ -14,16 +14,14 @@ use std::{io, slice, thread};
 
 use async_trait::async_trait;
 use futures::{AsyncSeekExt, AsyncWriteExt};
+use libc::{send, time};
 #[cfg(feature = "io_uring")]
 use rio::Rio;
-
-use libc::{send, time};
 #[cfg(feature = "io_uring")]
 use snafu::ResultExt;
 use tokio::fs::File;
 use tokio::spawn;
 use tokio::task::spawn_blocking;
-
 use trace::{error, info};
 
 use crate::file_system::file::os::{check_err, open, pread, pwrite, FileId};

--- a/tskv/src/file_system/file/cursor.rs
+++ b/tskv/src/file_system/file/cursor.rs
@@ -1,8 +1,5 @@
-use std::io::{ErrorKind, IoSlice};
-use std::{
-    io::{Error, Result, SeekFrom},
-    ops::Deref,
-};
+use std::io::{Error, ErrorKind, IoSlice, Result, SeekFrom};
+use std::ops::Deref;
 
 use crate::file_system::file::async_file::{AsyncFile, IFile};
 

--- a/tskv/src/file_system/file/os/macos.rs
+++ b/tskv/src/file_system/file/os/macos.rs
@@ -1,9 +1,7 @@
-use std::{
-    fs::{File, OpenOptions},
-    io::Result,
-    os::unix::io::AsRawFd,
-    path::Path,
-};
+use std::fs::{File, OpenOptions};
+use std::io::Result;
+use std::os::unix::io::AsRawFd;
+use std::path::Path;
 
 use super::unix::check_err;
 

--- a/tskv/src/file_system/file/os/unix.rs
+++ b/tskv/src/file_system/file/os/unix.rs
@@ -1,17 +1,16 @@
-use std::os::unix::io::RawFd;
-use std::{
-    fs::File,
-    io::{Error, Result},
-    mem::MaybeUninit,
-    os::unix::io::AsRawFd,
-};
+use std::fs::File;
+use std::io::{Error, Result};
+use std::mem::MaybeUninit;
+use std::os::unix::io::{AsRawFd, RawFd};
 
 #[cfg(not(target_os = "macos"))]
 pub use not_macos::*;
 
 #[cfg(not(target_os = "macos"))]
 mod not_macos {
-    use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt, path::Path};
+    use std::fs::OpenOptions;
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::path::Path;
 
     use super::*;
 

--- a/tskv/src/file_system/file/os/windows.rs
+++ b/tskv/src/file_system/file/os/windows.rs
@@ -1,16 +1,16 @@
-use std::{
-    convert::TryFrom,
-    fs::{File, OpenOptions},
-    io::{prelude::*, Error, Result},
-    mem::MaybeUninit,
-    os::windows::{fs::OpenOptionsExt, io::AsRawHandle},
-    path::Path,
-};
+use std::convert::TryFrom;
+use std::fs::{File, OpenOptions};
+use std::io::prelude::*;
+use std::io::{Error, Result};
+use std::mem::MaybeUninit;
+use std::os::windows::fs::OpenOptionsExt;
+use std::os::windows::io::AsRawHandle;
+use std::path::Path;
 
-use winapi::{
-    shared::minwindef::*,
-    um::{fileapi::*, minwinbase::OVERLAPPED, winbase::FILE_FLAG_NO_BUFFERING},
-};
+use winapi::shared::minwindef::*;
+use winapi::um::fileapi::*;
+use winapi::um::minwinbase::OVERLAPPED;
+use winapi::um::winbase::FILE_FLAG_NO_BUFFERING;
 
 //todo:
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/tskv/src/file_system/file_manager.rs
+++ b/tskv/src/file_system/file_manager.rs
@@ -1,19 +1,14 @@
+use std::borrow::BorrowMut;
+use std::fs;
 use std::fs::OpenOptions;
-use std::{
-    borrow::BorrowMut,
-    fs,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use once_cell::sync::OnceCell;
 use snafu::{ResultExt, Snafu};
 
-use crate::{
-    error,
-    file_system::file::async_file::{AsyncFile, FsRuntime},
-    Error, Result,
-};
+use crate::file_system::file::async_file::{AsyncFile, FsRuntime};
+use crate::{error, Error, Result};
 
 #[derive(Snafu, Debug)]
 pub enum FileError {
@@ -173,17 +168,17 @@ pub async fn open_create_file(path: impl AsRef<Path>) -> Result<AsyncFile> {
 
 #[cfg(test)]
 mod test {
+    use std::os::unix::io::FromRawFd;
     use std::os::unix::prelude::AsRawFd;
+    use std::path::Path;
     use std::sync::Arc;
-    use std::{os::unix::io::FromRawFd, path::Path};
 
     use libc::send;
     use tokio::sync::{mpsc, oneshot};
     use trace::info;
 
-    use crate::file_system::{file_manager, FileCursor, IFile};
-
     use super::FileManager;
+    use crate::file_system::{file_manager, FileCursor, IFile};
 
     #[tokio::test]
     async fn test_get_instance() {

--- a/tskv/src/file_system/mod.rs
+++ b/tskv/src/file_system/mod.rs
@@ -6,6 +6,5 @@
 mod file;
 pub mod file_manager;
 
-pub use file::async_file::AsyncFile;
-pub use file::async_file::IFile;
+pub use file::async_file::{AsyncFile, IFile};
 pub use file::cursor::FileCursor;

--- a/tskv/src/index/binlog.rs
+++ b/tskv/src/index/binlog.rs
@@ -1,19 +1,16 @@
-use std::{
-    collections::HashMap,
-    io::SeekFrom,
-    marker::PhantomData,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::collections::HashMap;
+use std::io::SeekFrom;
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
-use crate::file_system::{file_manager, AsyncFile, FileCursor, IFile};
-use crate::{byte_utils, file_utils};
 use parking_lot::RwLock;
 use snafu::prelude::*;
-
 use trace::{debug, error, info, warn};
 
 use super::{IndexEngine, IndexError, IndexResult};
+use crate::file_system::{file_manager, AsyncFile, FileCursor, IFile};
+use crate::{byte_utils, file_utils};
 
 const SEGMENT_FILE_HEADER_SIZE: usize = 8;
 const SEGMENT_FILE_MAGIC: [u8; 4] = [0x48, 0x49, 0x4e, 0x02];

--- a/tskv/src/index/cache.rs
+++ b/tskv/src/index/cache.rs
@@ -1,12 +1,10 @@
+use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
 use lru::LruCache;
 use lru_cache::ShardedCache;
 use models::{SeriesId, SeriesKey};
-
-use std::{
-    num::NonZeroUsize,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
 
 pub struct SeriesKeyInfo {
     pub key: SeriesKey,

--- a/tskv/src/index/engine.rs
+++ b/tskv/src/index/engine.rs
@@ -1,19 +1,15 @@
 use std::cmp::Ordering;
-use std::default;
-use std::fs;
-use std::io;
-use std::ops::Range;
-use std::ops::RangeBounds;
+use std::ops::{Range, RangeBounds};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::{default, fs, io};
 
 use radixdb;
 use radixdb::store;
 use radixdb::store::BlobStore;
 use trace::debug;
 
-use super::IndexError;
-use super::IndexResult;
+use super::{IndexError, IndexResult};
 
 #[derive(Debug)]
 pub struct IndexEngine {
@@ -274,9 +270,11 @@ impl Iterator for RangeKeyValIter {
 }
 
 mod test {
+    use std::sync::atomic::AtomicU64;
+    use std::sync::{self, Arc};
+
     use models::utils::now_timestamp;
     use parking_lot::RwLock;
-    use std::sync::{self, atomic::AtomicU64, Arc};
     use tokio::time::{self, Duration};
 
     use super::IndexEngine;

--- a/tskv/src/index/errors.rs
+++ b/tskv/src/index/errors.rs
@@ -1,8 +1,10 @@
+use std::fmt::Debug;
+use std::io;
+
+use sled;
 use snafu::Snafu;
-use std::{fmt::Debug, io};
 
 use crate::record_file;
-use sled;
 
 #[derive(Snafu, Debug)]
 pub enum IndexError {

--- a/tskv/src/index/ts_index.rs
+++ b/tskv/src/index/ts_index.rs
@@ -1,40 +1,36 @@
-use fmt::Debug;
 use std::borrow::Borrow;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::hash::Hash;
 use std::mem::size_of;
 use std::ops::{BitAnd, BitOr, Bound, Index, RangeBounds};
 use std::path::{self, Path, PathBuf};
 use std::string::FromUtf8Error;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use bytes::BufMut;
 use chrono::format::format;
-use datafusion::prelude::Column;
-use datafusion::scalar::ScalarValue;
-use lazy_static::__Deref;
-use models::predicate::domain::{utf8_from, Domain, Marker, Range, ValueEntry};
-use once_cell::sync::OnceCell;
-use parking_lot::RwLock;
-use sled::Error;
-use snafu::ResultExt;
-
 use config::Config;
 use datafusion::arrow::datatypes::{DataType, ToByteSlice};
 use datafusion::parquet::data_type::AsBytes;
+use datafusion::prelude::Column;
+use datafusion::scalar::ScalarValue;
+use fmt::Debug;
+use lazy_static::__Deref;
 use models::codec::Encoding;
-use models::{
-    tag::TagFromParts, utils, ColumnId, FieldId, FieldInfo, SeriesId, SeriesKey, Tag, ValueType,
-};
+use models::predicate::domain::{utf8_from, Domain, Marker, Range, ValueEntry};
+use models::tag::TagFromParts;
+use models::{utils, ColumnId, FieldId, FieldInfo, SeriesId, SeriesKey, Tag, ValueType};
+use once_cell::sync::OnceCell;
+use parking_lot::RwLock;
 use protos::models::Point;
+use sled::Error;
+use snafu::ResultExt;
 use trace::{debug, error, info, warn};
 
 use super::binlog::*;
 use super::cache::{ForwardIndexCache, SeriesKeyInfo};
-use super::*;
-use super::{errors, IndexEngine, IndexError, IndexResult};
-
+use super::{errors, IndexEngine, IndexError, IndexResult, *};
 use crate::file_system::file_manager;
 use crate::Error::IndexErr;
 use crate::{byte_utils, file_utils};
@@ -594,14 +590,14 @@ pub fn encode_series_id_list(list: &[u32]) -> Vec<u8> {
 
 #[cfg(test)]
 mod test {
-    use std::{
-        num::NonZeroUsize,
-        path::{Path, PathBuf},
-    };
+    use std::num::NonZeroUsize;
+    use std::path::{Path, PathBuf};
 
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use lru::LruCache;
-    use models::{schema::ExternalTableSchema, utils::now_timestamp, SeriesKey, Tag};
+    use models::schema::ExternalTableSchema;
+    use models::utils::now_timestamp;
+    use models::{SeriesKey, Tag};
 
     use super::TSIndex;
 

--- a/tskv/src/kv_option.rs
+++ b/tskv/src/kv_option.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
 
 use config::Config;
 use serde::{Deserialize, Serialize};

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -1,26 +1,14 @@
+use std::collections::HashMap;
+use std::panic;
+use std::sync::Arc;
 use std::time::Duration;
-use std::{collections::HashMap, panic, sync::Arc};
 
-use crate::compaction::{LevelCompactionPicker, Picker};
+use config::ClusterConfig;
 use datafusion::prelude::Column;
 use flatbuffers::FlatBufferBuilder;
 use futures::stream::SelectNextSome;
 use futures::FutureExt;
 use libc::printf;
-use snafu::{OptionExt, ResultExt};
-use tokio::sync::watch;
-use tokio::sync::RwLock;
-use tokio::{
-    runtime::Runtime,
-    sync::{
-        broadcast::{self, Receiver as BroadcastReceiver, Sender as BroadcastSender},
-        mpsc::{self, Receiver, Sender},
-        oneshot,
-    },
-    time::Instant,
-};
-
-use config::ClusterConfig;
 use meta::meta_manager::RemoteMetaManager;
 use meta::MetaRef;
 use metrics::{incr_compaction_failed, incr_compaction_success, sample_tskv_compaction_duration};
@@ -29,43 +17,42 @@ use models::predicate::domain::{ColumnDomains, PredicateRef};
 use models::schema::{
     make_owner, DatabaseSchema, TableColumn, TableSchema, TskvTableSchema, DEFAULT_CATALOG,
 };
+use models::utils::unite_id;
 use models::{
-    utils::unite_id, ColumnId, FieldId, FieldInfo, InMemPoint, SeriesId, SeriesKey, Tag, Timestamp,
-    ValueType,
+    ColumnId, FieldId, FieldInfo, InMemPoint, SeriesId, SeriesKey, Tag, Timestamp, ValueType,
 };
-use protos::kv_service::WritePointsResponse;
-use protos::{kv_service::WritePointsRequest, models as fb_models};
+use protos::kv_service::{WritePointsRequest, WritePointsResponse};
+use protos::models as fb_models;
+use snafu::{OptionExt, ResultExt};
+use tokio::runtime::Runtime;
+use tokio::sync::broadcast::{self, Receiver as BroadcastReceiver, Sender as BroadcastSender};
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::sync::{oneshot, watch, RwLock};
+use tokio::time::Instant;
 use trace::{debug, error, info, trace, warn};
 
-use crate::context::{self, GlobalSequenceContext, GlobalSequenceTask};
-use crate::database::Database;
-use crate::error::MetaSnafu;
-use crate::error::SchemaSnafu;
-use crate::error::SendSnafu;
-use crate::file_system::file_manager::{self, FileManager};
-use crate::kv_option::StorageOptions;
-use crate::schema::error::SchemaError;
-use crate::tseries_family::TseriesFamily;
-use crate::tsm::codec::get_str_codec;
-use crate::{
-    compaction::{self, run_flush_memtable_job, CompactReq, FlushReq},
-    context::GlobalContext,
-    database,
-    engine::Engine,
-    error::{self, IndexErrSnafu, Result},
-    file_utils,
-    index::IndexResult,
-    kv_option::Options,
-    memcache::{DataType, MemCache},
-    record_file::Reader,
-    summary::{self, Summary, SummaryProcessor, SummaryTask, VersionEdit, WriteSummaryRequest},
-    tseries_family::{SuperVersion, TimeRange, Version},
-    tsm::{DataBlock, TsmTombstone, MAX_BLOCK_VALUES},
-    version_set,
-    version_set::VersionSet,
-    wal::{self, WalEntryType, WalManager, WalTask},
-    Error, TseriesFamilyId,
+use crate::compaction::{
+    self, run_flush_memtable_job, CompactReq, FlushReq, LevelCompactionPicker, Picker,
 };
+use crate::context::{self, GlobalContext, GlobalSequenceContext, GlobalSequenceTask};
+use crate::database::Database;
+use crate::engine::Engine;
+use crate::error::{self, IndexErrSnafu, MetaSnafu, Result, SchemaSnafu, SendSnafu};
+use crate::file_system::file_manager::{self, FileManager};
+use crate::index::IndexResult;
+use crate::kv_option::{Options, StorageOptions};
+use crate::memcache::{DataType, MemCache};
+use crate::record_file::Reader;
+use crate::schema::error::SchemaError;
+use crate::summary::{
+    self, Summary, SummaryProcessor, SummaryTask, VersionEdit, WriteSummaryRequest,
+};
+use crate::tseries_family::{SuperVersion, TimeRange, TseriesFamily, Version};
+use crate::tsm::codec::get_str_codec;
+use crate::tsm::{DataBlock, TsmTombstone, MAX_BLOCK_VALUES};
+use crate::version_set::VersionSet;
+use crate::wal::{self, WalEntryType, WalManager, WalTask};
+use crate::{database, file_utils, version_set, Error, TseriesFamilyId};
 
 pub const COMPACT_REQ_CHANNEL_CAP: usize = 16;
 pub const SUMMARY_REQ_CHANNEL_CAP: usize = 16;
@@ -948,18 +935,20 @@ mod test {
     use std::sync::atomic::{AtomicI64, Ordering};
     use std::sync::{atomic, Arc};
 
-    use flatbuffers::{FlatBufferBuilder, WIPOffset};
-    use tokio::runtime::{self, Runtime};
-    use tokio::sync::watch;
-
     use config::get_config;
+    use flatbuffers::{FlatBufferBuilder, WIPOffset};
     use meta::meta_manager::RemoteMetaManager;
     use meta::MetaRef;
     use models::utils::now_timestamp;
     use models::{ColumnId, InMemPoint, SeriesId, SeriesKey, Timestamp};
-    use protos::{models::Points, models_helper};
+    use protos::models::Points;
+    use protos::models_helper;
+    use tokio::runtime::{self, Runtime};
+    use tokio::sync::watch;
 
-    use crate::{engine::Engine, error, tsm::DataBlock, Options, TimeRange, TsKv};
+    use crate::engine::Engine;
+    use crate::tsm::DataBlock;
+    use crate::{error, Options, TimeRange, TsKv};
 
     #[tokio::test]
     #[ignore]

--- a/tskv/src/lib.rs
+++ b/tskv/src/lib.rs
@@ -3,14 +3,12 @@
 #![allow(unreachable_patterns)]
 #![allow(unused_imports, unused_variables)]
 
-use tokio::sync::oneshot;
-
 pub use error::{Error, Result};
 pub use kv_option::Options;
 pub use kvcore::TsKv;
 use protos::kv_service::WritePointsResponse;
-pub use summary::print_summary_statistics;
-pub use summary::{Summary, VersionEdit};
+pub use summary::{print_summary_statistics, Summary, VersionEdit};
+use tokio::sync::oneshot;
 pub use tseries_family::TimeRange;
 pub use tsm::print_tsm_statistics;
 use utils::BloomFilter;

--- a/tskv/src/record_file/reader.rs
+++ b/tskv/src/record_file/reader.rs
@@ -1,11 +1,9 @@
-use std::{
-    borrow::Borrow,
-    cmp::Ordering,
-    fmt::format,
-    fs,
-    io::{Error as IoError, Read},
-    path::{Path, PathBuf},
-};
+use std::borrow::Borrow;
+use std::cmp::Ordering;
+use std::fmt::format;
+use std::fs;
+use std::io::{Error as IoError, Read};
+use std::path::{Path, PathBuf};
 
 use async_recursion::async_recursion;
 use bytes::{Buf, BufMut};
@@ -15,18 +13,15 @@ use parking_lot::Mutex;
 use snafu::ResultExt;
 use trace::{error, info};
 
-use crate::{
-    byte_utils::decode_be_u32,
-    error::{self, Error, Result},
-    file_system::{file_manager, AsyncFile, FileCursor, IFile},
-};
-
 use super::{
     file_crc_source_len, Record, FILE_FOOTER_CRC32_NUMBER_LEN, FILE_FOOTER_LEN,
     FILE_FOOTER_MAGIC_NUMBER_LEN, FILE_MAGIC_NUMBER_LEN, READER_BUF_SIZE, RECORD_CRC32_NUMBER_LEN,
     RECORD_DATA_SIZE_LEN, RECORD_DATA_TYPE_LEN, RECORD_DATA_VERSION_LEN, RECORD_HEADER_LEN,
     RECORD_MAGIC_NUMBER, RECORD_MAGIC_NUMBER_LEN,
 };
+use crate::byte_utils::decode_be_u32;
+use crate::error::{self, Error, Result};
+use crate::file_system::{file_manager, AsyncFile, FileCursor, IFile};
 
 pub struct Reader {
     path: PathBuf,
@@ -258,18 +253,14 @@ pub(crate) mod test {
 
     use snafu::ResultExt;
 
-    use crate::{
-        byte_utils::decode_be_u32,
-        error::{self, Error, Result},
-        file_system::{file_manager, AsyncFile, FileCursor, IFile},
-        record_file::{
-            Record, RECORD_CRC32_NUMBER_LEN, RECORD_DATA_SIZE_LEN, RECORD_DATA_TYPE_LEN,
-            RECORD_DATA_VERSION_LEN, RECORD_HEADER_LEN, RECORD_MAGIC_NUMBER,
-            RECORD_MAGIC_NUMBER_LEN,
-        },
-    };
-
     use super::Reader;
+    use crate::byte_utils::decode_be_u32;
+    use crate::error::{self, Error, Result};
+    use crate::file_system::{file_manager, AsyncFile, FileCursor, IFile};
+    use crate::record_file::{
+        Record, RECORD_CRC32_NUMBER_LEN, RECORD_DATA_SIZE_LEN, RECORD_DATA_TYPE_LEN,
+        RECORD_DATA_VERSION_LEN, RECORD_HEADER_LEN, RECORD_MAGIC_NUMBER, RECORD_MAGIC_NUMBER_LEN,
+    };
 
     impl Reader {
         pub(crate) async fn read_at(&mut self, pos: usize) -> Result<Record> {

--- a/tskv/src/record_file/writer.rs
+++ b/tskv/src/record_file/writer.rs
@@ -1,27 +1,22 @@
-use std::{
-    borrow::Borrow,
-    fs,
-    io::{IoSlice, SeekFrom},
-    path::{Path, PathBuf},
-};
+use std::borrow::Borrow;
+use std::fs;
+use std::io::{IoSlice, SeekFrom};
+use std::path::{Path, PathBuf};
 
 use num_traits::ToPrimitive;
 use parking_lot::Mutex;
 use snafu::ResultExt;
 use trace::error;
 
-use crate::{
-    byte_utils::decode_be_u32,
-    error::{self, Error, Result},
-    file_system::{file_manager, AsyncFile, FileCursor, IFile},
-    record_file::RECORD_CRC32_NUMBER_LEN,
-};
-
 use super::{
     file_crc_source_len, Reader, RecordDataType, BLOCK_SIZE, FILE_FOOTER_LEN,
     FILE_FOOTER_MAGIC_NUMBER_LEN, FILE_MAGIC_NUMBER, FILE_MAGIC_NUMBER_LEN, RECORD_HEADER_LEN,
     RECORD_MAGIC_NUMBER, RECORD_MAGIC_NUMBER_LEN,
 };
+use crate::byte_utils::decode_be_u32;
+use crate::error::{self, Error, Result};
+use crate::file_system::{file_manager, AsyncFile, FileCursor, IFile};
+use crate::record_file::RECORD_CRC32_NUMBER_LEN;
 
 pub struct Writer {
     path: PathBuf,
@@ -175,16 +170,11 @@ mod test {
 
     use serial_test::serial;
 
-    use crate::{
-        error::Result,
-        file_system::file_manager,
-        record_file::{
-            reader::test::{test_reader, test_reader_read_one},
-            RecordDataType, FILE_FOOTER_LEN,
-        },
-    };
-
     use super::Writer;
+    use crate::error::Result;
+    use crate::file_system::file_manager;
+    use crate::record_file::reader::test::{test_reader, test_reader_read_one};
+    use crate::record_file::{RecordDataType, FILE_FOOTER_LEN};
 
     #[tokio::test]
     #[serial]

--- a/tskv/src/schema/schemas.rs
+++ b/tskv/src/schema/schemas.rs
@@ -1,4 +1,6 @@
-use crate::schema::error::{MetaSnafu, Result, SchemaError};
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use meta::error::MetaError;
 use meta::meta_manager::RemoteMetaManager;
 use meta::{MetaClientRef, MetaRef};
@@ -10,11 +12,10 @@ use models::{ColumnId, SeriesId};
 use parking_lot::RwLock;
 use protos::models::Point;
 use snafu::ResultExt;
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use crate::Error;
 use trace::{error, info, warn};
+
+use crate::schema::error::{MetaSnafu, Result, SchemaError};
+use crate::Error;
 
 const TIME_STAMP_NAME: &str = "time";
 

--- a/tskv/src/summary.rs
+++ b/tskv/src/summary.rs
@@ -1,9 +1,10 @@
+use std::borrow::Borrow;
 use std::cmp::max;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::fs::{remove_file, rename};
 use std::path::{Path, PathBuf};
-use std::{borrow::Borrow, collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use config::get_config;
 use futures::TryFutureExt;
@@ -13,27 +14,24 @@ use meta::MetaRef;
 use models::Timestamp;
 use parking_lot::RwLock as SyncRwLock;
 use serde::{Deserialize, Serialize};
-use tokio::{
-    runtime::Runtime,
-    sync::{mpsc::Sender, oneshot::Sender as OneShotSender, watch::Receiver, RwLock},
-};
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::oneshot::Sender as OneShotSender;
+use tokio::sync::watch::Receiver;
+use tokio::sync::RwLock;
 use trace::{debug, error, info};
 use utils::BloomFilter;
 
-use crate::{
-    byte_utils,
-    compaction::FlushReq,
-    context::{GlobalContext, GlobalSequenceTask},
-    error::{Error, Result},
-    file_system::file_manager::try_exists,
-    file_utils,
-    kv_option::{Options, StorageOptions},
-    record_file::{Reader, RecordDataType, RecordDataVersion, Writer},
-    tseries_family::{ColumnFile, LevelInfo, Version},
-    tsm::TsmReader,
-    version_set::VersionSet,
-    ColumnFileId, LevelId, TseriesFamilyId,
-};
+use crate::compaction::FlushReq;
+use crate::context::{GlobalContext, GlobalSequenceTask};
+use crate::error::{Error, Result};
+use crate::file_system::file_manager::try_exists;
+use crate::kv_option::{Options, StorageOptions};
+use crate::record_file::{Reader, RecordDataType, RecordDataVersion, Writer};
+use crate::tseries_family::{ColumnFile, LevelInfo, Version};
+use crate::tsm::TsmReader;
+use crate::version_set::VersionSet;
+use crate::{byte_utils, file_utils, ColumnFileId, LevelId, TseriesFamilyId};
 
 const MAX_BATCH_SIZE: usize = 64;
 
@@ -828,31 +826,27 @@ mod test {
     use std::fs;
     use std::sync::Arc;
 
+    use config::{get_config, ClusterConfig, Config};
     use meta::meta_manager::RemoteMetaManager;
     use meta::MetaRef;
+    use models::schema::{make_owner, DatabaseSchema, TenantOptions};
     use snafu::ResultExt;
     use tokio::runtime::Runtime;
     use tokio::sync::mpsc;
     use tokio::sync::mpsc::Sender;
     use trace::debug;
-
-    use config::{get_config, ClusterConfig, Config};
-    use models::schema::{make_owner, DatabaseSchema, TenantOptions};
     use utils::BloomFilter;
 
+    use crate::compaction::FlushReq;
+    use crate::context::GlobalSequenceTask;
+    use crate::file_system::file_manager;
+    use crate::kv_option::{Options, StorageOptions};
     use crate::kvcore::{
         COMPACT_REQ_CHANNEL_CAP, GLOBAL_TASK_REQ_CHANNEL_CAP, SUMMARY_REQ_CHANNEL_CAP,
     };
-    use crate::{
-        compaction::FlushReq,
-        context::GlobalSequenceTask,
-        error,
-        file_system::file_manager,
-        kv_option::{Options, StorageOptions},
-        summary::{CompactMeta, Summary, SummaryTask, VersionEdit, WriteSummaryRequest},
-        tseries_family::LevelInfo,
-        TseriesFamilyId,
-    };
+    use crate::summary::{CompactMeta, Summary, SummaryTask, VersionEdit, WriteSummaryRequest};
+    use crate::tseries_family::LevelInfo;
+    use crate::{error, TseriesFamilyId};
 
     #[test]
     fn test_version_edit() {

--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -1,47 +1,38 @@
-use std::{
-    borrow::{Borrow, BorrowMut},
-    cmp::{self, max, min},
-    collections::{HashMap, HashSet},
-    ops::{Bound, Deref, DerefMut},
-    path::{Path, PathBuf},
-    rc::Rc,
-    sync::{
-        atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
-
-use lazy_static::lazy_static;
-use parking_lot::{Mutex, RwLock};
-use tokio::{
-    runtime::Runtime,
-    sync::{mpsc::Sender, watch::Receiver},
-    time::Instant,
-};
-use tokio_util::sync::CancellationToken;
+use std::borrow::{Borrow, BorrowMut};
+use std::cmp::{self, max, min};
+use std::collections::{HashMap, HashSet};
+use std::ops::{Bound, Deref, DerefMut};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
 use config::get_config;
+use lazy_static::lazy_static;
 use lru_cache::ShardedCache;
-use models::{
-    schema::TableColumn, ColumnId, FieldId, InMemPoint, SchemaId, SeriesId, Timestamp, ValueType,
-};
+use models::schema::TableColumn;
+use models::{ColumnId, FieldId, InMemPoint, SchemaId, SeriesId, Timestamp, ValueType};
+use parking_lot::{Mutex, RwLock};
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::watch::Receiver;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
 use trace::{debug, error, info, warn};
 use utils::BloomFilter;
 
-use crate::{
-    compaction::{CompactReq, FlushReq, LevelCompactionPicker, Picker},
-    error::{Error, Result},
-    file_system::file_manager,
-    file_utils::{self, make_delta_file_name, make_tsm_file_name},
-    kv_option::{CacheOptions, Options, StorageOptions},
-    memcache::{DataType, MemCache, RowGroup},
-    summary::{CompactMeta, VersionEdit},
-    tsm::{
-        BlockMetaIterator, ColumnReader, DataBlock, Index, IndexReader, TsmReader, TsmTombstone,
-    },
-    ColumnFileId, LevelId, TseriesFamilyId,
+use crate::compaction::{CompactReq, FlushReq, LevelCompactionPicker, Picker};
+use crate::error::{Error, Result};
+use crate::file_system::file_manager;
+use crate::file_utils::{self, make_delta_file_name, make_tsm_file_name};
+use crate::kv_option::{CacheOptions, Options, StorageOptions};
+use crate::memcache::{DataType, MemCache, RowGroup};
+use crate::summary::{CompactMeta, VersionEdit};
+use crate::tsm::{
+    BlockMetaIterator, ColumnReader, DataBlock, Index, IndexReader, TsmReader, TsmTombstone,
 };
+use crate::{ColumnFileId, LevelId, TseriesFamilyId};
 
 lazy_static! {
     pub static ref FLUSH_REQ: Arc<Mutex<Vec<FlushReq>>> = Arc::new(Mutex::new(vec![]));
@@ -938,42 +929,36 @@ impl Drop for TseriesFamily {
 
 #[cfg(test)]
 mod test {
-    use std::collections::hash_map;
+    use std::collections::{hash_map, HashMap};
     use std::mem::{size_of, size_of_val};
-    use std::{collections::HashMap, path::PathBuf, sync::Arc};
-
-    use parking_lot::{Mutex, RwLock};
+    use std::path::PathBuf;
+    use std::sync::Arc;
 
     use config::{get_config, ClusterConfig};
     use lru_cache::ShardedCache;
     use meta::meta_manager::RemoteMetaManager;
     use meta::MetaRef;
-    use models::{
-        schema::{DatabaseSchema, TenantOptions},
-        Timestamp, ValueType,
-    };
-    use tokio::sync::{
-        mpsc::{self, Receiver},
-        RwLock as AsyncRwLock,
-    };
+    use models::schema::{DatabaseSchema, TenantOptions};
+    use models::{Timestamp, ValueType};
+    use parking_lot::{Mutex, RwLock};
+    use tokio::sync::mpsc::{self, Receiver};
+    use tokio::sync::RwLock as AsyncRwLock;
     use trace::info;
 
-    use crate::kvcore::{COMPACT_REQ_CHANNEL_CAP, SUMMARY_REQ_CHANNEL_CAP};
-    use crate::{
-        compaction::{flush_tests::default_with_field_id, run_flush_memtable_job, FlushReq},
-        context::GlobalContext,
-        file_system::file_manager,
-        file_utils::{self, make_tsm_file_name},
-        kv_option::Options,
-        memcache::{FieldVal, MemCache, RowData, RowGroup},
-        summary::{CompactMeta, SummaryTask, VersionEdit},
-        tseries_family::{TimeRange, TseriesFamily, Version},
-        tsm::TsmTombstone,
-        version_set::VersionSet,
-        TseriesFamilyId,
-    };
-
     use super::{ColumnFile, LevelInfo};
+    use crate::compaction::flush_tests::default_with_field_id;
+    use crate::compaction::{run_flush_memtable_job, FlushReq};
+    use crate::context::GlobalContext;
+    use crate::file_system::file_manager;
+    use crate::file_utils::{self, make_tsm_file_name};
+    use crate::kv_option::Options;
+    use crate::kvcore::{COMPACT_REQ_CHANNEL_CAP, SUMMARY_REQ_CHANNEL_CAP};
+    use crate::memcache::{FieldVal, MemCache, RowData, RowGroup};
+    use crate::summary::{CompactMeta, SummaryTask, VersionEdit};
+    use crate::tseries_family::{TimeRange, TseriesFamily, Version};
+    use crate::tsm::TsmTombstone;
+    use crate::version_set::VersionSet;
+    use crate::TseriesFamilyId;
 
     #[tokio::test]
     async fn test_version_apply_version_edits_1() {

--- a/tskv/src/tsm/block.rs
+++ b/tskv/src/tsm/block.rs
@@ -1,18 +1,18 @@
-use minivec::MiniVec;
 use std::cmp::min;
-use std::{fmt::Display, mem::size_of, ops::Index};
+use std::fmt::Display;
+use std::mem::size_of;
+use std::ops::Index;
 
+use minivec::MiniVec;
 use models::{Timestamp, ValueType};
 use protos::models::FieldType;
 use trace::error;
 
-use crate::{
-    memcache::DataType,
-    tseries_family::TimeRange,
-    tsm::codec::{
-        get_bool_codec, get_f64_codec, get_i64_codec, get_str_codec, get_ts_codec, get_u64_codec,
-        DataBlockEncoding,
-    },
+use crate::memcache::DataType;
+use crate::tseries_family::TimeRange;
+use crate::tsm::codec::{
+    get_bool_codec, get_f64_codec, get_i64_codec, get_str_codec, get_ts_codec, get_u64_codec,
+    DataBlockEncoding,
 };
 
 pub trait ByTimeRange {
@@ -650,14 +650,15 @@ fn exclude_slow(v: &mut Vec<MiniVec<u8>>, min_idx: usize, max_idx: usize) {
 
 #[cfg(test)]
 pub mod test {
-    use minivec::mini_vec;
     use std::mem::size_of;
 
-    use crate::{
-        memcache::DataType,
-        tseries_family::TimeRange,
-        tsm::{block::exclude_fast, codec::DataBlockEncoding, DataBlock},
-    };
+    use minivec::mini_vec;
+
+    use crate::memcache::DataType;
+    use crate::tseries_family::TimeRange;
+    use crate::tsm::block::exclude_fast;
+    use crate::tsm::codec::DataBlockEncoding;
+    use crate::tsm::DataBlock;
 
     pub(crate) fn check_data_block(block: &DataBlock, pattern: &[DataType]) {
         assert_eq!(block.len(), pattern.len());

--- a/tskv/src/tsm/codec/boolean.rs
+++ b/tskv/src/tsm/codec/boolean.rs
@@ -1,7 +1,10 @@
-use std::{cmp, convert::TryInto, error::Error};
+use std::cmp;
+use std::convert::TryInto;
+use std::error::Error;
+
+use integer_encoding::VarInt;
 
 use crate::tsm::codec::Encoding;
-use integer_encoding::VarInt;
 // note: encode/decode adapted from influxdb_iox
 // https://github.com/influxdata/influxdb_iox/tree/main/influxdb_tsm/src/encoders
 

--- a/tskv/src/tsm/codec/float.rs
+++ b/tskv/src/tsm/codec/float.rs
@@ -1,7 +1,9 @@
+use std::error::Error;
+
+use q_compress::{auto_compress, auto_decompress, DEFAULT_COMPRESSION_LEVEL};
+
 use crate::byte_utils::decode_be_f64;
 use crate::tsm::codec::Encoding;
-use q_compress::{auto_compress, auto_decompress, DEFAULT_COMPRESSION_LEVEL};
-use std::error::Error;
 
 // note: encode/decode adapted from influxdb_iox
 // https://github.com/influxdata/influxdb_iox/tree/main/influxdb_tsm/src/encoders

--- a/tskv/src/tsm/codec/instance.rs
+++ b/tskv/src/tsm/codec/instance.rs
@@ -1,3 +1,10 @@
+use std::error::Error;
+
+use datafusion::physical_plan::expressions::Min;
+use libc::max_align_t;
+use minivec::MiniVec;
+use models::codec::Encoding;
+
 use crate::tsm::codec::boolean::{
     bool_bitpack_decode, bool_bitpack_encode, bool_without_compress_decode,
     bool_without_compress_encode,
@@ -24,11 +31,6 @@ use crate::tsm::codec::unsigned::{
     u64_q_compress_decode, u64_q_compress_encode, u64_without_compress_decode,
     u64_without_compress_encode, u64_zigzag_simple8b_decode, u64_zigzag_simple8b_encode,
 };
-use datafusion::physical_plan::expressions::Min;
-use libc::max_align_t;
-use minivec::MiniVec;
-use models::codec::Encoding;
-use std::error::Error;
 
 pub trait TimestampCodec {
     fn encode(&self, src: &[i64], dst: &mut Vec<u8>) -> Result<(), Box<dyn Error + Send + Sync>>;

--- a/tskv/src/tsm/codec/integer.rs
+++ b/tskv/src/tsm/codec/integer.rs
@@ -1,13 +1,13 @@
 use std::error::Error;
 
+use integer_encoding::*;
+
+use super::simple8b;
 use crate::tsm::codec::timestamp::{
     ts_q_compress_decode, ts_q_compress_encode, ts_without_compress_decode,
     ts_without_compress_encode,
 };
 use crate::tsm::codec::Encoding;
-use integer_encoding::*;
-
-use super::simple8b;
 
 // note: encode/decode adapted from influxdb_iox
 // https://github.com/influxdata/influxdb_iox/tree/main/influxdb_tsm/src/encoders

--- a/tskv/src/tsm/codec/simple8b.rs
+++ b/tskv/src/tsm/codec/simple8b.rs
@@ -214,7 +214,8 @@ fn decode_value(v: u64, dst: &mut [u64]) -> usize {
 #[cfg(test)]
 #[allow(clippy::unreadable_literal)]
 mod tests {
-    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
 

--- a/tskv/src/tsm/codec/string.rs
+++ b/tskv/src/tsm/codec/string.rs
@@ -1,15 +1,16 @@
+use std::convert::TryInto;
+use std::error::Error;
 use std::io::Write;
-use std::{convert::TryInto, error::Error};
 
-use crate::byte_utils::{decode_be_i64, decode_be_u32, decode_be_u64};
-use crate::tsm::codec::Encoding;
 use bzip2::write::{BzDecoder, BzEncoder};
 use bzip2::Compression as CompressionBzip;
-use flate2::write::{GzDecoder, GzEncoder};
-use flate2::write::{ZlibDecoder, ZlibEncoder};
+use flate2::write::{GzDecoder, GzEncoder, ZlibDecoder, ZlibEncoder};
 use flate2::Compression as CompressionFlate;
 use integer_encoding::VarInt;
 use minivec::MiniVec;
+
+use crate::byte_utils::{decode_be_i64, decode_be_u32, decode_be_u64};
+use crate::tsm::codec::Encoding;
 // note: encode/decode adapted from influxdb_iox
 // https://github.com/influxdata/influxdb_iox/tree/main/influxdb_tsm/src/encoders
 
@@ -353,8 +354,9 @@ pub fn str_without_compress_decode(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use datafusion::parquet::data_type::AsBytes;
+
+    use super::*;
 
     #[test]
     fn encode_no_values() {

--- a/tskv/src/tsm/codec/timestamp.rs
+++ b/tskv/src/tsm/codec/timestamp.rs
@@ -1,12 +1,12 @@
-use bytes::Buf;
 use std::error::Error;
 
-use crate::byte_utils::decode_be_i64;
-use crate::tsm::codec::Encoding;
+use bytes::Buf;
 use integer_encoding::*;
 use q_compress::{auto_compress, auto_decompress, DEFAULT_COMPRESSION_LEVEL};
 
 use super::simple8b;
+use crate::byte_utils::decode_be_i64;
+use crate::tsm::codec::Encoding;
 
 // note: encode/decode adapted from influxdb_iox
 // https://github.com/influxdata/influxdb_iox/tree/main/influxdb_tsm/src/encoders

--- a/tskv/src/tsm/codec/unsigned.rs
+++ b/tskv/src/tsm/codec/unsigned.rs
@@ -94,10 +94,9 @@ fn u64_to_i64_vector(src: &[u64]) -> Vec<i64> {
 #[cfg(test)]
 #[allow(clippy::unreadable_literal)]
 mod tests {
-    use super::{
-        super::{integer::DeltaEncoding, simple8b},
-        *,
-    };
+    use super::super::integer::DeltaEncoding;
+    use super::super::simple8b;
+    use super::*;
     use crate::tsm::codec::{get_encoding, Encoding};
 
     #[test]

--- a/tskv/src/tsm/index.rs
+++ b/tskv/src/tsm/index.rs
@@ -1,16 +1,16 @@
-use std::{cmp, fmt::Display, io::SeekFrom, sync::Arc};
+use std::cmp;
+use std::fmt::Display;
+use std::io::SeekFrom;
+use std::sync::Arc;
 
 use models::{FieldId, Timestamp, ValueType};
 use utils::BloomFilter;
 
-use crate::{
-    byte_utils::{self, decode_be_i64, decode_be_u16, decode_be_u32, decode_be_u64},
-    error::{Error, Result},
-    tseries_family::TimeRange,
-    tsm::{
-        BlockMetaIterator, WriteTsmError, WriteTsmResult, BLOCK_META_SIZE, FOOTER_SIZE,
-        INDEX_META_SIZE,
-    },
+use crate::byte_utils::{self, decode_be_i64, decode_be_u16, decode_be_u32, decode_be_u64};
+use crate::error::{Error, Result};
+use crate::tseries_family::TimeRange;
+use crate::tsm::{
+    BlockMetaIterator, WriteTsmError, WriteTsmResult, BLOCK_META_SIZE, FOOTER_SIZE, INDEX_META_SIZE,
 };
 
 #[derive(Debug, Clone)]

--- a/tskv/src/tsm/reader.rs
+++ b/tskv/src/tsm/reader.rs
@@ -1,34 +1,29 @@
-use std::{
-    borrow::Borrow,
-    fmt::Debug,
-    path::{Path, PathBuf},
-    ptr,
-    sync::Arc,
-};
+use std::borrow::Borrow;
+use std::fmt::Debug;
+use std::path::{Path, PathBuf};
+use std::ptr;
+use std::sync::Arc;
 
 use minivec::MiniVec;
+use models::{utils as model_utils, FieldId, Timestamp, ValueType};
 use parking_lot::RwLock;
 use snafu::{ResultExt, Snafu};
-
-use models::{utils as model_utils, FieldId, Timestamp, ValueType};
 use utils::BloomFilter;
 
-use crate::{
-    byte_utils::{decode_be_i64, decode_be_u16, decode_be_u32, decode_be_u64},
-    error::{self, Error, Result},
-    file_system::{file_manager, AsyncFile, IFile},
-    file_utils,
-    tseries_family::TimeRange,
-    tsm::{
-        codec::{
-            get_bool_codec, get_encoding, get_f64_codec, get_i64_codec, get_str_codec,
-            get_ts_codec, get_u64_codec, DataBlockEncoding,
-        },
-        get_data_block_meta_unchecked, get_index_meta_unchecked,
-        tombstone::TsmTombstone,
-        BlockEntry, BlockMeta, DataBlock, Index, IndexEntry, IndexMeta, BLOCK_META_SIZE,
-        BLOOM_FILTER_SIZE, FOOTER_SIZE, INDEX_META_SIZE, MAX_BLOCK_VALUES,
-    },
+use crate::byte_utils::{decode_be_i64, decode_be_u16, decode_be_u32, decode_be_u64};
+use crate::error::{self, Error, Result};
+use crate::file_system::{file_manager, AsyncFile, IFile};
+use crate::file_utils;
+use crate::tseries_family::TimeRange;
+use crate::tsm::codec::{
+    get_bool_codec, get_encoding, get_f64_codec, get_i64_codec, get_str_codec, get_ts_codec,
+    get_u64_codec, DataBlockEncoding,
+};
+use crate::tsm::tombstone::TsmTombstone;
+use crate::tsm::{
+    get_data_block_meta_unchecked, get_index_meta_unchecked, BlockEntry, BlockMeta, DataBlock,
+    Index, IndexEntry, IndexMeta, BLOCK_META_SIZE, BLOOM_FILTER_SIZE, FOOTER_SIZE, INDEX_META_SIZE,
+    MAX_BLOCK_VALUES,
 };
 
 pub type ReadTsmResult<T, E = ReadTsmError> = std::result::Result<T, E>;
@@ -672,27 +667,22 @@ pub fn decode_data_block(
 #[cfg(test)]
 pub mod tsm_reader_tests {
     use core::panic;
-    use std::{
-        collections::HashMap,
-        path::{Path, PathBuf},
-        sync::Arc,
-    };
-
-    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
 
     use models::{FieldId, Timestamp};
+    use parking_lot::Mutex;
     use snafu::ResultExt;
 
+    use crate::error::{self, Error, Result};
+    use crate::file_system::file_manager::{self, get_file_manager};
+    use crate::file_utils;
+    use crate::tseries_family::TimeRange;
     use crate::tsm::codec::DataBlockEncoding;
-    use crate::{
-        error::{self, Error, Result},
-        file_utils,
-        tseries_family::TimeRange,
-        tsm::{BlockEntry, DataBlock, IndexEntry, IndexFile, TsmReader, TsmTombstone, TsmWriter},
-    };
-    use crate::{
-        file_system::file_manager::{self, get_file_manager},
-        tsm::tsm_writer_tests::write_to_tsm,
+    use crate::tsm::tsm_writer_tests::write_to_tsm;
+    use crate::tsm::{
+        BlockEntry, DataBlock, IndexEntry, IndexFile, TsmReader, TsmTombstone, TsmWriter,
     };
 
     async fn prepare(dir: impl AsRef<Path>) -> Result<(PathBuf, PathBuf)> {

--- a/tskv/src/tsm/tombstone.rs
+++ b/tskv/src/tsm/tombstone.rs
@@ -11,16 +11,12 @@
 //! +------------+---------------+---------------+
 //! ```
 
-use std::{
-    collections::HashMap,
-    fmt::write,
-    io::IoSlice,
-    path::{Path, PathBuf},
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-};
+use std::collections::HashMap;
+use std::fmt::write;
+use std::io::IoSlice;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use bytes::buf;
 use datafusion::parquet::record;
@@ -29,16 +25,11 @@ use parking_lot::{Mutex, RwLock};
 use snafu::ResultExt;
 use trace::error;
 
-use crate::{
-    byte_utils, error,
-    file_system::{file_manager, AsyncFile, FileCursor, IFile},
-    file_utils,
-    record_file::{self, RecordDataType, RecordDataVersion},
-    tseries_family::TimeRange,
-    Error, Result,
-};
-
 use super::DataBlock;
+use crate::file_system::{file_manager, AsyncFile, FileCursor, IFile};
+use crate::record_file::{self, RecordDataType, RecordDataVersion};
+use crate::tseries_family::TimeRange;
+use crate::{byte_utils, error, file_utils, Error, Result};
 
 const TOMBSTONE_FILE_SUFFIX: &str = ".tombstone";
 const FOOTER_MAGIC_NUMBER: u32 = u32::from_be_bytes([b'r', b'o', b'm', b'b']);
@@ -223,15 +214,14 @@ impl TsmTombstone {
 
 #[cfg(test)]
 mod test {
-    use std::{
-        path::{Path, PathBuf},
-        str::FromStr,
-        sync::Arc,
-    };
+    use std::path::{Path, PathBuf};
+    use std::str::FromStr;
+    use std::sync::Arc;
 
     use super::TsmTombstone;
     use crate::file_system::file_manager;
-    use crate::{byte_utils, file_utils, tseries_family::TimeRange};
+    use crate::tseries_family::TimeRange;
+    use crate::{byte_utils, file_utils};
 
     #[tokio::test]
     async fn test_write_read_1() {

--- a/tskv/src/tsm/writer.rs
+++ b/tskv/src/tsm/writer.rs
@@ -1,22 +1,18 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    io::IoSlice,
-    path::{Path, PathBuf},
-};
+use std::collections::{BTreeMap, HashMap};
+use std::io::IoSlice;
+use std::path::{Path, PathBuf};
 
 use models::{FieldId, Timestamp, ValueType};
 use protos::kv_service::FieldType;
 use snafu::{ResultExt, Snafu};
 use utils::{BkdrHasher, BloomFilter};
 
-use crate::{
-    error::{self, Error, Result},
-    file_system::{file_manager, FileCursor, IFile},
-    file_utils,
-    tsm::{
-        BlockEntry, BlockMeta, BlockMetaIterator, DataBlock, Index, IndexEntry, IndexMeta,
-        BLOCK_META_SIZE, BLOOM_FILTER_BITS, INDEX_META_SIZE, MAX_BLOCK_VALUES,
-    },
+use crate::error::{self, Error, Result};
+use crate::file_system::{file_manager, FileCursor, IFile};
+use crate::file_utils;
+use crate::tsm::{
+    BlockEntry, BlockMeta, BlockMetaIterator, DataBlock, Index, IndexEntry, IndexMeta,
+    BLOCK_META_SIZE, BLOOM_FILTER_BITS, INDEX_META_SIZE, MAX_BLOCK_VALUES,
 };
 
 // A TSM file is composed for four sections: header, blocks, index and the footer.
@@ -480,28 +476,22 @@ async fn write_footer_to(
 
 #[cfg(test)]
 pub mod tsm_writer_tests {
-    use std::{
-        collections::HashMap,
-        io::{Error as IoError, ErrorKind as IoErrorKind},
-        path::{Path, PathBuf},
-        sync::Arc,
-    };
+    use std::collections::HashMap;
+    use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
 
     use models::{FieldId, ValueType};
     use snafu::ResultExt;
 
-    use crate::{
-        error::{self, Error, Result},
-        file_system::file_manager::{self, get_file_manager, FileManager},
-        file_system::IFile,
-        file_utils::{self, make_tsm_file_name},
-        memcache::FieldVal,
-        tsm::tsm_reader_tests::read_and_check,
-        tsm::{
-            codec::DataBlockEncoding, new_tsm_writer, ColumnReader, DataBlock, IndexReader,
-            TsmReader, TsmWriter,
-        },
-    };
+    use crate::error::{self, Error, Result};
+    use crate::file_system::file_manager::{self, get_file_manager, FileManager};
+    use crate::file_system::IFile;
+    use crate::file_utils::{self, make_tsm_file_name};
+    use crate::memcache::FieldVal;
+    use crate::tsm::codec::DataBlockEncoding;
+    use crate::tsm::tsm_reader_tests::read_and_check;
+    use crate::tsm::{new_tsm_writer, ColumnReader, DataBlock, IndexReader, TsmReader, TsmWriter};
 
     const TEST_PATH: &str = "/tmp/test/tsm_writer";
 

--- a/tskv/src/version_set.rs
+++ b/tskv/src/version_set.rs
@@ -1,32 +1,27 @@
-use std::{
-    collections::HashMap,
-    sync::{atomic::AtomicU32, atomic::Ordering, Arc, Mutex},
-};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
 
 use meta::MetaRef;
 use models::schema::{make_owner, split_owner, DatabaseSchema};
 use parking_lot::RwLock as SyncRwLock;
 use snafu::ResultExt;
-use tokio::{
-    runtime::Runtime,
-    sync::{mpsc::Sender, oneshot, watch::Receiver, RwLock},
-};
-
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::watch::Receiver;
+use tokio::sync::{oneshot, RwLock};
 use trace::error;
 use utils::BloomFilter;
 
-use crate::{
-    compaction::FlushReq,
-    context::GlobalSequenceContext,
-    database::Database,
-    error::MetaSnafu,
-    error::Result,
-    kv_option::StorageOptions,
-    memcache::MemCache,
-    summary::{VersionEdit, WriteSummaryRequest},
-    tseries_family::{LevelInfo, TseriesFamily, Version},
-    ColumnFileId, Options, TseriesFamilyId,
-};
+use crate::compaction::FlushReq;
+use crate::context::GlobalSequenceContext;
+use crate::database::Database;
+use crate::error::{MetaSnafu, Result};
+use crate::kv_option::StorageOptions;
+use crate::memcache::MemCache;
+use crate::summary::{VersionEdit, WriteSummaryRequest};
+use crate::tseries_family::{LevelInfo, TseriesFamily, Version};
+use crate::{ColumnFileId, Options, TseriesFamilyId};
 
 #[derive(Debug)]
 pub struct VersionSet {

--- a/tskv/src/wal.rs
+++ b/tskv/src/wal.rs
@@ -20,36 +20,29 @@
 //! +------------+---------------+--------------+--------------+
 //! ```
 
-use datafusion::parquet::data_type::AsBytes;
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    string::String,
-    sync::Arc,
-};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::string::String;
+use std::sync::Arc;
 
-use models::{
-    auth::user::{ROOT, ROOT_PWD},
-    codec::Encoding,
-};
+use datafusion::parquet::data_type::AsBytes;
+use models::auth::user::{ROOT, ROOT_PWD};
+use models::codec::Encoding;
 use protos::kv_service::{Meta, WritePointsRequest};
 use snafu::ResultExt;
 use tokio::sync::{oneshot, RwLock};
 use trace::{debug, error, info, warn};
 
-use crate::{
-    byte_utils::{decode_be_u32, decode_be_u64},
-    context::{GlobalContext, GlobalSequenceContext},
-    engine,
-    error::{self, Error, Result},
-    file_system::file_manager::{self, FileManager},
-    file_utils,
-    kv_option::WalOptions,
-    record_file::{self, Record, RecordDataType, RecordDataVersion},
-    tsm::{codec::get_str_codec, DecodeSnafu, EncodeSnafu},
-    version_set::VersionSet,
-    TseriesFamilyId,
-};
+use crate::byte_utils::{decode_be_u32, decode_be_u64};
+use crate::context::{GlobalContext, GlobalSequenceContext};
+use crate::error::{self, Error, Result};
+use crate::file_system::file_manager::{self, FileManager};
+use crate::kv_option::WalOptions;
+use crate::record_file::{self, Record, RecordDataType, RecordDataVersion};
+use crate::tsm::codec::get_str_codec;
+use crate::tsm::{DecodeSnafu, EncodeSnafu};
+use crate::version_set::VersionSet;
+use crate::{engine, file_utils, TseriesFamilyId};
 
 const ENTRY_TYPE_LEN: usize = 1;
 const ENTRY_SEQUENCE_LEN: usize = 8;
@@ -547,48 +540,42 @@ impl WalReader {
 #[cfg(test)]
 mod test {
     use core::panic;
+    use std::borrow::BorrowMut;
     use std::collections::HashMap;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
     use std::time::Duration;
-    use std::{borrow::BorrowMut, path::PathBuf, sync::Arc};
 
     use chrono::Utc;
+    use config::get_config;
     use datafusion::parquet::data_type::AsBytes;
     use flatbuffers::{self, Vector, WIPOffset};
     use lazy_static::lazy_static;
     use meta::meta_manager::RemoteMetaManager;
     use meta::MetaRef;
     use minivec::MiniVec;
+    use models::codec::Encoding;
+    use models::schema::TenantOptions;
     use models::Timestamp;
     use protos::models::FieldType;
+    use protos::{models as fb_models, models_helper};
     use serial_test::serial;
     use tokio::runtime;
     use tokio::sync::RwLock;
     use tokio::time::sleep;
-
-    use config::get_config;
-
-    use models::codec::Encoding;
-    use models::schema::TenantOptions;
-    use protos::{models as fb_models, models_helper};
     use trace::{info, init_default_global_tracing};
 
+    use crate::context::GlobalSequenceContext;
+    use crate::engine::Engine;
+    use crate::file_system::file_manager::{self, list_file_names, FileManager};
+    use crate::file_system::FileCursor;
+    use crate::kv_option::WalOptions;
     use crate::memcache::test::get_one_series_cache_data;
     use crate::memcache::{FieldVal, MemCache};
-    use crate::{
-        context::GlobalSequenceContext,
-        engine::Engine,
-        file_system::{
-            file_manager::{self, list_file_names, FileManager},
-            FileCursor,
-        },
-        kv_option,
-        kv_option::WalOptions,
-        tsm::codec::get_str_codec,
-        version_set::VersionSet,
-        wal::{self, WalEntryBlock, WalEntryType, WalManager, WalReader},
-        Error, Options, Result, TsKv,
-    };
+    use crate::tsm::codec::get_str_codec;
+    use crate::version_set::VersionSet;
+    use crate::wal::{self, WalEntryBlock, WalEntryType, WalManager, WalReader};
+    use crate::{kv_option, Error, Options, Result, TsKv};
 
     fn random_write_data() -> Vec<u8> {
         let mut fbb = flatbuffers::FlatBufferBuilder::new();

--- a/tskv/tests/test_kvcore_interface.rs
+++ b/tskv/tests/test_kvcore_interface.rs
@@ -1,22 +1,21 @@
 #[cfg(test)]
 mod tests {
 
-    use meta::meta_manager::RemoteMetaManager;
-    use meta::MetaRef;
-    use serial_test::serial;
     use std::path::Path;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
-    use tokio::runtime;
-    use tokio::runtime::Runtime;
-    use tskv::engine::Engine;
 
     use config::get_config;
+    use meta::meta_manager::RemoteMetaManager;
+    use meta::MetaRef;
     use models::schema::TenantOptions;
-
     use protos::kv_service::Meta;
     use protos::{kv_service, models_helper};
+    use serial_test::serial;
+    use tokio::runtime;
+    use tokio::runtime::Runtime;
     use trace::{debug, error, info, init_default_global_tracing, warn};
+    use tskv::engine::Engine;
     use tskv::file_system::file_manager;
     use tskv::{kv_option, TsKv};
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

Added two config in rustfmt.toml.

```toml
group_imports = "StdExternalCrate"
imports_granularity = "Module"
```

After:

```rust
use std::fs::File;
use std::io::Write;

use actix_web::web::Data;
use actix_web::{get, post, web, Responder};

use crate::store::state_machine::CommandResp;
use crate::MetaApp;
```

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
