### PR TITLE
fix: limit the size of exported files

### DIFF
--- a/query_server/query/src/data_source/sink/mod.rs
+++ b/query_server/query/src/data_source/sink/mod.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
 use bytes::Bytes;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use spi::query::datasource::WriteContext;
 use spi::Result;
@@ -14,9 +16,18 @@ pub trait RecordBatchSerializer {
     /// Serialize [`SendableRecordBatchStream`] into a bytes array.
     ///
     /// Return the number of data rows and bytes array.
-    async fn to_bytes(
+    async fn stream_to_bytes(
         &self,
         ctx: &WriteContext,
         stream: SendableRecordBatchStream,
+    ) -> Result<(usize, Bytes)>;
+    /// Serialize multi [`RecordBatch`] into a bytes array.
+    ///
+    /// Return the number of data rows and bytes array.
+    async fn batches_to_bytes(
+        &self,
+        ctx: &WriteContext,
+        schema: SchemaRef,
+        batches: &[RecordBatch],
     ) -> Result<(usize, Bytes)>;
 }

--- a/query_server/query/src/data_source/sink/obj_store/mod.rs
+++ b/query_server/query/src/data_source/sink/obj_store/mod.rs
@@ -1,11 +1,14 @@
 pub mod serializer;
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::SendableRecordBatchStream;
+use futures::{pin_mut, TryStreamExt};
 use object_store::path::Path;
 use object_store::DynObjectStore;
 use spi::query::datasource::WriteContext;
@@ -21,9 +24,12 @@ pub struct ObjectStoreSink {
     object_store: Arc<DynObjectStore>,
 }
 
+// 128MB
+const MAX_FILE_SIZXE: usize = 128 * 1024 * 1024;
+
 #[async_trait]
 impl RecordBatchSink for ObjectStoreSink {
-    async fn append(&self, _record_batch: RecordBatch) -> Result<SinkMetadata> {
+    async fn append(&self, _: RecordBatch) -> Result<SinkMetadata> {
         Err(QueryError::Unimplement {
             msg: "ObjectStoreRecordBatchSink::append".to_string(),
         })
@@ -32,22 +38,21 @@ impl RecordBatchSink for ObjectStoreSink {
     async fn stream_write(&self, stream: SendableRecordBatchStream) -> Result<SinkMetadata> {
         debug!("Process ObjectStoreRecordBatchSink::stream_write");
 
-        let path = self.ctx.location().child(format!(
-            "part-{}{}",
-            self.ctx.partition(),
-            self.ctx.file_extension()
-        ));
+        pin_mut!(stream);
 
-        let (rows_writed, data) = self.s.to_bytes(&self.ctx, stream).await?;
-        let bytes_writed = data.len();
+        let mut writer = BufferedWriter::new(
+            &self.ctx,
+            &self.s,
+            &self.object_store,
+            stream.schema(),
+            MAX_FILE_SIZXE,
+        );
 
-        if bytes_writed > 0 {
-            self.object_store.put(&path, data).await?;
-
-            debug!("Generated parquet file: {}", path);
+        while let Some(batch) = stream.try_next().await? {
+            writer.write(batch).await?;
         }
 
-        Ok(SinkMetadata::new(rows_writed, bytes_writed))
+        writer.close().await
     }
 }
 
@@ -91,5 +96,111 @@ impl RecordBatchSinkProvider for ObjectStoreSinkProvider {
             s: self.serializer.clone(),
             object_store: self.object_store.clone(),
         })
+    }
+}
+
+#[non_exhaustive]
+struct BufferedWriter<'a> {
+    ctx: &'a WriteContext,
+    s: &'a Arc<DynRecordBatchSerializer>,
+    object_store: &'a Arc<DynObjectStore>,
+    schema: SchemaRef,
+
+    /// For each column, maintain an ordered queue of arrays to write
+    buffer: Vec<RecordBatch>,
+    /// The total number of bytes of memory of currently buffered
+    buffered_size: usize,
+
+    // max buffer size
+    max_file_size: usize,
+
+    // statistics
+    rows_writed: usize,
+    bytes_writed: usize,
+
+    // flushed file seq num
+    file_number: AtomicU64,
+}
+
+impl<'a> BufferedWriter<'a> {
+    pub fn new(
+        ctx: &'a WriteContext,
+        s: &'a Arc<DynRecordBatchSerializer>,
+        object_store: &'a Arc<DynObjectStore>,
+        schema: SchemaRef,
+        max_file_sizxe: usize,
+    ) -> Self {
+        Self {
+            ctx,
+            s,
+            object_store,
+            schema,
+            max_file_size: max_file_sizxe,
+            buffer: Default::default(),
+            buffered_size: Default::default(),
+            rows_writed: Default::default(),
+            bytes_writed: Default::default(),
+            file_number: Default::default(),
+        }
+    }
+
+    pub async fn write(&mut self, batch: RecordBatch) -> Result<()> {
+        self.buffered_size += batch.get_array_memory_size();
+        self.buffer.push(batch);
+        self.try_flush().await?;
+        Ok(())
+    }
+
+    pub async fn try_flush(&mut self) -> Result<()> {
+        if self.buffered_size >= self.max_file_size {
+            self.flush().await?;
+        }
+
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<()> {
+        if self.buffered_size == 0 {
+            return Ok(());
+        }
+
+        debug!(
+            "Export partition {} data, flushing, buffered_size: {}, max_file_size: {}",
+            self.ctx.partition(),
+            self.buffered_size,
+            self.max_file_size
+        );
+
+        let (rows_writed, data) = self
+            .s
+            .batches_to_bytes(self.ctx, self.schema.clone(), &self.buffer)
+            .await?;
+        self.buffer.clear();
+        self.buffered_size = 0;
+        let bytes_writed = data.len();
+
+        if bytes_writed > 0 {
+            let path = self.ctx.location().child(format!(
+                "part-{}-{}{}",
+                self.ctx.partition(),
+                self.file_number.fetch_add(1, Ordering::Relaxed),
+                self.ctx.file_extension()
+            ));
+
+            self.object_store.put(&path, data).await?;
+
+            debug!("Generated file: {}, size: {} bytes.", path, bytes_writed);
+
+            self.rows_writed += rows_writed;
+            self.bytes_writed += bytes_writed;
+        }
+
+        Ok(())
+    }
+
+    pub async fn close(mut self) -> Result<SinkMetadata> {
+        self.flush().await?;
+
+        Ok(SinkMetadata::new(self.rows_writed, self.bytes_writed))
     }
 }

--- a/query_server/query/src/data_source/sink/obj_store/serializer/json.rs
+++ b/query_server/query/src/data_source/sink/obj_store/serializer/json.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
 use bytes::Bytes;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::json::LineDelimitedWriter;
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{pin_mut, TryStreamExt};
 use snafu::ResultExt;
@@ -13,7 +15,7 @@ pub struct NdJsonRecordBatchSerializer {}
 
 #[async_trait]
 impl RecordBatchSerializer for NdJsonRecordBatchSerializer {
-    async fn to_bytes(
+    async fn stream_to_bytes(
         &self,
         _ctx: &WriteContext,
         stream: SendableRecordBatchStream,
@@ -28,6 +30,26 @@ impl RecordBatchSerializer for NdJsonRecordBatchSerializer {
             while let Some(batch) = stream.try_next().await? {
                 num_rows += batch.num_rows();
                 writer.write(batch).context(SerializeJsonSnafu)?;
+            }
+        }
+
+        Ok((num_rows, Bytes::from(bytes)))
+    }
+
+    async fn batches_to_bytes(
+        &self,
+        _ctx: &WriteContext,
+        _schema: SchemaRef,
+        batches: &[RecordBatch],
+    ) -> Result<(usize, Bytes)> {
+        let mut num_rows = 0;
+        let mut bytes = vec![];
+        {
+            let mut writer = LineDelimitedWriter::new(&mut bytes);
+
+            for batch in batches {
+                num_rows += batch.num_rows();
+                writer.write(batch.clone()).context(SerializeJsonSnafu)?;
             }
         }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1034 .

The current pr limits the size of the exported file

Premise: the batch_size of RecordBatch in the stream meets expectations @zipper-meng 

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
