### PR TITLE
feat(config): Change type of  size items to string (num + k/m/g)

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -17,11 +17,11 @@ auth_enabled = false
 path = 'data/db'
 
 # The maximum file size of summary file.
-max_summary_size = 134217728 # 128M (128 * 1024 * 1024)
+max_summary_size = "128M" # 134217728
 
 # The maximum file size of a level is:
 # $base_file_size * level * $compact_trigger_file_num
-base_file_size = 16777216 # 16M (16 * 1024 * 1024)
+base_file_size = "16M" # 16777216
 
 # The maxmimum data file level (from 0 to 4).
 max_level = 4
@@ -33,7 +33,7 @@ compact_trigger_file_num = 4
 compact_trigger_cold_duration = "1h"
 
 # The maximum size of all files in a compaction.
-max_compact_size = 2147483648 # 2G (2 * 1024 * 1024 * 1024)
+max_compact_size = "2G" # 2147483648
 
 # The maximum concurrent compactions.
 max_concurrent_compaction = 4
@@ -50,14 +50,14 @@ enabled = true
 path = 'data/wal'
 
 # The maximum size of a wal file.
-max_file_size = 1073741824 # 1024 * 1024 * 1024
+max_file_size = "1G" # 1073741824
 
 # If true, fsync will be called after every wal writes.
 sync = false
 sync_interval = "0" # h, m, s
 
 [cache]
-max_buffer_size = 134217728 # 128M (128 * 1024 * 1024)
+max_buffer_size = "128M" # 134217728
 max_immutable_number = 4
 
 [log]

--- a/config/config_31001.toml
+++ b/config/config_31001.toml
@@ -10,12 +10,12 @@ auth_enabled = false
 # Directory for tsm: $path/data/$database/tsm/
 # Directory for delta: $path/data/$database/delta/
 path = '/tmp/cnosdb/1001/db'
-max_summary_size = 134217728 # 128 * 1024 * 1024
-base_file_size = 16777216 # 16 * 1024 * 1024
+max_summary_size = "128M" # 134217728
+base_file_size = "16M" # 16777216
 max_level = 4
 compact_trigger_file_num = 4
 compact_trigger_cold_duration = "1h"
-max_compact_size = 2147483648 # 2 * 1024 * 1024 * 1024
+max_compact_size = "2G" # 2147483648
 max_concurrent_compaction = 4
 dio_max_resident = 1024
 dio_max_non_resident = 1024
@@ -25,11 +25,11 @@ strict_write = false
 [wal]
 enabled = true
 path = '/tmp/cnosdb/1001/wal'
-max_file_size = 1073741824 # 1024 * 1024 * 1024
+max_file_size = "1G" # 1073741824
 sync = false
 
 [cache]
-max_buffer_size = 134217728 # 128 * 1024 * 1024
+max_buffer_size = "128M" # 134217728
 max_immutable_number = 4
 
 [log]

--- a/config/config_32001.toml
+++ b/config/config_32001.toml
@@ -10,12 +10,12 @@ auth_enabled = false
 # Directory for tsm: $path/data/$database/tsm/
 # Directory for delta: $path/data/$database/delta/
 path = '/tmp/cnosdb/2001/db'
-max_summary_size = 134217728 # 128 * 1024 * 1024
-base_file_size = 16777216 # 16 * 1024 * 1024
+max_summary_size = "128M" # 134217728
+base_file_size = "16M" # 16777216
 max_level = 4
 compact_trigger_file_num = 4
 compact_trigger_cold_duration = "1h"
-max_compact_size = 2147483648 # 2 * 1024 * 1024 * 1024
+max_compact_size = "2G" # 2147483648
 max_concurrent_compaction = 4
 dio_max_resident = 1024
 dio_max_non_resident = 1024
@@ -25,11 +25,11 @@ strict_write = false
 [wal]
 enabled = true
 path = '/tmp/cnosdb/2001/wal'
-max_file_size = 1073741824 # 1024 * 1024 * 1024
+max_file_size = "1G" # 1073741824
 sync = false
 
 [cache]
-max_buffer_size = 134217728 # 128 * 1024 * 1024
+max_buffer_size = "128M" # 134217728
 max_immutable_number = 4
 
 [log]

