### PR TITLE
add operation command for change node state and report time for add d…

### DIFF
--- a/common/models/src/meta_data.rs
+++ b/common/models/src/meta_data.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 use std::ffi::CString;
-use std::io;
 use std::mem::MaybeUninit;
 use std::sync::Arc;
+use std::{fmt, io};
 
 use serde::{Deserialize, Serialize};
 
@@ -35,14 +35,44 @@ pub struct UserInfo {
     pub perm: u64, //read write admin bitmap
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone)]
+pub enum NodeState {
+    #[default]
+    Running,
+    Pending,
+    Cold,
+    Unknown,
+}
+
+impl fmt::Display for NodeState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            NodeState::Running => write!(f, "RUNNING"),
+            NodeState::Pending => write!(f, "PENDING"),
+            NodeState::Cold => write!(f, "COLD"),
+            NodeState::Unknown => write!(f, "UNKNOWN"),
+        }
+    }
+}
+
+impl From<String> for NodeState {
+    fn from(node_state: String) -> Self {
+        match node_state.to_uppercase().as_str() {
+            "RUNNING" => NodeState::Running,
+            "PENDING" => NodeState::Pending,
+            "COLD" => NodeState::Cold,
+            _ => NodeState::Unknown,
+        }
+    }
+}
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct NodeInfo {
     pub id: NodeId,
     pub grpc_addr: String,
     pub http_addr: String,
     pub disk_free: u64,
-    pub is_cold: bool,
-    pub status: u64,
+    pub time: u64,
+    pub status: NodeState,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/common/protos/proto/kv_service.proto
+++ b/common/protos/proto/kv_service.proto
@@ -86,6 +86,11 @@ message CompactVnodeRequest {
     repeated uint32 vnode_ids = 1;
 }
 
+message ChangeNodeStateRequest {
+  uint64 node_id = 1;
+  string node_state = 2;
+}
+
 message DropColumnRequest {
     string db = 1;
     string table = 2;
@@ -117,6 +122,7 @@ message AdminCommandRequest {
     DropColumnRequest drop_column = 8;
     AddColumnRequest add_column = 9;
     AlterColumnRequest alter_column = 10;
+    ChangeNodeStateRequest  change_node_state = 11;
   }
 }
 
@@ -145,6 +151,7 @@ message QueryRecordBatchRequest {
     bytes expr = 2;
     bytes aggs = 3;
 }
+
 
 /* -------------------------------------------------------------------- */
 service TSKVService {

--- a/common/protos/src/generated/protobuf_generated/kv_service.rs
+++ b/common/protos/src/generated/protobuf_generated/kv_service.rs
@@ -135,6 +135,14 @@ pub struct CompactVnodeRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChangeNodeStateRequest {
+    #[prost(uint64, tag = "1")]
+    pub node_id: u64,
+    #[prost(string, tag = "2")]
+    pub node_state: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DropColumnRequest {
     #[prost(string, tag = "1")]
     pub db: ::prost::alloc::string::String,
@@ -172,7 +180,7 @@ pub struct AdminCommandRequest {
     pub tenant: ::prost::alloc::string::String,
     #[prost(
         oneof = "admin_command_request::Command",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11"
     )]
     pub command: ::core::option::Option<admin_command_request::Command>,
 }
@@ -199,6 +207,8 @@ pub mod admin_command_request {
         AddColumn(super::AddColumnRequest),
         #[prost(message, tag = "10")]
         AlterColumn(super::AlterColumnRequest),
+        #[prost(message, tag = "11")]
+        ChangeNodeState(super::ChangeNodeStateRequest),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use meta::model::{MetaClientRef, MetaRef};
 use models::consistency_level::ConsistencyLevel;
+use models::meta_data::NodeState;
 use models::schema::Precision;
 use protos::kv_service::{AdminCommandRequest, WritePointsRequest};
 use tskv::query_iterator::QueryOption;
@@ -14,6 +15,7 @@ pub mod errors;
 pub mod file_info;
 pub mod hh_queue;
 pub mod metrics;
+pub mod node_mgr;
 pub mod reader;
 pub mod service;
 pub mod service_mock;
@@ -30,6 +32,11 @@ pub struct WriteRequest {
     pub level: models::consistency_level::ConsistencyLevel,
     pub precision: Precision,
     pub request: protos::kv_service::WritePointsRequest,
+}
+
+#[derive(Debug, Clone)]
+pub enum NodeManagerCmdType {
+    ChangeNodeState(u64, NodeState),
 }
 
 #[derive(Debug, Clone)]
@@ -81,5 +88,11 @@ pub trait Coordinator: Send + Sync + Debug {
         &self,
         tenant: &str,
         cmd_type: VnodeManagerCmdType,
+    ) -> CoordinatorResult<()>;
+
+    async fn execute_node_command(
+        &self,
+        tenant: &str,
+        cmd_type: NodeManagerCmdType,
     ) -> CoordinatorResult<()>;
 }

--- a/coordinator/src/node_mgr.rs
+++ b/coordinator/src/node_mgr.rs
@@ -1,0 +1,46 @@
+use meta::model::MetaRef;
+use models::meta_data::NodeState;
+
+use crate::errors::{CoordinatorError, CoordinatorResult};
+
+pub struct NodeManager {
+    node_id: u64,
+    meta: MetaRef,
+}
+
+impl NodeManager {
+    pub fn new(meta: MetaRef, node_id: u64) -> Self {
+        Self { node_id, meta }
+    }
+
+    pub async fn change_node_state(
+        &self,
+        tenant: &str,
+        node_state: String,
+    ) -> CoordinatorResult<()> {
+        let meta_client = self.meta.tenant_manager().tenant_meta(tenant).await.ok_or(
+            CoordinatorError::TenantNotFound {
+                name: tenant.to_string(),
+            },
+        )?;
+
+        let admin_meta = self.meta.admin_meta();
+        let source_node_state = admin_meta.get_node_state(self.node_id).await?;
+
+        admin_meta
+            .update_node_state_cache(self.node_id, NodeState::from(node_state.clone()))
+            .await?;
+
+        if let Err(e) = meta_client
+            .update_node_state(self.node_id, node_state)
+            .await
+        {
+            admin_meta
+                .update_node_state_cache(self.node_id, source_node_state)
+                .await?;
+            return Err(CoordinatorError::from(e));
+        }
+
+        Ok(())
+    }
+}

--- a/coordinator/src/service_mock.rs
+++ b/coordinator/src/service_mock.rs
@@ -14,7 +14,7 @@ use tskv::EngineRef;
 
 use crate::errors::CoordinatorResult;
 use crate::reader::ReaderIterator;
-use crate::{Coordinator, VnodeManagerCmdType};
+use crate::{Coordinator, NodeManagerCmdType, VnodeManagerCmdType};
 
 #[derive(Debug, Default)]
 pub struct MockCoordinator {}
@@ -65,6 +65,14 @@ impl Coordinator for MockCoordinator {
         &self,
         tenant: &str,
         cmd_type: VnodeManagerCmdType,
+    ) -> CoordinatorResult<()> {
+        Ok(())
+    }
+
+    async fn execute_node_command(
+        &self,
+        tenant: &str,
+        cmd_type: NodeManagerCmdType,
     ) -> CoordinatorResult<()> {
         Ok(())
     }

--- a/coordinator/src/writer.rs
+++ b/coordinator/src/writer.rs
@@ -258,7 +258,6 @@ impl<'a> VnodeMapping<'a> {
 
             hasher.number()
         };
-
         //let full_name = format!("{}.{}", meta_client.tenant_name(), db);
         let info = meta_client
             .locate_replcation_set_for_write(db_name, hash_id, ts)

--- a/meta/src/model/meta_client.rs
+++ b/meta/src/model/meta_client.rs
@@ -645,7 +645,6 @@ impl MetaClient for RemoteMetaClient {
             db.to_string(),
             ts,
         );
-
         let rsp = self
             .client
             .write::<command::TenaneMetaDataResp>(&req)
@@ -801,6 +800,20 @@ impl MetaClient for RemoteMetaClient {
 
         let rsp = self.client.write::<command::StatusResponse>(&req).await?;
         info!("update replication set: {:?}; {:?}", req, rsp);
+
+        if rsp.code == command::META_REQUEST_SUCCESS {
+            Ok(())
+        } else {
+            Err(MetaError::CommonError {
+                msg: rsp.to_string(),
+            })
+        }
+    }
+
+    async fn update_node_state(&self, node_id: u64, node_state: String) -> MetaResult<()> {
+        let req = command::WriteCommand::ChangeNodeState(self.cluster.clone(), node_id, node_state);
+        let rsp = self.client.write::<command::StatusResponse>(&req).await?;
+        info!("update node state: {:?}; {:?}", req, rsp);
 
         if rsp.code == command::META_REQUEST_SUCCESS {
             Ok(())

--- a/meta/src/model/meta_client_mock.rs
+++ b/meta/src/model/meta_client_mock.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 use models::auth::privilege::DatabasePrivilege;
 use models::auth::role::{CustomTenantRole, SystemTenantRole, TenantRoleIdentifier};
 use models::meta_data::{
-    BucketInfo, DatabaseInfo, ExpiredBucketInfo, NodeInfo, ReplicationSet, VnodeAllInfo, VnodeInfo,
+    BucketInfo, DatabaseInfo, ExpiredBucketInfo, NodeInfo, NodeState, ReplicationSet, VnodeAllInfo,
+    VnodeInfo,
 };
 use models::oid::Oid;
 use models::schema::{
@@ -55,6 +56,14 @@ impl AdminMeta for MockAdminMeta {
 
     async fn process_watch_log(&self, entry: &EntryLog) -> MetaResult<()> {
         Ok(())
+    }
+
+    async fn update_node_state_cache(&self, node_id: u64, node_state: NodeState) -> MetaResult<()> {
+        Ok(())
+    }
+
+    async fn get_node_state(&self, node_id: u64) -> MetaResult<NodeState> {
+        Ok(NodeState::Running)
     }
 }
 
@@ -246,6 +255,10 @@ impl MetaClient for MockMetaClient {
 
     async fn version(&self) -> u64 {
         0
+    }
+
+    async fn update_node_state(&self, node_id: u64, node_state: String) -> MetaResult<()> {
+        Ok(())
     }
 
     fn get_vnode_all_info(&self, id: u32) -> Option<VnodeAllInfo> {

--- a/meta/src/model/mod.rs
+++ b/meta/src/model/mod.rs
@@ -7,7 +7,8 @@ use models::auth::privilege::DatabasePrivilege;
 use models::auth::role::{CustomTenantRole, SystemTenantRole, TenantRoleIdentifier};
 use models::auth::user::{User, UserDesc, UserOptions};
 use models::meta_data::{
-    BucketInfo, DatabaseInfo, ExpiredBucketInfo, NodeInfo, ReplicationSet, VnodeAllInfo, VnodeInfo,
+    BucketInfo, DatabaseInfo, ExpiredBucketInfo, NodeInfo, NodeState, ReplicationSet, VnodeAllInfo,
+    VnodeInfo,
 };
 use models::oid::{Identifier, Oid};
 use models::schema::{
@@ -51,6 +52,8 @@ pub trait AdminMeta: Send + Sync + Debug {
     async fn get_node_conn(&self, node_id: u64) -> MetaResult<Channel>;
     async fn retain_id(&self, count: u32) -> MetaResult<u32>;
     async fn process_watch_log(&self, entry: &EntryLog) -> MetaResult<()>;
+    async fn update_node_state_cache(&self, node_id: u64, node_state: NodeState) -> MetaResult<()>;
+    async fn get_node_state(&self, node_id: u64) -> MetaResult<NodeState>;
 }
 
 #[async_trait]
@@ -146,6 +149,8 @@ pub trait MetaClient: Send + Sync + Debug {
         del_info: &[VnodeInfo],
         add_info: &[VnodeInfo],
     ) -> MetaResult<()>;
+
+    async fn update_node_state(&self, node_id: u64, node_state: String) -> MetaResult<()>;
 
     async fn version(&self) -> u64;
 

--- a/meta/src/store/command.rs
+++ b/meta/src/store/command.rs
@@ -37,6 +37,9 @@ pub enum WriteCommand {
     // cluster, node info
     AddDataNode(String, NodeInfo),
 
+    //cluster ,node_id ,state
+    ChangeNodeState(String, u64, String),
+
     // cluster, tenant, db schema
     CreateDB(String, String, DatabaseSchema),
 

--- a/meta/src/store/state_machine.rs
+++ b/meta/src/store/state_machine.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use models::auth::privilege::DatabasePrivilege;
 use models::auth::role::{CustomTenantRole, SystemTenantRole, TenantRoleIdentifier};
@@ -512,6 +513,10 @@ impl StateMachine {
 
             WriteCommand::AddDataNode(cluster, node) => self.process_add_date_node(cluster, node),
 
+            WriteCommand::ChangeNodeState(cluster, node_id, node_state) => {
+                self.change_node_state(cluster, node_id, node_state)
+            }
+
             WriteCommand::CreateDB(cluster, tenant, schema) => {
                 self.process_create_db(cluster, tenant, schema)
             }
@@ -657,14 +662,52 @@ impl StateMachine {
         }
     }
 
-    fn process_add_date_node(&self, cluster: &str, node: &NodeInfo) -> CommandResp {
-        self.check_node_ip_address(cluster, node);
+    fn insert_node_to_db(&self, cluster: &str, node: &NodeInfo) -> CommandResp {
         let key = KeyPath::data_node_id(cluster, node.id);
         let value = serde_json::to_string(node).unwrap();
         let _ = self.insert(&key, &value);
         info!("WRITE: {} :{}", key, value);
 
         serde_json::to_string(&StatusResponse::default()).unwrap()
+    }
+
+    fn process_add_date_node(&self, cluster: &str, node: &NodeInfo) -> CommandResp {
+        self.check_node_ip_address(cluster, node);
+        self.insert_node_to_db(cluster, node)
+    }
+
+    fn change_node_state(&self, cluster: &str, node_id: &u64, node_state: &str) -> CommandResp {
+        let mut status = StatusResponse::new(META_REQUEST_FAILED, "".to_string());
+
+        let value = match get_struct::<NodeInfo>(
+            &KeyPath::data_node_id(cluster, *node_id),
+            self.db.clone(),
+        ) {
+            Some(node) => node,
+            None => {
+                status.msg = format!("not found node {}", *node_id);
+                return serde_json::to_string(&status).unwrap();
+            }
+        };
+
+        let time_ = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(time) => time.as_secs(),
+            Err(e) => {
+                info!("{}", e);
+                0
+            }
+        };
+
+        let node = NodeInfo {
+            id: *node_id,
+            time: time_,
+            grpc_addr: value.grpc_addr.clone(),
+            http_addr: value.http_addr.clone(),
+            disk_free: value.disk_free,
+            status: NodeState::from(node_state.to_owned()),
+        };
+
+        self.insert_node_to_db(cluster, &node)
     }
 
     fn process_drop_db(&self, cluster: &str, tenant: &str, db_name: &str) -> CommandResp {
@@ -898,7 +941,7 @@ impl StateMachine {
                 .collect();
 
         let mut hot_node_list = node_list.clone();
-        hot_node_list.retain(|node_info| !node_info.is_cold);
+        hot_node_list.retain(|node_info| node_info.status != NodeState::Cold);
 
         if node_list.is_empty()
             || db_schema.config.shard_num_or_default() == 0

--- a/query_server/query/src/execution/ddl/change_node_state.rs
+++ b/query_server/query/src/execution/ddl/change_node_state.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+use coordinator::NodeManagerCmdType;
+use spi::query::execution::{Output, QueryStateMachineRef};
+use spi::query::logical_planner::ChangeNodeState;
+use spi::Result;
+
+use super::DDLDefinitionTask;
+
+pub struct ChangeNodeStateTask {
+    stmt: ChangeNodeState,
+}
+
+impl ChangeNodeStateTask {
+    #[inline(always)]
+    pub fn new(stmt: ChangeNodeState) -> Self {
+        Self { stmt }
+    }
+}
+
+#[async_trait]
+impl DDLDefinitionTask for ChangeNodeStateTask {
+    async fn execute(&self, query_state_machine: QueryStateMachineRef) -> Result<Output> {
+        let (node_id, node_state) = (self.stmt.node_id, self.stmt.node_state.clone());
+        let tenant = query_state_machine.session.tenant();
+
+        let coord = query_state_machine.coord.clone();
+        let cmd_type = NodeManagerCmdType::ChangeNodeState(node_id, node_state);
+        coord.execute_node_command(tenant, cmd_type).await?;
+
+        Ok(Output::Nil(()))
+    }
+}

--- a/query_server/query/src/execution/ddl/mod.rs
+++ b/query_server/query/src/execution/ddl/mod.rs
@@ -19,6 +19,7 @@ use self::drop_tenant_object::DropTenantObjectTask;
 use self::grant_revoke::GrantRevokeTask;
 use crate::execution::ddl::alter_database::AlterDatabaseTask;
 use crate::execution::ddl::alter_table::AlterTableTask;
+use crate::execution::ddl::change_node_state::ChangeNodeStateTask;
 use crate::execution::ddl::checksum_group::ChecksumGroupTask;
 use crate::execution::ddl::compact_vnode::CompactVnodeTask;
 use crate::execution::ddl::copy_vnode::CopyVnodeTask;
@@ -34,6 +35,7 @@ mod alter_database;
 mod alter_table;
 mod alter_tenant;
 mod alter_user;
+mod change_node_state;
 mod checksum_group;
 mod compact_vnode;
 mod copy_vnode;
@@ -170,6 +172,9 @@ impl DDLDefinitionTaskFactory {
             DDLPlan::CopyVnode(sub_plan) => Box::new(CopyVnodeTask::new(sub_plan.clone())),
             DDLPlan::MoveVnode(sub_plan) => Box::new(MoveVnodeTask::new(sub_plan.clone())),
             DDLPlan::CompactVnode(sub_plan) => Box::new(CompactVnodeTask::new(sub_plan.clone())),
+            DDLPlan::ChangeNodeState(sub_plan) => {
+                Box::new(ChangeNodeStateTask::new(sub_plan.clone()))
+            }
             DDLPlan::ChecksumGroup(sub_plan) => Box::new(ChecksumGroupTask::new(sub_plan.clone())),
             DDLPlan::CreateStreamTable(sub_plan) => {
                 let checker = self.stream_checker_manager.checker(&sub_plan.stream_type);

--- a/query_server/query/src/sql/planner.rs
+++ b/query_server/query/src/sql/planner.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
-use std::iter;
 use std::option::Option;
 use std::sync::Arc;
+use std::{iter, vec};
 
 use async_recursion::async_recursion;
 use async_trait::async_trait;
@@ -48,6 +48,7 @@ use models::auth::privilege::{
 };
 use models::auth::role::{SystemTenantRole, TenantRoleIdentifier};
 use models::auth::user::User;
+use models::meta_data::NodeState;
 use models::object_reference::{Resolve, ResolvedTable};
 use models::oid::{Identifier, Oid};
 use models::schema::{
@@ -57,16 +58,16 @@ use models::schema::{
 use models::utils::SeqIdGenerator;
 use models::{ColumnId, ValueType};
 use object_store::ObjectStore;
-use spi::query::ast;
 use spi::query::ast::{
-    AlterDatabase as ASTAlterDatabase, AlterTable as ASTAlterTable,
+    self, AlterDatabase as ASTAlterDatabase, AlterTable as ASTAlterTable,
     AlterTableAction as ASTAlterTableAction, AlterTenantOperation, AlterUserOperation,
-    ChecksumGroup as ASTChecksumGroup, ColumnOption, CompactVnode as ASTCompactVnode,
-    CopyIntoTable, CopyTarget, CopyVnode as ASTCopyVnode, CreateDatabase as ASTCreateDatabase,
-    CreateTable as ASTCreateTable, DatabaseOptions as ASTDatabaseOptions,
-    DescribeDatabase as DescribeDatabaseOptions, DescribeTable as DescribeTableOptions,
-    DropVnode as ASTDropVnode, ExtStatement, MoveVnode as ASTMoveVnode,
-    ShowSeries as ASTShowSeries, ShowTagBody, ShowTagValues as ASTShowTagValues, UriLocation, With,
+    ChangeNodeState as ASTChangeNodeState, ChecksumGroup as ASTChecksumGroup, ColumnOption,
+    CompactVnode as ASTCompactVnode, CopyIntoTable, CopyTarget, CopyVnode as ASTCopyVnode,
+    CreateDatabase as ASTCreateDatabase, CreateTable as ASTCreateTable,
+    DatabaseOptions as ASTDatabaseOptions, DescribeDatabase as DescribeDatabaseOptions,
+    DescribeTable as DescribeTableOptions, DropVnode as ASTDropVnode, ExtStatement,
+    MoveVnode as ASTMoveVnode, ShowSeries as ASTShowSeries, ShowTagBody,
+    ShowTagValues as ASTShowTagValues, UriLocation, With,
 };
 use spi::query::datasource::{self, UriSchema};
 use spi::query::logical_planner::{
@@ -74,8 +75,8 @@ use spi::query::logical_planner::{
     sql_options_to_tenant_options, sql_options_to_user_options,
     unset_option_to_alter_tenant_action, AlterDatabase, AlterTable, AlterTableAction, AlterTenant,
     AlterTenantAction, AlterTenantAddUser, AlterTenantSetUser, AlterUser, AlterUserAction,
-    ChecksumGroup, CompactVnode, CopyOptions, CopyOptionsBuilder, CopyVnode, CreateDatabase,
-    CreateRole, CreateStreamTable, CreateTable, CreateTenant, CreateUser, DDLPlan,
+    ChangeNodeState, ChecksumGroup, CompactVnode, CopyOptions, CopyOptionsBuilder, CopyVnode,
+    CreateDatabase, CreateRole, CreateStreamTable, CreateTable, CreateTenant, CreateUser, DDLPlan,
     DatabaseObjectType, DescribeDatabase, DescribeTable, DropDatabaseObject, DropGlobalObject,
     DropTenantObject, DropVnode, FileFormatOptions, FileFormatOptionsBuilder, GlobalObjectType,
     GrantRevoke, LogicalPlanner, MoveVnode, Plan, PlanWithPrivileges, QueryPlan, SYSPlan,
@@ -162,6 +163,7 @@ impl<'a, S: ContextProviderExtension + Send + Sync + 'a> SqlPlaner<'a, S> {
             ExtStatement::MoveVnode(stmt) => self.move_vnode_to_plan(stmt),
             ExtStatement::CompactVnode(stmt) => self.compact_vnode_to_plan(stmt),
             ExtStatement::ChecksumGroup(stmt) => self.checksum_group_to_plan(stmt),
+            ExtStatement::ChangeNodeState(stmt) => self.change_node_state_to_plan(stmt),
             ExtStatement::CreateStream(_) => Err(QueryError::NotImplemented {
                 err: "CreateStream Planner.".to_string(),
             }),
@@ -1466,6 +1468,23 @@ impl<'a, S: ContextProviderExtension + Send + Sync + 'a> SqlPlaner<'a, S> {
         })
     }
 
+    fn change_node_state_to_plan(&self, stmt: ASTChangeNodeState) -> Result<PlanWithPrivileges> {
+        let ASTChangeNodeState {
+            node_id,
+            node_state,
+        } = stmt;
+
+        let plan = Plan::DDL(DDLPlan::ChangeNodeState(ChangeNodeState {
+            node_id,
+            node_state: NodeState::from(node_state),
+        }));
+
+        Ok(PlanWithPrivileges {
+            plan,
+            privileges: vec![Privilege::Global(GlobalPrivilege::System)],
+        })
+    }
+
     fn checksum_group_to_plan(&self, stmt: ASTChecksumGroup) -> Result<PlanWithPrivileges> {
         let ASTChecksumGroup { replication_set_id } = stmt;
 
@@ -2205,7 +2224,6 @@ mod tests {
     use crate::metadata::ContextProviderExtension;
     use crate::sql::parser::ExtParser;
 
-    #[derive(Debug)]
     struct MockContext {}
 
     #[async_trait::async_trait]
@@ -2547,6 +2565,66 @@ mod tests {
                 _ => panic!(),
             },
             _ => panic!(),
+        }
+    }
+    #[tokio::test]
+    async fn test_change_node_state() {
+        let vec: Vec<String> = vec![
+            "change node 1001 state Running;".to_string(),
+            "change NODE 1001 state PENDING;".to_string(),
+            "CHANGE NODE 1001 STATE COld;".to_string(),
+            "change VNODE 1001 state Running;".to_string(),
+            "change NODE 1001 state Unknown;".to_string(),
+            "change NODE 1001 state;".to_string(),
+            "change NODE 1001;".to_string(),
+            "change;".to_string(),
+        ];
+
+        for (i, _elem) in vec.iter().enumerate() {
+            let statements = ExtParser::parse_sql(vec[i].as_str());
+
+            if i < 3 {
+                let mut state = statements.clone().unwrap();
+                assert_eq!(state.len(), 1);
+                let test = MockContext {};
+                let planner = SqlPlaner::new(&test);
+                let plan = planner
+                    .statement_to_plan(state.pop_back().unwrap(), &session())
+                    .await
+                    .unwrap();
+                if let Plan::DDL(DDLPlan::ChangeNodeState(ChangeNodeState {
+                    node_id,
+                    node_state,
+                })) = plan.plan
+                {
+                    println!("{:?} {:?}", node_id, node_state.to_string());
+                }
+            }
+            if let Err(e) = statements {
+                match i {
+                    3 => assert_eq!(
+                        "sql parser error: Expected NODE,after CHANGE",
+                        e.to_string().as_str()
+                    ),
+                    4 => assert_eq!(
+                        "sql parser error: Expected [RUNNING | PENDING | COLD], found: Unknown",
+                        e.to_string().as_str()
+                    ),
+                    5 => assert_eq!(
+                        "sql parser error: Expected [RUNNING | PENDING | COLD], found: ;",
+                        e.to_string().as_str()
+                    ),
+                    6 => assert_eq!(
+                        "sql parser error: Expected STATE, found: ;",
+                        e.to_string().as_str()
+                    ),
+                    7 => assert_eq!(
+                        "sql parser error: Expected NODE,after CHANGE",
+                        e.to_string().as_str()
+                    ),
+                    _ => panic!(),
+                }
+            }
         }
     }
 }

--- a/query_server/spi/src/query/ast.rs
+++ b/query_server/spi/src/query/ast.rs
@@ -10,7 +10,6 @@ use models::codec::Encoding;
 use models::meta_data::{NodeId, ReplicationSetId, VnodeId};
 
 use super::logical_planner::{DatabaseObjectType, GlobalObjectType, TenantObjectType};
-
 /// Statement representations
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExtStatement {
@@ -59,11 +58,20 @@ pub enum ExtStatement {
     MoveVnode(MoveVnode),
     CompactVnode(CompactVnode),
     ChecksumGroup(ChecksumGroup),
+
+    //node cmd
+    ChangeNodeState(ChangeNodeState),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChecksumGroup {
     pub replication_set_id: ReplicationSetId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeNodeState {
+    pub node_id: NodeId,
+    pub node_state: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/query_server/spi/src/query/logical_planner.rs
+++ b/query_server/spi/src/query/logical_planner.rs
@@ -23,7 +23,7 @@ use lazy_static::lazy_static;
 use models::auth::privilege::{DatabasePrivilege, GlobalPrivilege, Privilege};
 use models::auth::role::{SystemTenantRole, TenantRoleIdentifier};
 use models::auth::user::{UserOptions, UserOptionsBuilder};
-use models::meta_data::{NodeId, ReplicationSetId, VnodeId};
+use models::meta_data::{NodeId, NodeState, ReplicationSetId, VnodeId};
 use models::object_reference::ResolvedTable;
 use models::oid::{Identifier, Oid};
 use models::schema::{
@@ -140,12 +140,20 @@ pub enum DDLPlan {
 
     CompactVnode(CompactVnode),
 
+    ChangeNodeState(ChangeNodeState),
+
     ChecksumGroup(ChecksumGroup),
 }
 
 #[derive(Debug, Clone)]
 pub struct ChecksumGroup {
     pub replication_set_id: ReplicationSetId,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChangeNodeState {
+    pub node_id: NodeId,
+    pub node_state: NodeState,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION

# Which issue does this PR close?
SQL command
CHANGE NODE node_id STATE [RUNNING | COLD | PENDING]
Adding SQL commands to change the status of nodes and add time information to nodeinfo for reporting
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
