### PR TITLE
feat(tskv): counting by sreies return sum of each count(series_id)

### DIFF
--- a/query_server/test/cases/dml/copy_into/copy_into_table.result
+++ b/query_server/test/cases/dml/copy_into/copy_into_table.result
@@ -63,7 +63,7 @@ rows
 -- EXECUTE SQL: select count(time) from inner_parquet; --
 200 OK
 COUNT(inner_parquet.time)
-1800
+8192
 
 
 -- EXECUTE SQL: copy into inner_parquet from 'query_server/test/resource/csv/part-0.csv' file_format = (type = 'csv'); --


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

If we have inserted data as below:

| time | ta | fa |
| - | - | - |
| 1 | a1 | 1 |
| 1 | a2 | 1 |
| 2 |  a1 | 1  |

Column `ta` is the Tag column that comes out with two series, 'a1' and 'a2'. 'a1' has two time(1, 2), 'a2' has one time(1).

Then use this sql statement:

```sql
select count(*) from tab.
```

`count(*)` means `count(time)`, in the past we calculate the count of distinct time over all series, so we got 2.

now we calculate the sum of the count of each series, so we got 3.

**Before**



<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
