### PR TITLE
fix(#864): vnode drop flushed caches during the new super version installation

### DIFF
--- a/tskv/src/compaction/job.rs
+++ b/tskv/src/compaction/job.rs
@@ -59,7 +59,7 @@ pub fn run(
                         if flus_vnode {
                             let mut tsf_wlock = tsf.write().await;
                             tsf_wlock.switch_to_immutable();
-                            let flush_req = tsf_wlock.flush_req(true);
+                            let flush_req = tsf_wlock.build_flush_req(true);
                             drop(tsf_wlock);
                             if let Some(req) = flush_req {
                                 if let Err(e) = flush::run_flush_memtable_job(
@@ -83,6 +83,7 @@ pub fn run(
                                 let _ret = summary_task_sender_inner.send(SummaryTask::new(
                                     vec![version_edit],
                                     Some(file_metas),
+                                    None,
                                     summary_tx,
                                 ));
 

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -180,7 +180,7 @@ impl Database {
         self.ts_families.insert(tsf_id, tf.clone());
 
         let (task_state_sender, _task_state_receiver) = oneshot::channel();
-        let task = SummaryTask::new(version_edits, file_metas, task_state_sender);
+        let task = SummaryTask::new(version_edits, file_metas, None, task_state_sender);
         if let Err(e) = summary_task_sender.send(task).await {
             error!("failed to send Summary task, {:?}", e);
         }
@@ -195,7 +195,7 @@ impl Database {
 
         let edits = vec![VersionEdit::new_del_vnode(tf_id)];
         let (task_state_sender, _task_state_receiver) = oneshot::channel();
-        let task = SummaryTask::new(edits, None, task_state_sender);
+        let task = SummaryTask::new(edits, None, None, task_state_sender);
         if let Err(e) = summary_task_sender.send(task).await {
             error!("failed to send Summary task, {:?}", e);
         }

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -577,7 +577,7 @@ impl Engine for TsKv {
                 let request = {
                     let mut tsfamily = tsfamily.write().await;
                     tsfamily.switch_to_immutable();
-                    tsfamily.flush_req(true)
+                    tsfamily.build_flush_req(true)
                 };
 
                 if let Some(req) = request {
@@ -887,7 +887,7 @@ impl Engine for TsKv {
 
                 let mut tsf_wlock = ts_family.write().await;
                 tsf_wlock.switch_to_immutable();
-                let flush_req = tsf_wlock.flush_req(true);
+                let flush_req = tsf_wlock.build_flush_req(true);
                 drop(tsf_wlock);
                 if let Some(req) = flush_req {
                     if let Err(e) = run_flush_memtable_job(
@@ -914,6 +914,7 @@ impl Engine for TsKv {
                                 .send(SummaryTask::new(
                                     vec![version_edit],
                                     Some(file_metas),
+                                    None,
                                     summary_tx,
                                 ))
                                 .await;

--- a/tskv/src/version_set.rs
+++ b/tskv/src/version_set.rs
@@ -57,7 +57,7 @@ impl VersionSet {
         metrics_register: Arc<MetricsRegister>,
     ) -> Result<Self> {
         let mut dbs = HashMap::new();
-        for (_id, ver) in ver_set {
+        for ver in ver_set.into_values() {
             let owner = ver.database().to_string();
             let (tenant, database) = split_owner(&owner);
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #864 .

# Rationale for this change

# What changes are included in this PR?

## Memory cache now has it's id & improve state of memory cache.

- Remove `flushed` state in cache.
- Make `flushing` state in cache an `AtomicBool`, use `compare_and_exchange` to change in current thread.
- Before TseriesFamily's replace version, drop flushed memory caches from new super version.
- `CacheGroup::read_field_data()` and `CacheGroup::read_series_timestamps()` do not check state.
- `run_flush_memtable_job()` built a `HashMap` maps`TseriesFamilytId` to `Vec<MemCache>`, now send that map by `SummaryTask`.

## API change

- `TseriesFamily::flush_req()` -> `TseriesFamily::build_flush_req()`
- `Summary::write_summary(version_edits, file_metas)` -> `Summary::write_summary(version_edits, file_metas, mem_caches)`
- `SummaryTask::new(version_edits, file_metas, call_back)` -> `SummaryTask::new(version_edits, file_metas, mem_caches, call_back)`

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