--- a/config/src/bytes_num.rs
+++ b/config/src/bytes_num.rs
@@ -1,0 +1,272 @@
+use std::error::Error;
+
+use serde::{Deserialize, Deserializer, Serializer};
+
+// The signature of a serialize_with function must follow the pattern:
+//
+//    fn serialize<S>(&T, S) -> Result<S::Ok, S::Error>
+//    where
+//        S: Serializer
+//
+// although it may also be generic over the input types T.
+pub fn serialize<S>(num: &u64, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let s = format!("{:?}", num);
+    serializer.serialize_str(&s)
+}
+
+// The signature of a deserialize_with function must follow the pattern:
+//
+//    fn deserialize<'de, D>(D) -> Result<T, D::Error>
+//    where
+//        D: Deserializer<'de>
+//
+// although it may also be generic over the output types T.
+pub fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    parse_number(&s).map_err(serde::de::Error::custom)
+}
+
+const BYTE_CHARS: &[char] = &['b'];
+
+const KILOBYTES_CHARS: &[char] = &['k', 'b'];
+const KIBIBYTES_CHARS: &[char] = &['k', 'i', 'b'];
+const KIBIBYTES_SHORT: &[char] = &['k'];
+
+const MEGABYTES_CHARS: &[char] = &['m', 'b'];
+const MEBIBYTES_CHARS: &[char] = &['m', 'i', 'b'];
+const MEBIBYTES_SHORT: &[char] = &['m'];
+
+const GIGABYTES_CHARS: &[char] = &['g', 'b'];
+const GIBIBYTES_CHARS: &[char] = &['g', 'i', 'b'];
+const GIBIBYTES_SHORT: &[char] = &['g'];
+
+const BYTES: u64 = 1;
+const KILOBYTES: u64 = BYTES * 1000;
+const KIBIBYTES: u64 = BYTES * 1024;
+const MEGABYTES: u64 = KILOBYTES * 1000;
+const MEBIBYTES: u64 = KIBIBYTES * 1024;
+const GIGABYTES: u64 = MEGABYTES * 1000;
+const GIBIBYTES: u64 = MEBIBYTES * 1024;
+// terabytes
+// tebibytes
+// petabytes
+// pebibytes
+// exabytes
+// exbibytes
+// zettabyte
+// zebibyte
+
+/// Parse ([0-9]+[a-z]+) to u64 bytes.
+pub(crate) fn parse_number(num_str: &str) -> Result<u64, Box<dyn Error>> {
+    if num_str == "0" {
+        return Ok(0);
+    }
+    if num_str.is_empty() {
+        return Err(From::from(format!("Invalid bytes number '{}'", num_str)));
+    }
+
+    let chars: Vec<char> = num_str.to_lowercase().chars().collect();
+    let mut s = chars.as_slice();
+    let mut v;
+
+    // Consume integers
+    (v, s) = match consume_int(s) {
+        Ok((val, sli)) => (val, sli),
+        Err(e) => {
+            return Err(From::from(format!(
+                "Invalid bytes number ({}): '{}'",
+                e, num_str
+            )))
+        }
+    };
+
+    // Consume unit.
+    let mut i = 0_usize;
+    for c in s {
+        if *c == '.' || '0' <= *c && *c <= '9' {
+            break;
+        }
+        i += 1;
+    }
+    let mut unit = BYTES;
+    if i > 0 {
+        let u = &s[..i];
+        unit = match u {
+            BYTE_CHARS => BYTES,
+            KILOBYTES_CHARS => KILOBYTES,
+            KIBIBYTES_CHARS | KIBIBYTES_SHORT => KIBIBYTES,
+            MEGABYTES_CHARS => MEGABYTES,
+            MEBIBYTES_CHARS | MEBIBYTES_SHORT => MEBIBYTES,
+            GIGABYTES_CHARS => GIGABYTES,
+            GIBIBYTES_CHARS | GIBIBYTES_SHORT => GIBIBYTES,
+            _ => {
+                return Err(From::from(format!(
+                    "Unknown unit '{:?}' in bytes number '{}'",
+                    u, num_str
+                )))
+            }
+        }
+    }
+
+    if v > u64::MAX / unit {
+        return Err(From::from(format!(
+            "Invalid bytes number (u64 overflow) '{}'",
+            num_str
+        )));
+    }
+    v *= unit;
+
+    Ok(v)
+}
+
+fn consume_int(s: &[char]) -> Result<(u64, &[char]), Box<dyn Error>> {
+    let mut i = 0_usize;
+    let mut x = 0_u64;
+    for c in s {
+        if *c == '_' {
+            i += 1;
+            continue;
+        }
+        if *c < '0' || *c > '9' {
+            break;
+        }
+        if x > u64::MAX / 10 {
+            return Err(From::from("u64 overflow"));
+        }
+        x = x * 10 + *c as u64 - '0' as u64;
+        i += 1;
+    }
+    Ok((x, &s[i..]))
+}
+
+#[cfg(test)]
+mod test {
+    use std::any::Any;
+
+    use serde::{Deserialize, Serialize};
+
+    use crate::bytes_num::{self, parse_number};
+
+    #[test]
+    fn test_parse() {
+        assert_eq!(parse_number("1024").unwrap(), 1024);
+        assert_eq!(parse_number("1Kib").unwrap(), 1024);
+        assert_eq!(parse_number("1k").unwrap(), 1024);
+        assert_eq!(parse_number("1K").unwrap(), 1024);
+        assert_eq!(parse_number("1kb").unwrap(), 1_000);
+        assert_eq!(parse_number("1mib").unwrap(), 1024 * 1024);
+        assert_eq!(parse_number("1Mib").unwrap(), 1024 * 1024);
+        assert_eq!(parse_number("1m").unwrap(), 1024 * 1024);
+        assert_eq!(parse_number("1M").unwrap(), 1024 * 1024);
+        assert_eq!(parse_number("1mb").unwrap(), 1_000_000);
+        assert_eq!(parse_number("1mB").unwrap(), 1_000_000);
+        assert_eq!(parse_number("1gib").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_number("1Gib").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_number("1g").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_number("1G").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_number("1gb").unwrap(), 1_000_000_000);
+        assert_eq!(parse_number("1Gb").unwrap(), 1_000_000_000);
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct Foo {
+        pub name: String,
+        #[serde(with = "bytes_num")]
+        pub number: u64,
+    }
+
+    #[rustfmt::skip]
+    fn check_foo(foo: Foo, name: &str, number: u64) -> Result<(), Box<dyn Any + Send + 'static>> {
+        std::panic::catch_unwind(|| {
+            assert_eq!(foo.number, number, "Checking foo {:?} with '{}' and {}", foo, name, number);
+            assert_eq!(foo.name.as_str(), name,
+                "Checking {:?} with name: '{}' and number: {}", foo, name, number);
+        })
+    }
+
+    #[test]
+    fn test_ok() {
+        let config_str = r#"
+            number = "1024_000"
+            name = "Bar0"
+        "#;
+        check_foo(toml::from_str(config_str).unwrap(), "Bar0", 1024000).unwrap();
+
+        let config_str = r#"
+            number = "1kB"
+            name = "Bar1_1"
+        "#;
+        check_foo(toml::from_str(config_str).unwrap(), "Bar1_1", 1_000).unwrap();
+
+        let config_str = r#"
+            number = "2kIb"
+            name = "Bar1_2"
+        "#;
+        check_foo(toml::from_str(config_str).unwrap(), "Bar1_2", 2 * 1024).unwrap();
+
+        let config_str = r#"
+            number = "3MB"
+            name = "Bar2_1"
+        "#;
+        check_foo(toml::from_str(config_str).unwrap(), "Bar2_1", 3_000_000).unwrap();
+
+        let config_str = r#"
+            number = "4miB"
+            name = "Bar2_2"
+        "#;
+        check_foo(
+            toml::from_str(config_str).unwrap(),
+            "Bar2_2",
+            4 * 1024 * 1024,
+        )
+        .unwrap();
+
+        let config_str = r#"
+            number = "5Gb"
+            name = "Bar3_1"
+        "#;
+        check_foo(toml::from_str(config_str).unwrap(), "Bar3_1", 5_000_000_000).unwrap();
+
+        let config_str = r#"
+            number = "6GiB"
+            name = "Bar3_2"
+        "#;
+        check_foo(
+            toml::from_str(config_str).unwrap(),
+            "Bar3_2",
+            6 * 1024 * 1024 * 1024,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_error() {
+        let config_str = r#"
+            number = "a1s"
+            name = "Bar1"
+        "#;
+        let err = toml::from_str::<Foo>(config_str).unwrap_err();
+        let err_msg = format!("{}", err);
+        assert_eq!(
+            &err_msg,
+            "Unknown unit '['a']' in bytes number 'a1s' for key `number` at line 1 column 1"
+        );
+
+        let config_str = r#"
+            number = "10_000_000_000_000Gib"
+            name = "Bar2"
+        "#;
+        let err = toml::from_str::<Foo>(config_str).unwrap_err();
+        let err_msg = format!("{}", err);
+        assert_eq!(
+            &err_msg,
+            "Invalid bytes number (u64 overflow) '10_000_000_000_000Gib' for key `number` at line 1 column 1"
+        );
+    }
+}

--- a/config/src/duration.rs
+++ b/config/src/duration.rs
@@ -53,7 +53,7 @@ pub(crate) fn parse_duration(duration_str: &str) -> Result<Duration, Box<dyn Err
         return Ok(Duration::from_nanos(0));
     }
     if duration_str.is_empty() {
-        return Err(From::from(format!("invalid duration '{}'", duration_str)));
+        return Err(From::from(format!("Invalid duration '{}'", duration_str)));
     }
 
     let chars: Vec<char> = duration_str.chars().collect();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

# What changes are included in this PR?

You can use "number + unit" instead of a number to specify a byte number item.

Units are case-insensitive, you can use '1KiB' or '1kib' to get a value that equal to 1024.

- `b` | Empty Unit: bytes
- `kb`: kilobytes (aka 1000 bytes)
- `mb`: megabytes
- `gb`: gigabytes
- `k` | `kib`: kibibytes (aka 1024 bytes)
- `m` | `mib`: mebibytes
- `g` | `gib`: gibibytes

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
