### PR TITLE
feat(win32): add windows versoin for meta_data::get_disk_info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,6 +3610,7 @@ dependencies = [
  "trace",
  "utils",
  "uuid",
+ "winapi",
 ]
 
 [[package]]

--- a/common/models/Cargo.toml
+++ b/common/models/Cargo.toml
@@ -13,6 +13,7 @@ trace = { path = "../trace" }
 utils = { path = "../utils" }
 
 arrow-schema = { workspace = true, features = ["serde"] }
+async-backtrace = { workspace = true, optional = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
@@ -32,7 +33,9 @@ tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 uuid = { workspace = true }
-async-backtrace = { workspace = true, optional = true }
+
+[target.'cfg(windows)'.dependencies]
+winapi = { workspace = true }
 
 [features]
 default = []

--- a/common/models/src/errors.rs
+++ b/common/models/src/errors.rs
@@ -75,9 +75,20 @@ pub fn tuple_err<T, R, E>(value: (Result<T, E>, Result<R, E>)) -> Result<(T, R),
 }
 
 pub fn check_err(r: libc::c_int) -> io::Result<libc::c_int> {
-    if r == -1 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(r)
+    #[cfg(windows)]
+    {
+        if r == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(r)
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        if r == -1 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(r)
+        }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

The crate `sys_info` only gives`disk_info()` which will return disk info about the current volume.

On windows version it does not give `GetDiskFreeSpace` the target path.

```c
// sys-inf-0.9.1 c::windows.c
DiskInfo get_disk_info(void) {
	DWORD cluser, sector, free, total;
	double tmp;
	DiskInfo di;
	                                     v Here is the parameter.
	if (GetDiskFreeSpace(NULL, &cluser, &sector, &free, &total)) {
		tmp = cluser * sector;
		di.total = tmp * total / 1024;
		di.free = tmp * free / 1024;
	} else {
		di.total = 0;
		di.free = 0;
	}
	return di;
}
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
