### PR TITLE
fix: Marker Deserialize & QueryExpr encode use bincode

### DIFF
--- a/common/models/src/errors.rs
+++ b/common/models/src/errors.rs
@@ -41,7 +41,7 @@ pub enum Error {
     ))]
     Internal { err: String },
 
-    #[snafu(display("Invalid query expr message: {}", err))]
+    #[snafu(display("IO operator: {}", err))]
     IOErrors { err: String },
 
     #[snafu(display("Failed to convert vec to string"))]

--- a/common/models/src/predicate/domain.rs
+++ b/common/models/src/predicate/domain.rs
@@ -180,11 +180,7 @@ impl<'a> Deserialize<'a> for Marker {
     where
         D: serde::Deserializer<'a>,
     {
-        let mark = deserializer.deserialize_struct(
-            "ValueEntry",
-            &["data_type", "value", "bound"],
-            MarkerVisitor,
-        )?;
+        let mark = MarkerSerialize::deserialize(deserializer)?;
 
         Ok(mark.into())
     }
@@ -1201,16 +1197,16 @@ pub struct QueryExpr {
 
 impl QueryExpr {
     pub fn encode(option: &QueryExpr) -> Result<Vec<u8>> {
-        let bytes = serde_json::to_vec(option).map_err(|err| Error::InvalidQueryExprMsg {
-            err: err.to_string(),
+        let bytes = bincode::serialize(option).map_err(|e| Error::InvalidQueryExprMsg {
+            err: format!("encode error {}", e),
         })?;
 
         Ok(bytes)
     }
 
     pub fn decode(buf: &[u8]) -> Result<QueryExpr> {
-        serde_json::from_slice::<QueryExpr>(buf).map_err(|err| Error::InvalidQueryExprMsg {
-            err: err.to_string(),
+        bincode::deserialize::<QueryExpr>(buf).map_err(|e| Error::InvalidQueryExprMsg {
+            err: format!("decode error {}", e),
         })
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

1. "422 Unprocessable Entity, details: {\"error_code\":\"050007\",\"error_message\":\"Error from models: Invalid query expr message: key must be a string\"}"

2. "grpc client request error: grpc status: status: Internal, message: \\\"Invalid query expr message: decode ==error invalid type: sequence, expected This Visitor expects to receive Marker
