### PR TITLE
feat(tskv): fix flush set the wrong CompactMeta::level

### DIFF
--- a/tskv/src/compaction/flush.rs
+++ b/tskv/src/compaction/flush.rs
@@ -310,11 +310,11 @@ impl WriterWrapper {
         max_data_block_size: usize,
     ) -> Self {
         let data_block_buffers = [
-            DataBlock::new(max_data_block_size, ValueType::Float),
-            DataBlock::new(max_data_block_size, ValueType::Integer),
-            DataBlock::new(max_data_block_size, ValueType::Unsigned),
-            DataBlock::new(max_data_block_size, ValueType::Boolean),
-            DataBlock::new(max_data_block_size, ValueType::String),
+            DataBlock::new(0, ValueType::Float),
+            DataBlock::new(0, ValueType::Integer),
+            DataBlock::new(0, ValueType::Unsigned),
+            DataBlock::new(0, ValueType::Boolean),
+            DataBlock::new(0, ValueType::String),
         ];
         Self {
             ts_family_id,

--- a/tskv/src/compaction/job.rs
+++ b/tskv/src/compaction/job.rs
@@ -29,7 +29,8 @@ pub fn run(
         ));
 
         while let Some(compact_task) = receiver.recv().await {
-            let (vnode_id, flus_vnode) = match compact_task {
+            // Vnode id to compact & whether vnode be flushed before compact
+            let (vnode_id, flush_vnode) = match compact_task {
                 CompactTask::Vnode(id) => (id, false),
                 CompactTask::ColdVnode(id) => (id, true),
             };
@@ -56,7 +57,7 @@ pub fn run(
 
                     let permit = compaction_limit.clone().acquire_owned().await.unwrap();
                     runtime_inner.spawn(async move {
-                        if flus_vnode {
+                        if flush_vnode {
                             let mut tsf_wlock = tsf.write().await;
                             tsf_wlock.switch_to_immutable();
                             let flush_req = tsf_wlock.build_flush_req(true);

--- a/tskv/src/summary.rs
+++ b/tskv/src/summary.rs
@@ -105,7 +105,7 @@ impl CompactMetaBuilder {
         Self { ts_family_id }
     }
 
-    pub fn build_tsm(
+    pub fn build(
         &self,
         file_id: u64,
         file_size: u64,
@@ -120,27 +120,7 @@ impl CompactMetaBuilder {
             level,
             min_ts,
             max_ts,
-            is_delta: false,
-            ..Default::default()
-        }
-    }
-
-    pub fn build_delta(
-        &self,
-        file_id: u64,
-        file_size: u64,
-        level: LevelId,
-        min_ts: Timestamp,
-        max_ts: Timestamp,
-    ) -> CompactMeta {
-        CompactMeta {
-            file_id,
-            file_size,
-            tsf_id: self.ts_family_id,
-            level,
-            min_ts,
-            max_ts,
-            is_delta: true,
+            is_delta: level == 0,
             ..Default::default()
         }
     }

--- a/tskv/src/tsm/block.rs
+++ b/tskv/src/tsm/block.rs
@@ -179,6 +179,31 @@ impl DataBlock {
         }
     }
 
+    pub fn clear(&mut self) {
+        match self {
+            DataBlock::U64 { ts, val, .. } => {
+                ts.clear();
+                val.clear();
+            }
+            DataBlock::I64 { ts, val, .. } => {
+                ts.clear();
+                val.clear();
+            }
+            DataBlock::Str { ts, val, .. } => {
+                ts.clear();
+                val.clear();
+            }
+            DataBlock::F64 { ts, val, .. } => {
+                ts.clear();
+                val.clear();
+            }
+            DataBlock::Bool { ts, val, .. } => {
+                ts.clear();
+                val.clear();
+            }
+        }
+    }
+
     pub fn time_range(&self) -> Option<(Timestamp, Timestamp)> {
         if self.is_empty() {
             return None;
@@ -335,7 +360,7 @@ impl DataBlock {
         }
     }
 
-    pub fn set_encodings(&mut self, encoding: DataBlockEncoding) {
+    pub fn set_encoding(&mut self, encoding: DataBlockEncoding) {
         match self {
             DataBlock::U64 { enc, .. } => {
                 *enc = encoding;

--- a/tskv/src/tsm/reader.rs
+++ b/tskv/src/tsm/reader.rs
@@ -726,7 +726,7 @@ pub mod tsm_reader_tests {
 
     pub(crate) async fn read_and_check(
         reader: &TsmReader,
-        expected_data: HashMap<FieldId, Vec<DataBlock>>,
+        expected_data: &HashMap<FieldId, Vec<DataBlock>>,
     ) -> Result<()> {
         let mut read_data: HashMap<FieldId, Vec<DataBlock>> = HashMap::new();
         for idx in reader.index_iterator() {
@@ -779,7 +779,7 @@ pub mod tsm_reader_tests {
                 DataBlock::U64 { ts: vec![9], val: vec![109], enc: DataBlockEncoding::default() },
             ]),
         ]);
-        read_and_check(&reader, expected_data).await.unwrap();
+        read_and_check(&reader, &expected_data).await.unwrap();
     }
 
     pub(crate) async fn read_opt_and_check(

--- a/tskv/src/tsm/writer.rs
+++ b/tskv/src/tsm/writer.rs
@@ -527,7 +527,7 @@ pub mod tsm_writer_tests {
         write_to_tsm(&tsm_file, &data).await.unwrap();
 
         let reader = TsmReader::open(tsm_file).await.unwrap();
-        read_and_check(&reader, data).await.unwrap();
+        read_and_check(&reader, &data).await.unwrap();
     }
 
     #[tokio::test]
@@ -557,6 +557,6 @@ pub mod tsm_writer_tests {
         write_to_tsm(&tsm_file, &data).await.unwrap();
 
         let reader = TsmReader::open(tsm_file).await.unwrap();
-        read_and_check(&reader, data).await.unwrap();
+        read_and_check(&reader, &data).await.unwrap();
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

- feat(tskv): fix flush set the wrong `CompactMeta::level`.
- Decrease vector allocates in flushing.

There are two fields which means the level of files: `level` and `is_delta`，now it set the wrong level:

https://github.com/cnosdb/cnosdb/blob/e48dab9676fe65ac5347a9f269ac216f84a7de5b/tskv/src/compaction/flush.rs#L314-L337

After flush, files are written to the correct directory `$vnode_id/delta/`, but the summary saved the wrong `CompactMeta::level`, so CnosDB tries to load these files in the wrong directory `$vnode_id/tsm/`.

This PR may fix issue #1040 .

# What changes are included in this PR?

# Are there any user-facing changes?
