### PR TITLE
fix: add private key to request header and cli options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,7 @@ version = "2.2.0"
 dependencies = [
  "anyhow",
  "async-backtrace",
+ "base64 0.13.1",
  "clap 4.2.5",
  "datafusion",
  "dirs",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync
 async-backtrace = { workspace = true, optional = true }
 walkdir = { workspace = true }
 anyhow = { workspace = true }
+base64 = { workspace = true }
 
 [features]
 default = []

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,5 +1,5 @@
-use std::env;
 use std::path::{Path, PathBuf};
+use std::{env, fs};
 
 use clap::{value_parser, Parser};
 use client::ctx::{SessionConfig, SessionContext};
@@ -38,6 +38,12 @@ struct Args {
 
     #[arg(short, long, help = "Password used to connect to the CnosDB")]
     password: Option<String>,
+
+    #[arg(
+        long,
+        help = "Rsa private key path for key pair authentication used to connect to the CnosDB"
+    )]
+    private_key_path: Option<String>,
 
     #[arg(
         short,
@@ -136,11 +142,17 @@ pub async fn main() -> Result<(), anyhow::Error> {
         env::set_current_dir(p).unwrap();
     };
 
+    let private_key = args.private_key_path.as_ref().map(|e| {
+        let p = Path::new(e);
+        fs::read_to_string(p).expect("Read private key file.")
+    });
+
     let session_config = SessionConfig::from_env()
         .with_host(args.host)
         .with_port(args.port)
         .with_user(args.user)
         .with_password(args.password)
+        .with_private_key(private_key)
         .with_tenant(args.tenant)
         .with_database(args.database)
         .with_target_partitions(args.target_partitions)

