### PR TITLE
refactor: remove tenant of query option

### DIFF
--- a/common/models/src/predicate/domain.rs
+++ b/common/models/src/predicate/domain.rs
@@ -954,7 +954,6 @@ impl Predicate {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct QueryArgs {
-    pub tenant: String,
     pub vnode_ids: Vec<u32>,
 
     pub limit: Option<usize>,

--- a/coordinator/src/reader.rs
+++ b/coordinator/src/reader.rs
@@ -8,10 +8,8 @@ use datafusion::arrow::record_batch::RecordBatch;
 use meta::MetaRef;
 use metrics::count::U64Counter;
 use models::meta_data::VnodeInfo;
-use models::predicate::domain::{QueryArgs, QueryExpr};
 use models::utils::now_timestamp;
 use protos::kv_service::tskv_service_client::TskvServiceClient;
-use protos::kv_service::QueryRecordBatchRequest;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio_stream::StreamExt;
 use tonic::transport::Channel;
@@ -73,7 +71,10 @@ impl QueryExecutor {
         sender: Sender<CoordinatorResult<RecordBatch>>,
         metrics: Arc<CoordServiceMetrics>,
     ) -> Self {
-        let data_out = metrics.data_out(option.tenant.as_str(), option.table_schema.db.as_str());
+        let data_out = metrics.data_out(
+            option.table_schema.tenant.as_str(),
+            option.table_schema.db.as_str(),
+        );
         Self {
             option,
             kv_inst,
@@ -164,30 +165,12 @@ impl QueryExecutor {
         node_id: u64,
         vnodes: Vec<VnodeInfo>,
     ) -> CoordinatorResult<()> {
-        let mut vnode_ids = Vec::with_capacity(vnodes.len());
-        for item in vnodes.iter() {
-            vnode_ids.push(item.id);
-        }
-        let args = QueryArgs {
-            vnode_ids,
-            tenant: self.option.tenant.clone(),
-            limit: self.option.filter.limit(),
-            batch_size: self.option.batch_size,
-        };
-        let expr = QueryExpr {
-            filters: self.option.filter.exprs().to_vec(),
-            df_schema: self.option.df_schema.clone(),
-            table_schema: self.option.table_schema.clone(),
+        let cmd = {
+            let vnode_ids = vnodes.iter().map(|v| v.id).collect::<Vec<_>>();
+            let req = self.option.to_query_record_batch_request(vnode_ids)?;
+            tonic::Request::new(req)
         };
 
-        let args_bytes = QueryArgs::encode(&args)?;
-        let expr_bytes = QueryExpr::encode(&expr)?;
-        let cmd = tonic::Request::new(QueryRecordBatchRequest {
-            args: args_bytes,
-            expr: expr_bytes,
-        });
-
-        // .map_err(|e| CoordinatorError::FailoverNode { id: node_id })?;
         let channel = self
             .meta_manager
             .admin_meta()
@@ -215,7 +198,7 @@ impl QueryExecutor {
 
             self.meta_manager
                 .tenant_manager()
-                .limiter(self.option.tenant.as_str())
+                .limiter(self.option.table_schema.tenant.as_str())
                 .await
                 .check_data_out(record.get_array_memory_size())
                 .await?;
@@ -277,10 +260,10 @@ impl QueryExecutor {
         let meta = self
             .meta_manager
             .tenant_manager()
-            .tenant_meta(&self.option.tenant)
+            .tenant_meta(&self.option.table_schema.tenant)
             .await
             .ok_or(CoordinatorError::TenantNotFound {
-                name: self.option.tenant.clone(),
+                name: self.option.table_schema.tenant.clone(),
             })?;
 
         let mut vnode_mapping: HashMap<u64, Vec<VnodeInfo>> = HashMap::new();
@@ -320,10 +303,10 @@ impl QueryExecutor {
         let meta = self
             .meta_manager
             .tenant_manager()
-            .tenant_meta(&self.option.tenant)
+            .tenant_meta(&self.option.table_schema.tenant)
             .await
             .ok_or(CoordinatorError::TenantNotFound {
-                name: self.option.tenant.clone(),
+                name: self.option.table_schema.tenant.clone(),
             })?;
 
         let mut vnode_mapping: HashMap<u64, Vec<VnodeInfo>> = HashMap::new();

--- a/coordinator/src/service.rs
+++ b/coordinator/src/service.rs
@@ -202,7 +202,7 @@ impl CoordService {
         option: QueryOption,
         sender: Sender<CoordinatorResult<RecordBatch>>,
     ) {
-        let tenant = option.tenant.as_str();
+        let tenant = option.table_schema.tenant.as_str();
 
         if let Err(e) = self
             .meta

--- a/main/src/rpc/tskv.rs
+++ b/main/src/rpc/tskv.rs
@@ -199,7 +199,6 @@ impl TskvServiceImpl {
         let scan_metrics = TableScanMetrics::new(&plan_metrics, 0, None);
         let option = QueryOption::new(
             args.batch_size,
-            args.tenant.clone(),
             filter,
             None,
             expr.df_schema,

--- a/query_server/query/src/extension/physical/plan_node/aggregate_filter_scan.rs
+++ b/query_server/query/src/extension/physical/plan_node/aggregate_filter_scan.rs
@@ -92,7 +92,6 @@ impl ExecutionPlan for AggregateFilterTskvExec {
         let metrics = TableScanMetrics::new(&metrics, partition, Some(context.memory_pool()));
         let query_opt = QueryOption::new(
             100_usize,
-            self.table_schema.tenant.clone(),
             self.filter.clone(),
             Some(agg_columns),
             self.schema.clone(),

--- a/query_server/query/src/extension/physical/plan_node/tskv_exec.rs
+++ b/query_server/query/src/extension/physical/plan_node/tskv_exec.rs
@@ -226,7 +226,6 @@ impl TableScanStream {
 
         let option = QueryOption::new(
             batch_size,
-            table_schema.tenant.clone(),
             filter,
             None,
             proj_schema.clone(),

--- a/tskv/src/engine.rs
+++ b/tskv/src/engine.rs
@@ -8,7 +8,6 @@ use models::{ColumnId, SeriesId, SeriesKey, TimeRange};
 use protos::kv_service::{WritePointsRequest, WritePointsResponse};
 
 use crate::error::Result;
-use crate::index::IndexResult;
 use crate::kv_option::StorageOptions;
 use crate::tseries_family::SuperVersion;
 use crate::{TseriesFamilyId, VersionEdit};
@@ -70,12 +69,12 @@ pub trait Engine: Send + Sync + Debug {
 
     async fn get_series_id_by_filter(
         &self,
-        id: u32,
         tenant: &str,
         db: &str,
         tab: &str,
+        vnode_id: SeriesId,
         filter: &ColumnDomains<String>,
-    ) -> IndexResult<Vec<u32>>;
+    ) -> Result<Vec<SeriesId>>;
 
     async fn get_series_key(
         &self,
@@ -83,7 +82,7 @@ pub trait Engine: Send + Sync + Debug {
         db: &str,
         vnode_id: u32,
         sid: SeriesId,
-    ) -> IndexResult<Option<SeriesKey>>;
+    ) -> Result<Option<SeriesKey>>;
 
     async fn get_db_version(
         &self,

--- a/tskv/src/engine_mock.rs
+++ b/tskv/src/engine_mock.rs
@@ -13,7 +13,6 @@ use trace::debug;
 
 use crate::engine::Engine;
 use crate::error::Result;
-use crate::index::IndexResult;
 use crate::kv_option::StorageOptions;
 use crate::summary::VersionEdit;
 use crate::tseries_family::SuperVersion;
@@ -95,12 +94,12 @@ impl Engine for MockEngine {
 
     async fn get_series_id_by_filter(
         &self,
-        id: u32,
         tenant: &str,
         db: &str,
         tab: &str,
+        id: SeriesId,
         filter: &ColumnDomains<String>,
-    ) -> IndexResult<Vec<u32>> {
+    ) -> Result<Vec<SeriesId>> {
         Ok(vec![])
     }
 
@@ -110,7 +109,7 @@ impl Engine for MockEngine {
         db: &str,
         vnode_id: u32,
         sid: u32,
-    ) -> IndexResult<Option<SeriesKey>> {
+    ) -> Result<Option<SeriesKey>> {
         Ok(None)
     }
 


### PR DESCRIPTION
# Rationale for this change
The `struct TskvTableSchema` in `struct QueryOption` already holds the Tenant name, so the `tenant` field can be deleted
