### PR TITLE
feat(query): implement CHECKSUM GROUP <group id>

### DIFF
--- a/common/protos/proto/kv_service.proto
+++ b/common/protos/proto/kv_service.proto
@@ -120,6 +120,17 @@ message AdminCommandRequest {
   }
 }
 
+message FetchVnodeChecksumRequest {
+    uint32 vnode_id = 1;
+}
+
+message AdminFetchCommandRequest {
+  string tenant = 1;
+  oneof command {
+    FetchVnodeChecksumRequest fetch_vnode_checksum = 8;
+  }
+}
+
 /* -------------------------------------------------------------------- */
 
 message BatchBytesResponse {
@@ -154,6 +165,7 @@ service TSKVService {
   rpc WriteVnodePoints(WriteVnodeRequest) returns (StatusResponse) {};
   rpc QueryRecordBatch(QueryRecordBatchRequest) returns (stream BatchBytesResponse) {};
   rpc ExecAdminCommand(AdminCommandRequest) returns (StatusResponse) {};
+  rpc ExecAdminFetchCommand(AdminFetchCommandRequest) returns (BatchBytesResponse) {};
 
   rpc DownloadFile(DownloadFileRequest) returns (stream BatchBytesResponse) {};
   rpc GetVnodeFilesMeta(GetVnodeFilesMetaRequest) returns (GetVnodeFilesMetaResponse) {};

--- a/coordinator/src/errors.rs
+++ b/coordinator/src/errors.rs
@@ -142,6 +142,12 @@ pub enum CoordinatorError {
     FBPoints {
         source: PointsError,
     },
+
+    #[snafu(display("ReplicationSet not found: {}", id))]
+    #[error_code(code = 22)]
+    ReplicationSetNotFound {
+        id: u32,
+    },
 }
 
 impl From<PointsError> for CoordinatorError {

--- a/coordinator/src/service.rs
+++ b/coordinator/src/service.rs
@@ -215,8 +215,8 @@ impl CoordService {
         replication_set_id: u32,
     ) -> CoordinatorResult<ReplicationSet> {
         match self.tenant_meta(tenant).await {
-            Some(meta_client) => match meta_client.get_vnode_repl_set(replication_set_id) {
-                Some(all_info) => Ok(all_info),
+            Some(meta_client) => match meta_client.get_replication_set(replication_set_id) {
+                Some(repl_set) => Ok(repl_set),
                 None => Err(CoordinatorError::ReplicationSetNotFound {
                     id: replication_set_id,
                 }),

--- a/coordinator/src/service.rs
+++ b/coordinator/src/service.rs
@@ -12,7 +12,8 @@ use metrics::label::Labels;
 use metrics::metric::Metric;
 use metrics::metric_register::MetricsRegister;
 use models::consistency_level::ConsistencyLevel;
-use models::meta_data::{ExpiredBucketInfo, VnodeAllInfo};
+use models::meta_data::{ExpiredBucketInfo, ReplicationSet, VnodeAllInfo};
+use models::record_batch_decode;
 use models::schema::{Precision, DEFAULT_CATALOG};
 use protos::get_db_from_fb_points;
 use protos::kv_service::admin_command_request::Command::*;
@@ -32,7 +33,8 @@ use crate::metrics::LPReporter;
 use crate::reader::{QueryExecutor, ReaderIterator};
 use crate::writer::PointWriter;
 use crate::{
-    status_response_to_result, Coordinator, QueryOption, VnodeManagerCmdType, WriteRequest,
+    status_response_to_result, Coordinator, QueryOption, VnodeManagerCmdType,
+    VnodeSummarizerCmdType, WriteRequest,
 };
 
 pub type CoordinatorRef = Arc<dyn Coordinator>;
@@ -207,6 +209,25 @@ impl CoordService {
         }
     }
 
+    async fn get_replication_set(
+        &self,
+        tenant: &str,
+        replication_set_id: u32,
+    ) -> CoordinatorResult<ReplicationSet> {
+        match self.tenant_meta(tenant).await {
+            Some(meta_client) => match meta_client.get_vnode_repl_set(replication_set_id) {
+                Some(all_info) => Ok(all_info),
+                None => Err(CoordinatorError::ReplicationSetNotFound {
+                    id: replication_set_id,
+                }),
+            },
+
+            None => Err(CoordinatorError::TenantNotFound {
+                name: tenant.to_string(),
+            }),
+        }
+    }
+
     async fn select_statement_request(
         self,
         option: QueryOption,
@@ -320,6 +341,25 @@ impl CoordService {
 
         let response = client.exec_admin_command(request).await?.into_inner();
         status_response_to_result(&response)
+    }
+
+    async fn exec_admin_fetch_command_on_node(
+        &self,
+        node_id: u64,
+        req: AdminFetchCommandRequest,
+    ) -> CoordinatorResult<RecordBatch> {
+        let channel = self.meta.admin_meta().get_node_conn(node_id).await?;
+
+        let timeout_channel = Timeout::new(channel, Duration::from_secs(60 * 60));
+
+        let mut client = TskvServiceClient::<Timeout<Channel>>::new(timeout_channel);
+        let request = tonic::Request::new(req.clone());
+
+        let response = client.exec_admin_fetch_command(request).await?.into_inner();
+        match record_batch_decode(&response.data) {
+            Ok(r) => Ok(r),
+            Err(e) => Err(CoordinatorError::ArrowError { source: e }),
+        }
     }
 }
 
@@ -511,6 +551,53 @@ impl Coordinator for CoordService {
             }
         };
 
-        self.exec_admin_command_on_node(req_node_id, grpc_req).await
+        self.exec_admin_command_on_node(req_node_id, grpc_req)
+            .await
+            .map(|_| ())
+    }
+
+    async fn vnode_summarizer(
+        &self,
+        tenant: &str,
+        cmd_type: VnodeSummarizerCmdType,
+    ) -> CoordinatorResult<Vec<RecordBatch>> {
+        match cmd_type {
+            VnodeSummarizerCmdType::Checksum(replication_set_id) => {
+                let replication_set = self.get_replication_set(tenant, replication_set_id).await?;
+
+                // Group vnode ids by node id.
+                let mut node_vnode_ids_map: HashMap<u64, Vec<u32>> = HashMap::new();
+                for vnode in replication_set.vnodes {
+                    node_vnode_ids_map
+                        .entry(vnode.node_id)
+                        .or_default()
+                        .push(vnode.id);
+                }
+
+                let meta = self.meta.admin_meta();
+                let nodes = meta.data_nodes().await;
+
+                // Send grouped vnode ids to nodes.
+                let mut req_futures = vec![];
+                for node in nodes {
+                    if let Some(vnode_ids) = node_vnode_ids_map.remove(&node.id) {
+                        for vnode_id in vnode_ids {
+                            let cmd = AdminFetchCommandRequest {
+                                tenant: tenant.to_string(),
+                                command: Some(
+                                    admin_fetch_command_request::Command::FetchVnodeChecksum(
+                                        FetchVnodeChecksumRequest { vnode_id },
+                                    ),
+                                ),
+                            };
+                            req_futures.push(self.exec_admin_fetch_command_on_node(node.id, cmd));
+                        }
+                    }
+                }
+                let record_batches = futures::future::try_join_all(req_futures).await?;
+
+                return Ok(record_batches);
+            }
+        }
     }
 }

--- a/coordinator/src/service_mock.rs
+++ b/coordinator/src/service_mock.rs
@@ -3,6 +3,7 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use datafusion::arrow::record_batch::RecordBatch;
 use meta::model::meta_client_mock::{MockMetaClient, MockMetaManager};
 use meta::model::{MetaClientRef, MetaRef};
 use models::consistency_level::ConsistencyLevel;
@@ -14,7 +15,7 @@ use tskv::EngineRef;
 
 use crate::errors::CoordinatorResult;
 use crate::reader::ReaderIterator;
-use crate::{Coordinator, VnodeManagerCmdType};
+use crate::{Coordinator, VnodeManagerCmdType, VnodeSummarizerCmdType};
 
 #[derive(Debug, Default)]
 pub struct MockCoordinator {}
@@ -67,5 +68,13 @@ impl Coordinator for MockCoordinator {
         cmd_type: VnodeManagerCmdType,
     ) -> CoordinatorResult<()> {
         Ok(())
+    }
+
+    async fn vnode_summarizer(
+        &self,
+        tenant: &str,
+        cmd_type: VnodeSummarizerCmdType,
+    ) -> CoordinatorResult<Vec<RecordBatch>> {
+        Ok(vec![])
     }
 }

--- a/coordinator/src/writer.rs
+++ b/coordinator/src/writer.rs
@@ -261,7 +261,7 @@ impl<'a> VnodeMapping<'a> {
 
         //let full_name = format!("{}.{}", meta_client.tenant_name(), db);
         let info = meta_client
-            .locate_replcation_set_for_write(db_name, hash_id, ts)
+            .locate_replication_set_for_write(db_name, hash_id, ts)
             .await?;
         self.sets.entry(info.id).or_insert_with(|| info.clone());
         let entry = self

--- a/meta/src/model/meta_client.rs
+++ b/meta/src/model/meta_client.rs
@@ -246,7 +246,7 @@ impl MetaClient for RemoteMetaClient {
         }
     }
 
-    async fn reasign_member_role(
+    async fn reassign_member_role(
         &self,
         user_id: Oid,
         role: TenantRoleIdentifier,
@@ -742,13 +742,13 @@ impl MetaClient for RemoteMetaClient {
         None
     }
 
-    fn get_vnode_repl_set(&self, id: u32) -> Option<ReplicationSet> {
+    fn get_vnode_repl_set(&self, vnode_id: u32) -> Option<ReplicationSet> {
         let data = self.data.read();
         for (_db_name, db_info) in data.dbs.iter() {
             for bucket in db_info.buckets.iter() {
                 for repl_set in bucket.shard_group.iter() {
                     for vnode_info in repl_set.vnodes.iter() {
-                        if vnode_info.id == id {
+                        if vnode_info.id == vnode_id {
                             return Some(repl_set.clone());
                         }
                     }
@@ -765,7 +765,7 @@ impl MetaClient for RemoteMetaClient {
         Ok(buckets)
     }
 
-    async fn locate_replcation_set_for_write(
+    async fn locate_replication_set_for_write(
         &self,
         db: &str,
         hash_id: u64,
@@ -778,6 +778,21 @@ impl MetaClient for RemoteMetaClient {
         let bucket = self.create_bucket(db, ts).await?;
 
         Ok(bucket.vnode_for(hash_id))
+    }
+
+    fn get_replication_set(&self, repl_id: u32) -> Option<ReplicationSet> {
+        let data = self.data.read();
+        for (_db_name, db_info) in data.dbs.iter() {
+            for bucket in db_info.buckets.iter() {
+                for repl_set in bucket.shard_group.iter() {
+                    if repl_set.id == repl_id {
+                        return Some(repl_set.clone());
+                    }
+                }
+            }
+        }
+
+        None
     }
 
     async fn update_replication_set(

--- a/meta/src/model/meta_client_mock.rs
+++ b/meta/src/model/meta_client_mock.rs
@@ -145,7 +145,7 @@ impl MetaClient for MockMetaClient {
         Some(0)
     }
 
-    async fn locate_replcation_set_for_write(
+    async fn locate_replication_set_for_write(
         &self,
         db: &str,
         hash_id: u64,
@@ -178,7 +178,7 @@ impl MetaClient for MockMetaClient {
         todo!()
     }
 
-    async fn reasign_member_role(
+    async fn reassign_member_role(
         &self,
         user_id: Oid,
         role: TenantRoleIdentifier,
@@ -229,6 +229,10 @@ impl MetaClient for MockMetaClient {
 
     fn expired_bucket(&self) -> Vec<ExpiredBucketInfo> {
         vec![]
+    }
+
+    fn get_replication_set(&self, repl_id: u32) -> Option<ReplicationSet> {
+        todo!()
     }
 
     async fn update_replication_set(

--- a/meta/src/model/mod.rs
+++ b/meta/src/model/mod.rs
@@ -71,8 +71,11 @@ pub trait MetaClient: Send + Sync + Debug {
     ) -> MetaResult<()>;
     async fn member_role(&self, user_id: &Oid) -> MetaResult<Option<TenantRoleIdentifier>>;
     async fn members(&self) -> MetaResult<HashMap<String, TenantRoleIdentifier>>;
-    async fn reasign_member_role(&self, user_id: Oid, role: TenantRoleIdentifier)
-        -> MetaResult<()>;
+    async fn reassign_member_role(
+        &self,
+        user_id: Oid,
+        role: TenantRoleIdentifier,
+    ) -> MetaResult<()>;
     async fn remove_member(&self, user_id: Oid) -> MetaResult<()>;
 
     // tenant role
@@ -80,7 +83,7 @@ pub trait MetaClient: Send + Sync + Debug {
         &self,
         role_name: String,
         system_role: SystemTenantRole,
-        additiona_privileges: HashMap<String, DatabasePrivilege>,
+        additional_privileges: HashMap<String, DatabasePrivilege>,
     ) -> MetaResult<()>;
     async fn custom_role(&self, role_name: &str) -> MetaResult<Option<CustomTenantRole<Oid>>>;
     async fn custom_roles(&self) -> MetaResult<Vec<CustomTenantRole<Oid>>>;
@@ -125,17 +128,19 @@ pub trait MetaClient: Send + Sync + Debug {
     fn database_min_ts(&self, db: &str) -> Option<i64>;
     fn expired_bucket(&self) -> Vec<ExpiredBucketInfo>;
 
-    fn get_vnode_all_info(&self, id: u32) -> Option<VnodeAllInfo>;
-    fn get_vnode_repl_set(&self, id: u32) -> Option<ReplicationSet>;
+    fn get_vnode_all_info(&self, vnode_id: u32) -> Option<VnodeAllInfo>;
+    fn get_vnode_repl_set(&self, vnode_id: u32) -> Option<ReplicationSet>;
 
     fn mapping_bucket(&self, db_name: &str, start: i64, end: i64) -> MetaResult<Vec<BucketInfo>>;
 
-    async fn locate_replcation_set_for_write(
+    async fn locate_replication_set_for_write(
         &self,
         db: &str,
         hash_id: u64,
         ts: i64,
     ) -> MetaResult<ReplicationSet>;
+
+    fn get_replication_set(&self, repl_id: u32) -> Option<ReplicationSet>;
 
     async fn update_replication_set(
         &self,

--- a/query_server/query/src/execution/ddl/alter_tenant.rs
+++ b/query_server/query/src/execution/ddl/alter_tenant.rs
@@ -65,17 +65,17 @@ impl DDLDefinitionTask for AlterTenantTask {
                 // user_id: Oid,
                 // role: TenantRoleIdentifier,
                 // tenant_id: Oid,
-                // fn reasign_member_role_in_tenant(
+                // fn reassign_member_role_in_tenant(
                 //     &mut self,
                 //     user_id: Oid,
                 //     role: TenantRoleIdentifier,
                 //     tenant_id: Oid,
                 // ) -> Result<()>;
                 debug!(
-                    "Reasign role {:?} of user {} in tenant {}",
+                    "Reassign role {:?} of user {} in tenant {}",
                     role, user_id, tenant_name
                 );
-                meta.reasign_member_role(*user_id, role.clone()).await?;
+                meta.reassign_member_role(*user_id, role.clone()).await?;
                 // .context(MetaSnafu)?;
             }
             AlterTenantAction::RemoveUser(user_id) => {

--- a/query_server/query/src/execution/ddl/checksum_group.rs
+++ b/query_server/query/src/execution/ddl/checksum_group.rs
@@ -27,7 +27,7 @@ impl DDLDefinitionTask for ChecksumGroupTask {
         let coord = query_state_machine.coord.clone();
         let cmd_type = VnodeSummarizerCmdType::Checksum(replication_set_id);
         let checksums = coord.vnode_summarizer(tenant, cmd_type).await?;
-        let stream = RecordBatchStreamWrapper::new(tskv::vnode_checksum_schema(), checksums);
+        let stream = RecordBatchStreamWrapper::new(tskv::vnode_table_checksum_schema(), checksums);
         Ok(Output::StreamData(Box::pin(stream)))
     }
 }

--- a/tskv/src/compaction/check.rs
+++ b/tskv/src/compaction/check.rs
@@ -1,20 +1,26 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Display, Write};
-use std::rc::Rc;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use blake3::Hasher;
 use chrono::{Duration, DurationRound, NaiveDateTime};
+use datafusion::arrow::array::{Int64Array, StringBuilder, UInt32Array};
+use datafusion::arrow::datatypes::{
+    DataType as ArrowDataType, Field as ArrowField, Schema, SchemaRef,
+};
+use datafusion::arrow::record_batch::RecordBatch;
 use models::predicate::domain::TimeRange;
 use models::schema::ColumnType;
 use models::{utils, ColumnId, FieldId, Timestamp};
 use snafu::ResultExt;
+use tokio::sync::RwLock;
 use trace::warn;
 
 use crate::compaction::{CompactIterator, CompactingBlock};
-use crate::database::Database;
 use crate::error::{self, Error, Result};
 use crate::schema::schemas::DBschemas;
+use crate::tseries_family::TseriesFamily;
 use crate::tsm::{DataBlock, TsmReader};
 use crate::TseriesFamilyId;
 
@@ -30,8 +36,8 @@ pub fn hash_to_string(hash: Hash) -> String {
 
 #[derive(Default, Debug)]
 pub struct TableHashTreeNode {
-    table: String,
-    columns: Vec<ColumnHashTreeNode>,
+    pub table: String,
+    pub columns: Vec<ColumnHashTreeNode>,
 }
 
 impl TableHashTreeNode {
@@ -61,8 +67,8 @@ impl Display for TableHashTreeNode {
 
 #[derive(Default, Debug)]
 pub struct ColumnHashTreeNode {
-    column: String,
-    values: Vec<TimeRangeHashTreeNode>,
+    pub column: String,
+    pub values: Vec<TimeRangeHashTreeNode>,
 }
 
 impl ColumnHashTreeNode {
@@ -92,9 +98,9 @@ impl Display for ColumnHashTreeNode {
 
 #[derive(Default, Debug)]
 pub struct TimeRangeHashTreeNode {
-    min_ts: Timestamp,
-    max_ts: Timestamp,
-    hash: Hash,
+    pub min_ts: Timestamp,
+    pub max_ts: Timestamp,
+    pub hash: Hash,
 }
 
 impl TimeRangeHashTreeNode {
@@ -121,28 +127,72 @@ impl Display for TimeRangeHashTreeNode {
     }
 }
 
-pub(crate) async fn get_ts_family_hash_tree(
-    database: &Database,
-    ts_family_id: TseriesFamilyId,
+pub fn vnode_checksum_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        ArrowField::new("VNODE_ID", ArrowDataType::UInt32, false),
+        ArrowField::new("TABLE", ArrowDataType::Utf8, false),
+        ArrowField::new("COLUMN", ArrowDataType::Utf8, false),
+        ArrowField::new("MIN_TIME", ArrowDataType::Int64, false),
+        ArrowField::new("MAX_TIME", ArrowDataType::Int64, false),
+        ArrowField::new("CHECK_SUM", ArrowDataType::Utf8, false),
+    ]))
+}
+
+pub(crate) async fn vnode_checksum(
+    ts_family: Arc<RwLock<TseriesFamily>>,
+    schemas: Arc<DBschemas>,
+) -> Result<RecordBatch> {
+    let vnode_id = ts_family.read().await.tf_id();
+    let tree_nodes = ts_family_hash_tree(ts_family, schemas).await?;
+
+    let capacity = 1024;
+    let mut vnode_id_array = UInt32Array::builder(capacity);
+    let mut table_array = StringBuilder::new();
+    let mut column_array = StringBuilder::new();
+    let mut min_time_array = Int64Array::builder(capacity);
+    let mut max_time_array = Int64Array::builder(capacity);
+    let mut check_sum_array = StringBuilder::new();
+    for tn in tree_nodes {
+        for col in tn.columns {
+            for tr in col.values {
+                vnode_id_array.append_value(vnode_id);
+                table_array.append_value(tn.table.as_str());
+                column_array.append_value(col.column.as_str());
+                min_time_array.append_value(tr.min_ts);
+                max_time_array.append_value(tr.max_ts);
+                check_sum_array.append_value(hash_to_string(tr.hash));
+            }
+        }
+    }
+
+    RecordBatch::try_new(
+        vnode_checksum_schema(),
+        vec![
+            Arc::new(vnode_id_array.finish()),
+            Arc::new(table_array.finish()),
+            Arc::new(column_array.finish()),
+            Arc::new(min_time_array.finish()),
+            Arc::new(max_time_array.finish()),
+            Arc::new(check_sum_array.finish()),
+        ],
+    )
+    .map_err(|err| Error::CommonError {
+        reason: format!("get checksum fail, {}", err),
+    })
+}
+
+pub(crate) async fn ts_family_hash_tree(
+    ts_family: Arc<RwLock<TseriesFamily>>,
+    schemas: Arc<DBschemas>,
 ) -> Result<Vec<TableHashTreeNode>> {
     const MAX_DATA_BLOCK_SIZE: u32 = 1000;
 
-    let ts_family = match database.get_tsfamily(ts_family_id) {
-        Some(t) => t,
-        None => {
-            return Err(Error::InvalidParam {
-                reason: format!("can not find ts_family '{}'", ts_family_id),
-            });
-        }
-    };
-
-    let schemas = database.get_schemas();
-    let mut cid_table_name_map: HashMap<ColumnId, Rc<String>> = HashMap::new();
+    let mut cid_table_name_map: HashMap<ColumnId, Arc<String>> = HashMap::new();
     let mut cid_col_name_map: HashMap<ColumnId, String> = HashMap::new();
     for tab in schemas.list_tables()? {
         match schemas.get_table_schema(&tab)? {
             Some(sch) => {
-                let shared_tab = Rc::new(tab);
+                let shared_tab = Arc::new(tab);
                 for col in sch.columns() {
                     if matches!(col.column_type, ColumnType::Field(_)) {
                         cid_table_name_map.insert(col.id, shared_tab.clone());
@@ -155,19 +205,20 @@ pub(crate) async fn get_ts_family_hash_tree(
             }
         }
     }
-    let time_range_nanosec = get_default_time_range(schemas)?;
+    let time_range_nanosec = default_time_range(schemas)?;
 
     let (version, ts_family_id) = {
         let ts_family_rlock = ts_family.read().await;
         (ts_family_rlock.version(), ts_family_rlock.tf_id())
     };
     let mut readers: Vec<Arc<TsmReader>> = Vec::new();
-    for path in version
+    let tsm_paths: Vec<PathBuf> = version
         .levels_info()
         .iter()
         .flat_map(|l| l.files.iter().map(|f| f.file_path()))
-    {
-        let r = version.get_tsm_reader(path).await?;
+        .collect();
+    for p in tsm_paths {
+        let r = version.get_tsm_reader(p).await?;
         readers.push(r);
     }
 
@@ -227,7 +278,7 @@ pub(crate) async fn get_ts_family_hash_tree(
         .collect::<Vec<TableHashTreeNode>>())
 }
 
-fn get_default_time_range(db_schemas: Arc<DBschemas>) -> Result<i64> {
+fn default_time_range(db_schemas: Arc<DBschemas>) -> Result<i64> {
     let db_schema = db_schemas.db_schema().context(error::SchemaSnafu)?;
     let _tenant_name = db_schema.tenant_name();
     let _database_name = db_schema.database_name();
@@ -445,7 +496,9 @@ mod test {
     use tokio::runtime;
 
     use super::{calc_block_partial_time_range, find_timestamp, hash_partial_datablock, Hash};
-    use crate::compaction::check::{get_default_time_range, TimeRangeHashTreeNode};
+    use crate::compaction::check::{
+        default_time_range, ts_family_hash_tree, TimeRangeHashTreeNode,
+    };
     use crate::tsm::codec::DataBlockEncoding;
     use crate::tsm::DataBlock;
     use crate::{Engine, Options, TsKv, TseriesFamilyId};
@@ -948,7 +1001,7 @@ mod test {
                     panic!("created database '{}' exists: {:?}", &database_name, e)
                 });
             let schemas = database_ref.read().await.get_schemas();
-            let time_range_nanosec = get_default_time_range(schemas).unwrap();
+            let time_range_nanosec = default_time_range(schemas.clone()).unwrap();
             let ts_family_ref = database_ref
                 .read()
                 .await
@@ -1004,12 +1057,7 @@ mod test {
             }
 
             // Get hash values and check them.
-            let trees = database_ref
-                .read()
-                .await
-                .get_ts_family_hash_tree(ts_family_id)
-                .await
-                .unwrap();
+            let trees = ts_family_hash_tree(ts_family_ref, schemas).await.unwrap();
             assert_eq!(trees.len(), 1);
             assert_eq!(trees[0].table, table_name);
             assert_eq!(trees[0].columns.len(), 5);

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -19,7 +19,7 @@ use tokio::sync::{oneshot, RwLock};
 use trace::{debug, error, info};
 use utils::BloomFilter;
 
-use crate::compaction::{check, CompactTask, FlushReq};
+use crate::compaction::{CompactTask, FlushReq};
 use crate::error::{self, Result, SchemaSnafu};
 use crate::index::{self, IndexResult};
 use crate::kv_option::Options;
@@ -494,13 +494,6 @@ impl Database {
 
     pub fn get_schema(&self) -> Result<DatabaseSchema> {
         Ok(self.schemas.db_schema()?)
-    }
-
-    pub async fn get_ts_family_hash_tree(
-        &self,
-        ts_family_id: TseriesFamilyId,
-    ) -> Result<Vec<check::TableHashTreeNode>> {
-        check::get_ts_family_hash_tree(self, ts_family_id).await
     }
 
     pub fn owner(&self) -> Arc<String> {

--- a/tskv/src/engine_mock.rs
+++ b/tskv/src/engine_mock.rs
@@ -4,6 +4,8 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use datafusion::arrow::record_batch::RecordBatch;
+use models::meta_data::VnodeId;
 use models::predicate::domain::{ColumnDomains, TimeRange};
 use models::schema::{Precision, TableColumn};
 use models::{ColumnId, SeriesId, SeriesKey};
@@ -190,6 +192,10 @@ impl Engine for MockEngine {
     }
 
     async fn compact(&self, vnode_ids: Vec<TseriesFamilyId>) -> Result<()> {
+        todo!()
+    }
+
+    async fn get_vnode_hash_tree(&self, vnode_ids: VnodeId) -> Result<RecordBatch> {
         todo!()
     }
 

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -984,7 +984,7 @@ impl Engine for TsKv {
             }
         }
 
-        Ok(RecordBatch::new_empty(check::vnode_checksum_schema()))
+        Ok(RecordBatch::new_empty(check::vnode_table_checksum_schema()))
     }
 
     async fn close(&self) {

--- a/tskv/src/lib.rs
+++ b/tskv/src/lib.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-pub use compaction::check::vnode_checksum_schema;
+pub use compaction::check::vnode_table_checksum_schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use models::meta_data::VnodeId;
 use models::predicate::domain::{ColumnDomains, TimeRange};

--- a/tskv/src/lib.rs
+++ b/tskv/src/lib.rs
@@ -5,20 +5,22 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-pub use error::{Error, Result};
-pub use kv_option::Options;
-pub use kvcore::TsKv;
+pub use compaction::check::vnode_checksum_schema;
+use datafusion::arrow::record_batch::RecordBatch;
 use models::meta_data::VnodeId;
 use models::predicate::domain::{ColumnDomains, TimeRange};
 use models::schema::{Precision, TableColumn};
 use models::{ColumnId, SeriesId, SeriesKey};
 use protos::kv_service::{WritePointsRequest, WritePointsResponse};
-pub use summary::{print_summary_statistics, Summary, VersionEdit};
-pub use tsm::print_tsm_statistics;
-pub use wal::print_wal_statistics;
 
+pub use crate::error::{Error, Result};
+pub use crate::kv_option::Options;
 use crate::kv_option::StorageOptions;
+pub use crate::kvcore::TsKv;
+pub use crate::summary::{print_summary_statistics, Summary, VersionEdit};
 use crate::tseries_family::SuperVersion;
+pub use crate::tsm::print_tsm_statistics;
+pub use crate::wal::print_wal_statistics;
 
 pub mod byte_utils;
 mod compaction;
@@ -158,6 +160,8 @@ pub trait Engine: Send + Sync + Debug {
     async fn drop_vnode(&self, id: TseriesFamilyId) -> Result<()>;
 
     async fn compact(&self, vnode_ids: Vec<TseriesFamilyId>) -> Result<()>;
+
+    async fn get_vnode_hash_tree(&self, vnode_id: VnodeId) -> Result<RecordBatch>;
 
     async fn close(&self);
 }


### PR DESCRIPTION
# Which issue does this PR close?

This PR implements admin query statement `CHECKSUM GROUP <group id>`.

Feature group in #806 .

# Rationale for this change

```
benchmark ❯ checksum group 12;
+----------+-------+--------+---------------------+---------------------+-----------------------------------------------------------------+
| VNODE_ID | TABLE | COLUMN | MIN_TIME            | MAX_TIME            | CHECK_SUM                                                       |
+----------+-------+--------+---------------------+---------------------+-----------------------------------------------------------------+
| 13       | ma    | fa     | 1683599100000000000 | 1683599400000000000 | 641a8e6f64ba469b2334818baf36a7c3d0c2cb433065394cf8ca985e19b35b7 |
| 12       | ma    | fa     | 1683599100000000000 | 1683599400000000000 | 641a8e6f64ba469b2334818baf36a7c3d0c2cb433065394cf8ca985e19b35b7 |
+----------+-------+--------+---------------------+---------------------+-----------------------------------------------------------------+
```

# What changes are included in this PR?

## Protobuf

- Add `AdminFetchCommandRequest` to fetch something using admin privilege.
  - Add inner fetch command `FetchVnodeChecksumRequest` to fetch vnode checksum.

## Coordinator

- While method `vnode_manager()` is only for sending manage commands, I added method `vnode_summarizer()` to summarize vnode information.

# Are there any user-facing changes?
