### PR TITLE
fix: alter non-null user options

### DIFF
--- a/meta/src/store/state_machine.rs
+++ b/meta/src/store/state_machine.rs
@@ -1065,7 +1065,7 @@ impl StateMachine {
             match serde_json::from_slice::<UserDesc>(&e) {
                 Ok(old_user_desc) => {
                     let old_options = old_user_desc.options().to_owned();
-                    let new_options = old_options.merge(user_options.clone());
+                    let new_options = user_options.clone().merge(old_options);
 
                     let new_user_desc = UserDesc::new(
                         *old_user_desc.id(),

--- a/query_server/sqllogicaltests/cases/ddl/user.slt
+++ b/query_server/sqllogicaltests/cases/ddl/user.slt
@@ -1,0 +1,38 @@
+statement ok
+create user if not exists test_alter_options_u;
+
+statement ok
+alter user test_alter_options_u set comment = 'xxx ccc';
+
+# import data to tskv table
+query I
+select * from cluster_schema.users where user_name = 'test_alter_options_u';
+----
+test_alter_options_u false {"password":"*****","must_change_password":null,"rsa_public_key":null,"comment":"xxx ccc"}
+
+statement ok
+alter user test_alter_options_u set comment = 'ooo ooo';
+
+# import data to tskv table
+query I
+select * from cluster_schema.users where user_name = 'test_alter_options_u';
+----
+test_alter_options_u false {"password":"*****","must_change_password":null,"rsa_public_key":null,"comment":"ooo ooo"}
+
+statement ok
+alter user test_alter_options_u set must_change_password = false;
+
+# import data to tskv table
+query I
+select * from cluster_schema.users where user_name = 'test_alter_options_u';
+----
+test_alter_options_u false {"password":"*****","must_change_password":false,"rsa_public_key":null,"comment":"ooo ooo"}
+
+statement ok
+alter user test_alter_options_u set must_change_password = true;
+
+# import data to tskv table
+query I
+select * from cluster_schema.users where user_name = 'test_alter_options_u';
+----
+test_alter_options_u false {"password":"*****","must_change_password":true,"rsa_public_key":null,"comment":"ooo ooo"}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

fix can not repeatedly modify existing user options

Closes #.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
