### PR TITLE
improve: add tokio trace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,6 +1250,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a3a81dfaf6b66bce5d159eddae701e3a002f194d378cbf7be5f053c281d9be"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2519,6 +2555,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.3",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
 ]
 
 [[package]]
@@ -6133,6 +6182,8 @@ name = "trace"
 version = "2.1.0"
 dependencies = [
  "color-eyre",
+ "config",
+ "console-subscriber",
  "once_cell",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ tracing-futures = "0.2"
 tracing-subscriber = "0.3.16"
 tracing-appender = "0.2.2"
 tracing-error = "0.2.0"
+console-subscriber = "0.1.8"
 url = "2.2"
 uuid = { version = "1.1", features = ["v4"] }
 ureq = { version = "2.5.0", features = ["json", "charset"] }

--- a/common/trace/Cargo.toml
+++ b/common/trace/Cargo.toml
@@ -6,9 +6,11 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+config = {path = "../../config"}
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["parking_lot", "registry", "env-filter"] }
 tracing-appender = { workspace = true }
 tracing-error = { workspace = true }
 color-eyre = { workspace = true }
 once_cell = { workspace = true }
+console-subscriber = { workspace = true }

--- a/common/trace/src/lib.rs
+++ b/common/trace/src/lib.rs
@@ -1,6 +1,9 @@
+use std::net::SocketAddr;
 use std::sync::{Arc, Mutex, Once};
 
+use config::TokioTrace;
 use once_cell::sync::Lazy;
+use tracing::metadata::LevelFilter;
 pub use tracing::{debug, error, info, instrument, trace, warn};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::{non_blocking, rolling};
@@ -8,8 +11,9 @@ use tracing_error::ErrorLayer;
 use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{fmt, Registry};
+use tracing_subscriber::{fmt, Layer, Registry};
 
+const TOKIO_TRACE: &str = ",tokio=trace,runtime=trace";
 /// only use for unit test
 /// parameter only use for first call
 pub fn init_default_global_tracing(dir: &str, file_name: &str, level: &str) {
@@ -17,29 +21,58 @@ pub fn init_default_global_tracing(dir: &str, file_name: &str, level: &str) {
 
     START.call_once(|| {
         let mut g = GLOBAL_UT_LOG_GUARD.as_ref().lock().unwrap();
-        *g = Some(init_global_tracing(dir, file_name, level));
+        *g = Some(init_global_tracing(dir, level, file_name, None));
     });
 }
 
 static GLOBAL_UT_LOG_GUARD: Lazy<Arc<Mutex<Option<Vec<WorkerGuard>>>>> =
     Lazy::new(|| Arc::new(Mutex::new(None)));
 
-pub fn init_global_tracing(dir: &str, file_name: &str, level: &str) -> Vec<WorkerGuard> {
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level));
-    let formatting_layer = fmt::layer().pretty().with_writer(std::io::stderr);
+pub fn get_env_filter(log_level: &str, tokio_trace: Option<&TokioTrace>) -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        if tokio_trace.is_some() {
+            let level = log_level.to_string() + TOKIO_TRACE;
+            EnvFilter::new(&level)
+        } else {
+            EnvFilter::new(log_level)
+        }
+    })
+}
 
