### PR TITLE
refactor: add http context

### DIFF
--- a/common/metrics/src/metric_register.rs
+++ b/common/metrics/src/metric_register.rs
@@ -9,6 +9,7 @@ use crate::metric::Metric;
 use crate::reporter::Reporter;
 use crate::{CreateMetricRecorder, Measure, MetricRecorder};
 
+pub type MetricsRegisterRef = Arc<MetricsRegister>;
 #[derive(Debug)]
 pub struct MetricsRegister {
     labels: Labels,

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -58,6 +58,15 @@ impl Config {
     pub fn to_string_pretty(&self) -> String {
         toml::to_string_pretty(self).unwrap_or_else(|_| "Failed to stringfy Config".to_string())
     }
+    pub fn tls_config(&self) -> Option<&TLSConfig> {
+        self.security.tls_config.as_ref()
+    }
+    pub fn query_body_limit(&self) -> u64 {
+        self.query.query_sql_limit
+    }
+    pub fn write_body_limit(&self) -> u64 {
+        self.query.write_sql_limit
+    }
 }
 
 pub fn get_config(path: impl AsRef<Path>) -> Result<Config, std::io::Error> {

--- a/main/src/http/mod.rs
+++ b/main/src/http/mod.rs
@@ -12,7 +12,7 @@ use self::response::ResponseBuilder;
 
 pub mod header;
 pub mod http_service;
-mod metrics;
+pub mod metrics;
 mod response;
 mod result_format;
 

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -132,7 +132,7 @@ fn main() -> Result<(), std::io::Error> {
         },
     };
 
-    let config = parse_config(run_args.config.as_ref());
+    let config = Arc::new(parse_config(run_args.config.as_ref()));
 
     init_process_global_tracing(
         &config.log.path,

--- a/main/src/meta_single/meta_service.rs
+++ b/main/src/meta_single/meta_service.rs
@@ -114,11 +114,11 @@ pub async fn watch(
 }
 
 pub struct MetaService {
-    opt: Config,
+    opt: Arc<Config>,
 }
 
 impl MetaService {
-    pub fn new(opt: Config) -> Self {
+    pub fn new(opt: Arc<Config>) -> Self {
         Self { opt }
     }
 
@@ -127,7 +127,7 @@ impl MetaService {
     }
 }
 
-pub async fn run_service(opt: Config) -> std::io::Result<()> {
+pub async fn run_service(opt: Arc<Config>) -> std::io::Result<()> {
     let db_path = format!("{}/meta/{}.binlog", opt.storage.path, 0);
     let db = Arc::new(sled::open(db_path.clone()).unwrap());
     let state_machine = StateMachine::new(db);
@@ -156,7 +156,7 @@ pub async fn run_service(opt: Config) -> std::io::Result<()> {
     Ok(())
 }
 
-pub async fn init_meta(app: &Data<MetaApp>, opt: Config) {
+pub async fn init_meta(app: &Data<MetaApp>, opt: Arc<Config>) {
     // init user
     let user_opt_res = UserOptionsBuilder::default()
         .must_change_password(true)


### PR DESCRIPTION
Now the http service method calls too many parameters, replace the call parameters with context