### PR TITLE
fix(recover): Vnodes flushed earlier lose data in recovering

### DIFF
--- a/tskv/src/context.rs
+++ b/tskv/src/context.rs
@@ -102,8 +102,14 @@ impl GlobalSequenceContext {
         self.min_seq.store(inner.min_seq, Ordering::Release);
     }
 
+    /// Get minimum sequence number of presisted write request
+    /// of all `TseriesFamily`s in all `Database`s
     pub fn min_seq(&self) -> u64 {
         self.min_seq.load(Ordering::Acquire)
+    }
+
+    pub fn cloned(&self) -> HashMap<TseriesFamilyId, u64> {
+        self.inner.read().tsf_seq_map.clone()
     }
 }
 
@@ -119,7 +125,6 @@ impl GlobalSequenceContext {
         })
     }
 
-    #[cfg(test)]
     pub fn set_min_seq(&self, min_seq: u64) {
         let mut inner = self.inner.write();
         inner.min_seq = min_seq;
@@ -129,7 +134,8 @@ impl GlobalSequenceContext {
 
 #[derive(Debug)]
 struct GlobalSequenceContextInner {
-    /// Minimum sequence number of all `TseriesFamily`s in all `Database`s
+    /// Minimum sequence number of presisted write request
+    /// among all `TseriesFamily`s in all `Database`s.ß
     min_seq: u64,
     /// Maps `TseriesFamily`-ID to it's last sequence number flushed to disk.
     tsf_seq_map: HashMap<TseriesFamilyId, u64>,

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -185,10 +185,7 @@ impl TsKv {
             .await
             .unwrap();
 
-        wal_manager
-            .recover(self, self.global_ctx.clone())
-            .await
-            .unwrap();
+        wal_manager.recover(self).await.unwrap();
 
         wal_manager
     }
@@ -524,7 +521,6 @@ impl Engine for TsKv {
         let tsf = self
             .get_tsfamily_or_else_create(seq, id, None, db.clone())
             .await?;
-
         tsf.read().await.put_points(seq, write_group)?;
         return Ok(());
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

Now recovering WAL is from a **seq_no** `GlobalContext::last_seq()` which means the sequence number of the latest persisted write request to a Vnode records in summary file, in other words, the  maximum **seq_no** among all Vnodes of all databases, so all write requests to Vnodes flushed earlier with seq_no less than that  **seq_no** was losed.

# What changes are included in this PR?

Now we get the **seq_no** by `GlobalSequenceContext::min_seq()` which means the minimum sequence number of persisted write request of all Vnodes in all Databases.

Also, get the `HashMap` that maps vnode-id to vnode-`last_seq`s. When recovering WAL, get vnode-id and `seq` from each write requests, if `seq` is less than `last_seq`, ignore the write request.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