-    let file_appender = rolling::daily(dir, file_name);
+pub fn init_global_tracing(
+    log_path: &str,
+    log_level: &str,
+    log_file_prefix_name: &str,
+    tokio_trace: Option<&TokioTrace>,
+) -> Vec<WorkerGuard> {
+    let env_filter = get_env_filter(log_level, tokio_trace);
+    let formatting_layer = fmt::layer()
+        .pretty()
+        .with_writer(std::io::stderr)
+        .with_filter(LevelFilter::DEBUG);
+
+    let file_appender = rolling::daily(&log_path, log_file_prefix_name);
     let (non_blocking_appender, guard) = non_blocking(file_appender);
-    let file_layer = fmt::layer().with_writer(non_blocking_appender);
+    let file_layer = fmt::layer()
+        .with_writer(non_blocking_appender)
+        .with_filter(LevelFilter::DEBUG);
 
     let guards = vec![guard];
 
-    Registry::default()
+    let registry_builder = Registry::default()
         .with(env_filter)
         .with(ErrorLayer::default())
         .with(formatting_layer)
-        .with(file_layer)
-        .init();
+        .with(file_layer);
+
+    if let Some(tokio_trace) = tokio_trace {
+        let console_layer = console_subscriber::ConsoleLayer::builder()
+            .server_addr(tokio_trace.addr.parse::<SocketAddr>().unwrap())
+            .spawn();
+        registry_builder.with(console_layer).init()
+    } else {
+        registry_builder.init()
+    }
 
     match color_eyre::install() {
         Ok(_) => (),

--- a/common/trace/src/lib.rs
+++ b/common/trace/src/lib.rs
@@ -32,7 +32,7 @@ pub fn get_env_filter(log_level: &str, tokio_trace: Option<&TokioTrace>) -> EnvF
     EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         if tokio_trace.is_some() {
             let level = log_level.to_string() + TOKIO_TRACE;
-            EnvFilter::new(&level)
+            EnvFilter::new(level)
         } else {
             EnvFilter::new(log_level)
         }
@@ -51,7 +51,7 @@ pub fn init_global_tracing(
         .with_writer(std::io::stderr)
         .with_filter(LevelFilter::DEBUG);
 
-    let file_appender = rolling::daily(&log_path, log_file_prefix_name);
+    let file_appender = rolling::daily(log_path, log_file_prefix_name);
     let (non_blocking_appender, guard) = non_blocking(file_appender);
     let file_layer = fmt::layer()
         .with_writer(non_blocking_appender)

--- a/config/config_31001.toml
+++ b/config/config_31001.toml
@@ -33,6 +33,7 @@ max_immutable_number = 4
 [log]
 level = 'info'
 path = '/tmp/cnosdb/1001/log'
+#tokio_trace = { addr = "127.0.0.1:6669"}
 
 [security]
 # [security.tls_config]

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -340,11 +340,17 @@ impl CacheConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TokioTrace {
+    pub addr: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LogConfig {
     #[serde(default = "LogConfig::default_level")]
     pub level: String,
     #[serde(default = "LogConfig::default_path")]
     pub path: String,
+    pub tokio_trace: Option<TokioTrace>,
 }
 
 impl LogConfig {

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -90,7 +90,12 @@ fn main() -> Result<(), std::io::Error> {
     let cli = Cli::parse();
     let config = parse_config(&cli);
 
-    let _ = init_global_tracing(&config.log.path, "tsdb.log", &config.log.level);
+    let _ = init_global_tracing(
+        &config.log.path,
+        &config.log.level,
+        "tsdb.log",
+        config.log.tokio_trace.as_ref(),
+    );
     init_tskv_metrics_recorder();
 
     let runtime = Arc::new(init_runtime(Some(cli.cpu))?);

--- a/meta/config/config_21001.toml
+++ b/meta/config/config_21001.toml
@@ -1,11 +1,13 @@
 id = 1
 http_addr = "127.0.0.1:21001"
 
-logs_level = "info"
-logs_path = "/tmp/cnosdb/logs"
 snapshot_path = "/tmp/cnosdb/meta/snapshot"
 journal_path = "/tmp/cnosdb/meta/journal"
 snapshot_per_events = 500
+
+[log]
+logs_level = "info"
+logs_path = "/tmp/cnosdb/logs"
 
 [meta_init]
 cluster_name = "cluster_xxx"

--- a/meta/config/config_21002.toml
+++ b/meta/config/config_21002.toml
@@ -1,11 +1,13 @@
 id = 2
 http_addr = "127.0.0.1:21002"
 
-logs_level = "warn"
-logs_path = "/tmp/cnosdb/logs"
 snapshot_path = "/tmp/cnosdb/meta/snapshot"
 journal_path = "/tmp/cnosdb/meta/journal"
 snapshot_per_events = 500
+
+[log]
+logs_level = "info"
+logs_path = "/tmp/cnosdb/logs"
 
 [meta_init]
 cluster_name = "cluster_xxx"

--- a/meta/config/config_21003.toml
+++ b/meta/config/config_21003.toml
@@ -1,11 +1,13 @@
 id = 3
 http_addr = "127.0.0.1:21003"
 
-logs_level = "warn"
-logs_path = "/tmp/cnosdb/logs"
 snapshot_path = "/tmp/cnosdb/meta/snapshot"
 journal_path = "/tmp/cnosdb/meta/journal"
 snapshot_per_events = 500
+
+[log]
+logs_level = "info"
+logs_path = "/tmp/cnosdb/logs"
 
 [meta_init]
 cluster_name = "cluster_xxx"

--- a/meta/src/bin/main.rs
+++ b/meta/src/bin/main.rs
@@ -32,8 +32,13 @@ struct Cli {
 async fn main() -> std::io::Result<()> {
     let cli = Cli::parse();
     let options = store::config::get_opt(cli.config);
-    let logs_path = format!("{}/{}", options.logs_path, options.id);
-    let _ = init_global_tracing(&logs_path, "meta_server.log", &options.logs_level);
+    let logs_path = format!("{}/{}", options.log.path, options.id);
+    let _ = init_global_tracing(
+        &logs_path,
+        &options.log.level,
+        "meta_server.log",
+        options.log.tokio_trace.as_ref(),
+    );
 
     start_service(options).await
 }

--- a/meta/src/store/config.rs
+++ b/meta/src/store/config.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::prelude::Read;
 use std::path::Path;
 
+use config::LogConfig;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -28,8 +29,7 @@ pub struct Opt {
     pub snapshot_path: String,
     pub journal_path: String,
     pub snapshot_per_events: u32,
-    pub logs_path: String,
-    pub logs_level: String,
+    pub log: LogConfig,
     pub meta_init: MetaInit,
 }
 

--- a/meta/src/store/config.rs
+++ b/meta/src/store/config.rs
@@ -72,11 +72,13 @@ mod test {
 id = 1
 http_addr = "127.0.0.1:21001"
 
-logs_level = "warn"
-logs_path = "/tmp/cnosdb/logs"
 snapshot_path = "/tmp/cnosdb/meta/snapshot"
 journal_path = "/tmp/cnosdb/meta/journal"
 snapshot_per_events = 500
+
+[log]
+logs_level = "warn"
+logs_path = "/tmp/cnosdb/logs"
 
 [meta_init]
 cluster_name = "cluster_xxx"


### PR DESCRIPTION
# How to use

1. In order to collect task data from Tokio, the tokio_unstable cfg must be enabled. for example, you could build your project with
   ```shell
   RUSTFLAGS="--cfg tokio_unstable" cargo build
   ```
   or add the following to your `.cargo/config.toml` file:
   ```toml
   [build]
   rustflags = ["--cfg", "tokio_unstable"]
   ```
   For more information on the appropriate location of your .cargo/config.toml file, especially when using workspaces, see the [console-subscriber readme](https://github.com/tokio-rs/console/blob/main/console-subscriber/README.md#enabling-tokio-instrumentation).
   
2. Under the configuration file log entry, add tokio_trace
   ```toml
   [log]
   level = 'info'
   path = '/tmp/cnosdb/1001/log'
   tokio_trace = { addr = "127.0.0.1:6669" }
   ```
3. Run tokio-console
   ```shell
   cargo install --locked tokio-console
   # The address is filled in by the configuration
   tokio-console http://127.0.0.1:6669
   ```