--- a/common/http_protocol/src/header.rs
+++ b/common/http_protocol/src/header.rs
@@ -1,7 +1,11 @@
 // re-export const header names
 pub use reqwest::header::{HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 
-/// value
+// header
+// privateKey
+pub const PRIVATE_KEY: &str = "X-CnosDB-PrivateKey";
+
+// value
 pub const APPLICATION_PREFIX: &str = "application/";
 pub const APPLICATION_CSV: &str = "application/csv";
 pub const APPLICATION_TSV: &str = "application/tsv";
@@ -11,7 +15,7 @@ pub const APPLICATION_TABLE: &str = "application/table";
 pub const APPLICATION_STAR: &str = "application/*";
 pub const STAR_STAR: &str = "*/*";
 
-/// basic auth
+// basic auth
 pub const BASIC_PREFIX: &str = "Basic ";
 pub const BEARER_PREFIX: &str = "Bearer ";
 

--- a/main/src/flight_sql/auth_middleware/basic_call_header_authenticator.rs
+++ b/main/src/flight_sql/auth_middleware/basic_call_header_authenticator.rs
@@ -1,4 +1,4 @@
-use http_protocol::header;
+use http_protocol::header::{self, PRIVATE_KEY};
 use spi::server::dbms::DBMSRef;
 use tonic::metadata::MetadataMap;
 use tonic::Status;
@@ -28,8 +28,9 @@ impl CallHeaderAuthenticator for BasicCallHeaderAuthenticator {
 
         let authorization = utils::get_value_from_auth_header(req_headers, "")
             .ok_or_else(|| Status::unauthenticated("authorization field not present"))?;
+        let private_key = utils::get_value_from_header(req_headers, PRIVATE_KEY, "");
 
-        let user_info = Header::with(None, authorization)
+        let user_info = Header::with_private_key(None, authorization, private_key)
             .try_get_basic_auth()
             .map_err(|e| Status::invalid_argument(e.to_string()))?;
 

--- a/main/src/flight_sql/flight_sql_server.rs
+++ b/main/src/flight_sql/flight_sql_server.rs
@@ -900,7 +900,6 @@ mod test {
         let _handle = tokio::spawn(server);
     }
 
-    #[ignore]
     #[tokio::test]
     async fn test_client() {
         trace::init_default_global_tracing("/tmp", "test_rust.log", "info");

--- a/main/src/flight_sql/utils.rs
+++ b/main/src/flight_sql/utils.rs
@@ -9,12 +9,9 @@ use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::ipc::{self, reader};
 use datafusion::arrow::record_batch::RecordBatch;
 use http_protocol::header::AUTHORIZATION;
-use models::auth::user::UserInfo;
 use prost::Message;
 use tonic::metadata::{AsciiMetadataValue, MetadataMap};
 use tonic::{Request, Status};
-
-use crate::http::header::Header;
 
 /// Helper method for retrieving a value from the Authorization header.
 ///
@@ -89,21 +86,6 @@ pub fn parse_authorization_header(
         .map_err(|_| "authorization not parsable".to_string())?;
 
     Ok(authorization)
-}
-
-pub fn parse_user_info(
-    request: &Request<FlightDescriptor>,
-) -> std::result::Result<UserInfo, String> {
-    let authorization = request
-        .metadata()
-        .get(AUTHORIZATION.to_string())
-        .ok_or_else(|| "authorization field not present".to_string())?
-        .to_str()
-        .map_err(|_| "authorization not parsable".to_string())?;
-
-    Header::with(None, authorization.to_string())
-        .try_get_basic_auth()
-        .map_err(|e| format!("authorization not parsable, error: {}", e))
 }
 
 pub fn endpoint(

--- a/main/src/http/http_service.rs
+++ b/main/src/http/http_service.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 use chrono::Local;
 use config::TLSConfig;
 use coordinator::service::CoordinatorRef;
-use http_protocol::header::{ACCEPT, AUTHORIZATION};
+use http_protocol::header::{ACCEPT, AUTHORIZATION, PRIVATE_KEY};
 use http_protocol::parameter::{SqlParam, WriteParam};
 use http_protocol::response::ErrorResponse;
 use meta::error::MetaError;
@@ -126,8 +126,10 @@ impl HttpService {
     fn handle_header(&self) -> impl Filter<Extract = (Header,), Error = warp::Rejection> + Clone {
         header::optional::<String>(ACCEPT.as_str())
             .and(header::<String>(AUTHORIZATION.as_str()))
-            .and_then(|accept, authorization| async move {
-                let res: Result<Header, warp::Rejection> = Ok(Header::with(accept, authorization));
+            .and(header::optional::<String>(PRIVATE_KEY))
+            .and_then(|accept, authorization, private_key| async move {
+                let res: Result<Header, warp::Rejection> =
+                    Ok(Header::with_private_key(accept, authorization, private_key));
                 res
             })
     }

--- a/query_server/spi/src/query/execution.rs
+++ b/query_server/spi/src/query/execution.rs
@@ -194,6 +194,30 @@ pub struct QueryStateMachine {
 }
 
 impl QueryStateMachine {
+    /// only for test
+    pub fn test(query: Query) -> Self {
+        use coordinator::service_mock::MockCoordinator;
+        use datafusion::execution::memory_pool::UnboundedMemoryPool;
+
+        use super::session::SessionCtxFactory;
+
+        let factory = SessionCtxFactory::new("/tmp".into());
+        let ctx = query.context().clone();
+        QueryStateMachine::begin(
+            QueryId::next_id(),
+            query,
+            factory
+                .create_session_ctx(
+                    "session_id",
+                    ctx,
+                    0,
+                    Arc::new(UnboundedMemoryPool::default()),
+                )
+                .expect("create test session ctx"),
+            Arc::new(MockCoordinator {}),
+        )
+    }
+
     pub fn begin(
         query_id: QueryId,
         query: Query,

--- a/query_server/spi/src/server/dbms.rs
+++ b/query_server/spi/src/server/dbms.rs
@@ -8,7 +8,7 @@ use datafusion::from_slice::FromSlice;
 use models::auth::role::UserRole;
 use models::auth::user::{User, UserDesc, UserInfo, UserOptionsBuilder};
 
-use crate::query::execution::{Output, QueryStateMachineRef};
+use crate::query::execution::{Output, QueryStateMachine, QueryStateMachineRef};
 use crate::query::logical_planner::Plan;
 use crate::query::recordbatch::RecordBatchStreamWrapper;
 use crate::service::protocol::{Query, QueryHandle, QueryId};
@@ -85,23 +85,23 @@ impl DatabaseManagerSystem for DatabaseManagerSystemMock {
         ))
     }
 
-    async fn build_query_state_machine(&self, _query: Query) -> Result<QueryStateMachineRef> {
-        todo!()
+    async fn build_query_state_machine(&self, query: Query) -> Result<QueryStateMachineRef> {
+        Ok(Arc::new(QueryStateMachine::test(query)))
     }
 
     async fn build_logical_plan(
         &self,
         _query_state_machine: QueryStateMachineRef,
     ) -> Result<Option<Plan>> {
-        todo!()
+        Ok(None)
     }
 
     async fn execute_logical_plan(
         &self,
         _logical_plan: Plan,
-        _query_state_machine: QueryStateMachineRef,
+        query_state_machine: QueryStateMachineRef,
     ) -> Result<QueryHandle> {
-        todo!()
+        self.execute(&query_state_machine.query).await
     }
 
     fn metrics(&self) -> String {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

1. cli option
```
      --private-key-path <PRIVATE_KEY_PATH>
          Rsa private key path for key pair authentication used to connect to the CnosDB
```
2. http header

|  key   | value |
|  ----  | ----  |
| X-CnosDB-PrivateKey | 用于连接CnosDB的密钥对认证的rsa私钥内容（base64编码后） |

Closes #.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
