### PR TITLE
feat(test): integration test prints more details.

### DIFF
--- a/query_server/test/src/case.rs
+++ b/query_server/test/src/case.rs
@@ -1,18 +1,23 @@
 use std::fmt::{Display, Formatter};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Instant;
 
 use tokio::fs;
 use walkdir::WalkDir;
 
 use crate::db_request::DBRequest;
+use crate::db_result::DBResult;
 use crate::error::{Error, Result};
 use crate::CLIENT;
 
 #[derive(Clone, Debug)]
 pub struct Case {
-    name: String,
+    name: Arc<String>,
     path: PathBuf,
+    sql_file_path: PathBuf,
+    res_file_path: PathBuf,
+    out_file_path: PathBuf,
 }
 
 impl Case {
@@ -25,60 +30,101 @@ impl Case {
             .to_string();
 
         let path = sql_path.parent().ok_or(Error::CaseNew)?.to_path_buf();
-        Ok(Case { name, path })
+        let sql_file_path = Self::sql_file(&path, &name);
+        let res_file_path = Self::res_file(&path, &name);
+        let out_file_path = Self::out_file(&path, &name);
+        Ok(Case {
+            name: Arc::new(name),
+            path,
+            sql_file_path,
+            res_file_path,
+            out_file_path,
+        })
     }
 
     pub fn case_name(&self) -> &str {
         self.name.as_str()
     }
 
-    fn sql_file(&self) -> PathBuf {
-        let mut res = self.path.to_owned();
-        res.push(&self.name);
-        res.set_extension("sql");
-        res
+    fn sql_file(path: impl AsRef<Path>, name: &str) -> PathBuf {
+        let mut path: PathBuf = path.as_ref().into();
+        path.push(name);
+        path.set_extension("sql");
+        path
     }
 
-    fn out_file(&self) -> PathBuf {
-        let mut res = self.path.to_owned();
-        res.push(&self.name);
-        res.set_extension("out");
-        res
+    fn out_file(path: impl AsRef<Path>, name: &str) -> PathBuf {
+        let mut path: PathBuf = path.as_ref().into();
+        path.push(name);
+        path.set_extension("out");
+        path
     }
 
-    fn res_file(&self) -> PathBuf {
-        let mut res = self.path.to_owned();
-        res.push(&self.name);
-        res.set_extension("result");
-        res
+    fn res_file(path: impl AsRef<Path>, name: &str) -> PathBuf {
+        let mut path: PathBuf = path.as_ref().into();
+        path.push(name);
+        path.set_extension("result");
+        path
     }
 
     pub async fn get_queries(&self) -> Result<Vec<DBRequest>> {
-        let content = fs::read_to_string(self.sql_file()).await?;
+        let content = fs::read_to_string(&self.sql_file_path).await?;
         Ok(DBRequest::parse_requests(&content))
     }
 
+    pub async fn get_results(&self) -> Result<Vec<DBResult>> {
+        let content = fs::read_to_string(&self.res_file_path).await?;
+        Ok(DBResult::parse(self.name.clone(), &content))
+    }
+
     /// check out and expected result
-    pub async fn check(&self, result: &str, out: &str) -> bool {
-        let mut is_diff = false;
-        for diff in diff::lines(result, out) {
-            match diff {
-                diff::Result::Left(l) => {
-                    is_diff = true;
-                    println!("-{}", l)
+    pub async fn check(&self, origins: &[DBResult], outs: &[DBResult]) -> bool {
+        let mut no_diff = true;
+        let mut diff_buf = String::with_capacity(512);
+        for (i, (l, r)) in origins.iter().zip(outs.iter()).enumerate() {
+            let (mut ll, mut rl) = (1, 1);
+            let mut is_diff = false;
+            diff_buf.clear();
+            for diff in diff::lines(&l.response, &r.response) {
+                match diff {
+                    diff::Result::Left(l) => {
+                        is_diff = true;
+                        diff_buf.push_str(format!("{:<4}|    | -{}\n", ll, l).as_str());
+                        ll += 1;
+                    }
+                    diff::Result::Right(r) => {
+                        is_diff = true;
+                        diff_buf.push_str(format!("    |{:<4}| +{}\n", rl, r).as_str());
+                        rl += 1;
+                    }
+                    _ => {
+                        ll += 1;
+                        rl += 1;
+                    }
                 }
-                diff::Result::Right(r) => {
-                    is_diff = true;
-                    println!("+{}", r)
-                }
-                _ => {}
+            }
+            if is_diff {
+                no_diff = false;
+                println!(
+                    r#"====================
+Case: {} [{}]
+--------------------
+{}
+--------------------
+{}
+===================="#,
+                    &l.case_name,
+                    i + 1,
+                    &l.request,
+                    &diff_buf.trim_end()
+                );
+                fs::write(&self.out_file_path, format!("{}", r))
+                    .await
+                    .unwrap();
             }
         }
 
-        if is_diff {
-            fs::write(self.out_file(), &out).await.unwrap();
-        }
-        !is_diff
+        no_diff
     }
 
     /// run and return is succeed
@@ -87,15 +133,29 @@ impl Case {
         if queries.is_empty() {
             return Ok(());
         }
+        let results = self.get_results().await?;
+        if results.len() != queries.len() {
+            println!(
+                "Warn: queries({}) and results({}) are not the same length.",
+                queries.len(),
+                results.len()
+            );
+        }
 
         println!("\t{} begin.", &self);
         let before = Instant::now();
 
-        let result = fs::read_to_string(self.res_file()).await?;
+        let outs = CLIENT.execute_db_request(self.case_name(), &queries).await;
+        let outs = DBResult::parse(self.name.clone(), &outs);
+        if outs.len() != queries.len() {
+            println!(
+                "Warn: queries({}) and outs({}) are not the same length.",
+                queries.len(),
+                outs.len()
+            );
+        }
 
-        let out = CLIENT.execute_db_request(self.case_name(), &queries).await;
-
-        let succeed = self.check(&result, &out).await;
+        let succeed = self.check(&results, &outs).await;
 
         let after = Instant::now();
 
@@ -113,12 +173,7 @@ impl Case {
 
 impl Display for Case {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Case: {} at {}",
-            &self.name,
-            &self.path.as_os_str().to_str().unwrap()
-        )
+        write!(f, "Case: {} at {}", &self.name, &self.path.display())
     }
 }
 

--- a/query_server/test/src/db_result.rs
+++ b/query_server/test/src/db_result.rs
@@ -1,0 +1,91 @@
+use std::fmt::Display;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct DBResult {
+    pub case_name: Arc<String>,
+    pub request: String,
+    pub response: String,
+    pub is_sorted: bool,
+    pub is_ok: bool,
+}
+
+impl DBResult {
+    pub fn parse(case_name: Arc<String>, lines: &str) -> Vec<DBResult> {
+        let mut results = Vec::<DBResult>::new();
+
+        let mut parsing = false;
+        let mut parsing_header = true;
+        let mut parsing_line_protocol = false;
+        let mut req_buf = String::with_capacity(256);
+        let mut resp_buf = String::with_capacity(256);
+        let mut is_ok = true;
+        let mut is_sorted = false;
+
+        for line in lines.lines() {
+            if line.trim().is_empty() && parsing {
+                results.push(DBResult {
+                    case_name: case_name.clone(),
+                    request: req_buf.trim_end().to_string(),
+                    response: resp_buf.trim_end().to_string(),
+                    is_ok,
+                    is_sorted,
+                });
+
+                parsing = false;
+                parsing_header = true;
+                parsing_line_protocol = false;
+                req_buf.clear();
+                resp_buf.clear();
+                is_ok = true;
+                is_sorted = false;
+            } else if parsing_header {
+                if line.starts_with("-- EXECUTE SQL:") {
+                    parsing = true;
+                    parsing_header = false;
+                    if let Some(sql) = line.find(':').map(|p| line.split_at(p + 1).1.trim()) {
+                        if let Some(q) = sql.find(" --").map(|p| sql.split_at(p).0.trim()) {
+                            req_buf = q.to_string();
+                        } else {
+                            req_buf = sql.to_string();
+                        }
+                    }
+                } else if line.starts_with("-- WRITE LINE PROTOCOL") {
+                    parsing = true;
+                    parsing_header = false;
+                    parsing_line_protocol = true;
+                }
+            } else if parsing_line_protocol {
+                if line.starts_with("-- LINE PROTOCOL END") {
+                    parsing_line_protocol = false;
+                } else {
+                    req_buf.push_str(line);
+                    req_buf.push('\n');
+                }
+            } else if line.starts_with("-- AFTER_SORT") {
+                is_sorted = true;
+            } else if line.starts_with("-- ERROR:") {
+                is_ok = false;
+            } else {
+                resp_buf.push_str(line);
+                resp_buf.push('\n');
+            }
+        }
+
+        results
+    }
+}
+
+impl Display for DBResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "-- QUERY: {} --", &self.request)?;
+        if self.is_sorted {
+            writeln!(f, "-- AFTER_SORT --")?;
+        }
+        writeln!(f, "{}", &self.response)?;
+        if !self.is_ok {
+            writeln!(f, "-- ERROR: --")?;
+        }
+        Ok(())
+    }
+}

--- a/query_server/test/src/main.rs
+++ b/query_server/test/src/main.rs
@@ -12,6 +12,7 @@ use crate::error::{Error, Result};
 mod case;
 mod client;
 mod db_request;
+mod db_result;
 mod error;
 mod groups;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

For example, if the 17th query in test case `timestamp` returned an error, it prints:

```
====================
Case: timestamp [17]
--------------------
explain select fa from test_timestamp_conv where time >= '1997-01-31 09:26:56';
--------------------
4   |    | -  Filter: test_timestamp_conv.time >= TimestampNanosecond(854702816000000000, None)
5   |    | -    TableScan: test_timestamp_conv projection=[time, fa], partial_filters=[test_timestamp_conv.time >= TimestampNanosecond(854702816000000000, None)]"
    |4   | +  TableScan: test_timestamp_conv projection=[time, fa], full_filters=[test_timestamp_conv.time >= TimestampNanosecond(854702816000000000, None)]"
7   |    | -  CoalesceBatchesExec: target_batch_size=8192
8   |    | -    FilterExec: time@0 >= 854702816000000000
9   |    | -      RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
10  |    | -        TskvExec: limit=None, predicate=ColumnDomains { column_to_domain: Some({Column { relation: None, name: ""time"" }: Range(RangeValueSet { low_indexed_ranges: {Marker { data_type: Timestamp(Nanosecond, None), value: Some(TimestampNanosecond(854702816000000000, None)), bound: Exactly }: Range { low: Marker { data_type: Timestamp(Nanosecond, None), value: Some(TimestampNanosecond(854702816000000000, None)), bound: Exactly }, high: Marker { data_type: Timestamp(Nanosecond, None), value: None, bound: Below } }} })}) }, projection=[time,fa]
    |6   | +  RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
    |7   | +    TskvExec: limit=None, predicate=ColumnDomains { column_to_domain: Some({Column { relation: None, name: ""time"" }: Range(RangeValueSet { low_indexed_ranges: {Marker { data_type: Timestamp(Nanosecond, None), value: Some(TimestampNanosecond(854702816000000000, None)), bound: Exactly }: Range { low: Marker { data_type: Timestamp(Nanosecond, None), value: Some(TimestampNanosecond(854702816000000000, None)), bound: Exactly }, high: Marker { data_type: Timestamp(Nanosecond, None), value: None, bound: Below } }} })}) }, projection=[time,fa]
====================
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
