### PR TITLE
feat: support sliding window gap filling

### DIFF
--- a/query_server/query/src/extension/expr/mod.rs
+++ b/query_server/query/src/extension/expr/mod.rs
@@ -15,7 +15,8 @@ pub use selector_function::{BOTTOM, TOPK};
 use spi::query::function::FunctionMetadataManager;
 use spi::Result;
 pub use window::{
-    time_window_signature, TIME_WINDOW, TIME_WINDOW_UDF, WINDOW_COL_NAME, WINDOW_END, WINDOW_START,
+    ceil_sliding_window, floor_sliding_window, time_window_signature, DEFAULT_TIME_WINDOW_START,
+    TIME_WINDOW, TIME_WINDOW_UDF, WINDOW_COL_NAME, WINDOW_END, WINDOW_START,
 };
 
 pub static INTERVALS: &[DataType] = &[

--- a/query_server/query/src/extension/expr/window/mod.rs
+++ b/query_server/query/src/extension/expr/window/mod.rs
@@ -16,4 +16,7 @@ pub const WINDOW_COL_NAME: &str = "_window";
 pub const WINDOW_START: &str = "start";
 pub const WINDOW_END: &str = "end";
 
-pub use time_window::{signature as time_window_signature, TIME_WINDOW_UDF};
+pub use time_window::{
+    ceil_sliding_window, floor_sliding_window, signature as time_window_signature,
+    DEFAULT_TIME_WINDOW_START, TIME_WINDOW_UDF,
+};

--- a/query_server/query/src/extension/expr/window/time_window.rs
+++ b/query_server/query/src/extension/expr/window/time_window.rs
@@ -1,13 +1,18 @@
 use std::sync::Arc;
 
+use chrono::Duration;
 use datafusion::arrow::array::ArrayRef;
-use datafusion::arrow::datatypes::{DataType, Field, TimeUnit};
-use datafusion::error::DataFusionError;
+use datafusion::arrow::datatypes::{
+    DataType, Field, IntervalDayTimeType, IntervalMonthDayNanoType, TimeUnit,
+};
+use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::logical_expr::type_coercion::aggregates::TIMESTAMPS;
 use datafusion::logical_expr::{
     ReturnTypeFunction, ScalarUDF, Signature, TypeSignature, Volatility,
 };
 use datafusion::physical_expr::functions::make_scalar_function;
+use datafusion::physical_plan::ColumnarValue;
+use datafusion::scalar::ScalarValue;
 use once_cell::sync::Lazy;
 use spi::query::function::FunctionMetadataManager;
 use spi::Result;
@@ -16,6 +21,8 @@ use super::{TIME_WINDOW, WINDOW_END, WINDOW_START};
 use crate::extension::expr::INTERVALS;
 
 pub static TIME_WINDOW_UDF: Lazy<Arc<ScalarUDF>> = Lazy::new(|| Arc::new(new()));
+pub static DEFAULT_TIME_WINDOW_START: Lazy<ScalarValue> =
+    Lazy::new(|| ScalarValue::TimestampNanosecond(Some(0), Some("+00:00".into())));
 
 pub fn register_udf(func_manager: &mut dyn FunctionMetadataManager) -> Result<ScalarUDF> {
     let udf = new();
@@ -83,4 +90,280 @@ fn new() -> ScalarUDF {
     });
 
     ScalarUDF::new(TIME_WINDOW, &signature(), &return_type, &func)
+}
+
+/// Return the earliest window where timestamp_ns is located,
+/// if timestamp_ns is not in any window, return the first window after timestamp_ns
+pub fn ceil_sliding_window(
+    timestamp_ns: i64,
+    window_duration: &ColumnarValue,
+    slide_duration: &ColumnarValue,
+    start_time: &ColumnarValue,
+) -> DFResult<(i64, i64)> {
+    let window_ns = extract_interval_ns(window_duration)?;
+    let slide_ns = extract_interval_ns(slide_duration)?;
+    let start_time = columnar_value_to_timestamp_ns(start_time)?;
+
+    // all windows
+    let overlapping_windows = (window_ns + slide_ns - 1) / slide_ns;
+
+    let mut ceil_window: Option<(i64, i64)> = None;
+
+    for i in (0..overlapping_windows).rev() {
+        match sliding_window(
+            timestamp_ns,
+            window_ns,
+            slide_ns,
+            start_time,
+            // last window
+            i,
+        )? {
+            window @ (start, end) if timestamp_ns >= start && timestamp_ns < end => {
+                return Ok(window)
+            }
+            other => {
+                // 不符合条件的窗口，直接跳过
+                trace::trace!("Window {other:?} Not match timestamp: {timestamp_ns}, window_duration : {window_ns}, slide_duration: {slide_ns}, start_time: {start_time}");
+                ceil_window = Some(other);
+            }
+        }
+    }
+
+    // timestamp_ns 不在任何窗口中，返回 timestamp_ns 后面的第一个窗口
+    if let Some(ceil_window) = ceil_window {
+        let mut next_window = ceil_window;
+        while timestamp_ns >= next_window.1 {
+            next_window = (next_window.0 + slide_ns, next_window.1 + slide_ns);
+        }
+        return Ok(next_window);
+    }
+
+    // not reach here
+    Err(DataFusionError::Execution(
+        "Not match any time window, this maybe a bug".to_string(),
+    ))
+}
+
+/// Returns the latest window that timestamp_ns is in,
+/// or the first window before timestamp_ns if timestamp_ns is not in any window
+pub fn floor_sliding_window(
+    timestamp_ns: i64,
+    window_duration: &ColumnarValue,
+    slide_duration: &ColumnarValue,
+    start_time: &ColumnarValue,
+) -> DFResult<(i64, i64)> {
+    let window_ns = extract_interval_ns(window_duration)?;
+    let slide_ns = extract_interval_ns(slide_duration)?;
+    let start_time = columnar_value_to_timestamp_ns(start_time)?;
+
+    let floor_window = match sliding_window(
+        timestamp_ns,
+        window_ns,
+        slide_ns,
+        start_time,
+        // last window
+        0,
+    )? {
+        window @ (start, end) if timestamp_ns >= start && timestamp_ns < end => return Ok(window),
+        other => {
+            // 不符合条件的窗口，直接跳过
+            trace::trace!("Window {other:?} Not match timestamp: {timestamp_ns}, window_duration : {window_ns}, slide_duration: {slide_ns}, start_time: {start_time}");
+            other
+        }
+    };
+
+    // timestamp_ns 不在任何窗口中，返回 timestamp_ns 前面的第一个窗口
+    let mut next_window = floor_window;
+    while timestamp_ns < next_window.0 {
+        next_window = (next_window.0 - slide_ns, next_window.1 - slide_ns);
+    }
+
+    Ok(next_window)
+}
+
+fn sliding_window(
+    i64_time: i64,
+    window_duration: i64,
+    slide_duration: i64,
+    start_time: i64,
+    i: i64,
+) -> DFResult<(i64, i64)> {
+    let i64_start_time = start_time % window_duration;
+    let last_start = i64_time - (i64_time - i64_start_time + slide_duration) % slide_duration;
+
+    let window_start = last_start - i * slide_duration;
+    let window_end = window_start + window_duration;
+
+    Ok((window_start, window_end))
+}
+
+fn extract_interval_ns(interval: &ColumnarValue) -> DFResult<i64> {
+    let ns = match interval {
+        ColumnarValue::Scalar(ScalarValue::IntervalDayTime(Some(v))) => {
+            let (days, ms) = IntervalDayTimeType::to_parts(*v);
+            let nanos =
+                (Duration::days(days as i64) + Duration::milliseconds(ms as i64)).num_nanoseconds();
+            match nanos {
+                Some(v) => v,
+                _ => {
+                    return Err(DataFusionError::Execution(format!(
+                        "Interval is too large, {days}days & {ms}ms"
+                    )))
+                }
+            }
+        }
+        ColumnarValue::Scalar(ScalarValue::IntervalMonthDayNano(Some(v))) => {
+            let (months, days, nanos) = IntervalMonthDayNanoType::to_parts(*v);
+            if months != 0 {
+                return Err(DataFusionError::NotImplemented(
+                    "Not support month intervals".to_string(),
+                ));
+            }
+            let nanos =
+                (Duration::days(days as i64) + Duration::nanoseconds(nanos)).num_nanoseconds();
+            match nanos {
+                Some(v) => v,
+                _ => {
+                    return Err(DataFusionError::Execution(format!(
+                        "Interval is too large, {days}days & {nanos:?}ns"
+                    )))
+                }
+            }
+        }
+        ColumnarValue::Scalar(v) => {
+            return Err(DataFusionError::Execution(format!(
+                "Expect INTERVAL but got {}",
+                v.get_datatype()
+            )))
+        }
+        ColumnarValue::Array(_) => {
+            return Err(DataFusionError::NotImplemented(
+                "Only supports literal values, not arrays".to_string(),
+            ))
+        }
+    };
+
+    Ok(ns)
+}
+
+fn columnar_value_to_timestamp_ns(value: &ColumnarValue) -> DFResult<i64> {
+    match value {
+        ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(v), _)) => Ok(*v),
+        ColumnarValue::Scalar(v) => Err(DataFusionError::Execution(format!(
+            "TIME_WINDOW expects start_time argument to be a TIMESTAMP but got {}",
+            v.get_datatype()
+        ))),
+        ColumnarValue::Array(_) => Err(DataFusionError::NotImplemented(
+            "TIME_WINDOW only supports literal values for the start_time argument, not arrays"
+                .to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::physical_plan::ColumnarValue;
+    use datafusion::scalar::ScalarValue;
+
+    use super::{ceil_sliding_window, floor_sliding_window};
+
+    fn ceil_sliding_window_once(
+        timestamp_ns: i64,
+        window_duration: i64,
+        slide_duration: i64,
+        start_time: i64,
+    ) -> (i64, i64) {
+        let window_duration: &ColumnarValue = &ColumnarValue::Scalar(
+            ScalarValue::IntervalMonthDayNano(Some(window_duration as i128)),
+        );
+        let slide_duration: &ColumnarValue = &ColumnarValue::Scalar(
+            ScalarValue::IntervalMonthDayNano(Some(slide_duration as i128)),
+        );
+        let start_time: &ColumnarValue =
+            &ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(start_time), None));
+
+        ceil_sliding_window(timestamp_ns, window_duration, slide_duration, start_time).unwrap()
+    }
+
+    fn floor_sliding_window_once(
+        timestamp_ns: i64,
+        window_duration: i64,
+        slide_duration: i64,
+        start_time: i64,
+    ) -> (i64, i64) {
+        let window_duration: &ColumnarValue = &ColumnarValue::Scalar(
+            ScalarValue::IntervalMonthDayNano(Some(window_duration as i128)),
+        );
+        let slide_duration: &ColumnarValue = &ColumnarValue::Scalar(
+            ScalarValue::IntervalMonthDayNano(Some(slide_duration as i128)),
+        );
+        let start_time: &ColumnarValue =
+            &ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(start_time), None));
+
+        floor_sliding_window(timestamp_ns, window_duration, slide_duration, start_time).unwrap()
+    }
+
+    fn test_sliding_window(first: bool, args: Vec<(i64, i64, i64, i64)>, expects: Vec<(i64, i64)>) {
+        args.into_iter().zip(expects).for_each(|(arg, expect)| {
+            let result = if first {
+                ceil_sliding_window_once(arg.0, arg.1, arg.2, arg.3)
+            } else {
+                floor_sliding_window_once(arg.0, arg.1, arg.2, arg.3)
+            };
+
+            assert_eq!(result, expect)
+        });
+    }
+
+    #[test]
+    fn test_first_sliding_window_start_bound() {
+        #[rustfmt::skip]
+        test_sliding_window(
+            true,
+            vec![
+                (9, 5, 2, 0),
+                (9, 5, 2, 1),
+                (9, 4, 2, 0),
+                (0, 5, 2, 0),
+                (10, 5, 2, 0),
+                (10, 2, 5, 0),
+                (946598400000, 5, 10, 2),
+                (946598400000, 5000000000000000, 10, 2),
+            ],
+            vec![
+                (6, 11),
+                (5, 10),
+                (6, 10),
+                (-4, 1),
+                (6, 11),
+                (10, 12),
+                (946598400002, 946598400007),
+                (-4999053401599998, 946598400002),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_last_sliding_window_start_bound() {
+        #[rustfmt::skip]
+        test_sliding_window(
+            false,
+            vec![
+                (9, 5, 2, 0),
+                (9, 5, 2, 1),
+                (9, 4, 2, 0),
+                (0, 5, 2, 0),
+                (10, 5, 2, 0),
+                (13, 2, 5, 0),
+            ],
+            vec![
+                (8, 13),
+                (9, 14),
+                (8, 12),
+                (0, 5),
+                (10, 15),
+                (10, 12),
+            ],
+        );
+    }
 }

--- a/query_server/query/src/extension/logical/plan_node/gapfill.rs
+++ b/query_server/query/src/extension/logical/plan_node/gapfill.rs
@@ -30,6 +30,8 @@ pub struct GapFill {
 pub struct GapFillParams {
     /// The stride argument from the call to TIME_WINDOW_GAPFILL
     pub stride: Expr,
+    /// The sliding argument from the call to TIME_WINDOW_GAPFILL
+    pub sliding: Expr,
     /// The source time column
     pub time_column: Expr,
     /// The origin argument from the call to TIME_WINDOW_GAPFILL
@@ -67,7 +69,11 @@ pub enum FillStrategy {
 impl GapFillParams {
     // Extract the expressions so they can be optimized.
     fn expressions(&self) -> Vec<Expr> {
-        let mut exprs = vec![self.stride.clone(), self.time_column.clone()];
+        let mut exprs = vec![
+            self.stride.clone(),
+            self.sliding.clone(),
+            self.time_column.clone(),
+        ];
         if let Some(e) = self.origin.as_ref() {
             exprs.push(e.clone())
         }
@@ -90,6 +96,7 @@ impl GapFillParams {
         );
         let mut iter = exprs.iter().cloned();
         let stride = iter.next().unwrap();
+        let sliding = iter.next().unwrap();
         let time_column = iter.next().unwrap();
         let origin = self.origin.as_ref().map(|_| iter.next().unwrap());
         let time_range = try_map_range(&self.time_range, |b| {
@@ -112,6 +119,7 @@ impl GapFillParams {
 
         Self {
             stride,
+            sliding,
             time_column,
             origin,
             time_range,

--- a/query_server/query/src/extension/physical/plan_node/gapfill/algo.rs
+++ b/query_server/query/src/extension/physical/plan_node/gapfill/algo.rs
@@ -776,7 +776,7 @@ impl Cursor {
         }
 
         // last_ts is the last timestamp that will fit in the output batch
-        let last_ts = next_ts + (output_row_count - 1) as i64 * params.stride;
+        let last_ts = next_ts + (output_row_count - 1) as i64 * params.sliding;
 
         loop {
             if self.next_input_offset >= series_end {
@@ -791,14 +791,14 @@ impl Cursor {
                     series_end_offset: series_end,
                     ts: next_ts,
                 })?;
-                next_ts += params.stride;
+                next_ts += params.sliding;
             }
             vec_builder.push(RowStatus::Present {
                 series_end_offset: series_end,
                 offset: self.next_input_offset,
                 ts: next_ts,
             })?;
-            next_ts += params.stride;
+            next_ts += params.sliding;
             self.next_input_offset += 1;
         }
 
@@ -808,10 +808,10 @@ impl Cursor {
                 series_end_offset: series_end,
                 ts: next_ts,
             })?;
-            next_ts += params.stride;
+            next_ts += params.sliding;
         }
 
-        self.next_ts = Some(last_ts + params.stride);
+        self.next_ts = Some(last_ts + params.sliding);
         self.remaining_output_batch_size -= output_row_count;
         Ok(())
     }

--- a/query_server/query/src/extension/physical/plan_node/gapfill/mod.rs
+++ b/query_server/query/src/extension/physical/plan_node/gapfill/mod.rs
@@ -47,6 +47,8 @@ pub struct GapFillExec {
 pub struct GapFillExecParams {
     /// The uniform interval of incoming timestamps
     stride: Arc<dyn PhysicalExpr>,
+    /// The sliding interval of incoming timestamps
+    sliding: Arc<dyn PhysicalExpr>,
     /// The timestamp column produced by date_bin
     time_column: Column,
     /// The origin argument from the all to TIME_WINDOW_GAPFILL
@@ -62,6 +64,7 @@ pub struct GapFillExecParams {
 impl GapFillExecParams {
     pub fn new(
         stride: Arc<dyn PhysicalExpr>,
+        sliding: Arc<dyn PhysicalExpr>,
         time_column: Column,
         origin: Option<Arc<dyn PhysicalExpr>>,
         time_range: Range<Bound<Arc<dyn PhysicalExpr>>>,
@@ -69,6 +72,7 @@ impl GapFillExecParams {
     ) -> Self {
         Self {
             stride,
+            sliding,
             time_column,
             origin,
             time_range,

--- a/query_server/query/src/extension/physical/plan_node/gapfill/params.rs
+++ b/query_server/query/src/extension/physical/plan_node/gapfill/params.rs
@@ -6,12 +6,14 @@ use chrono::Duration;
 use datafusion::arrow::datatypes::{IntervalMonthDayNanoType, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::physical_expr::datetime_expressions::date_bin;
 use datafusion::physical_plan::expressions::Column;
 use datafusion::physical_plan::ColumnarValue;
 use datafusion::scalar::ScalarValue;
 
 use super::{try_map_bound, try_map_range, FillStrategy, GapFillExecParams};
+use crate::extension::expr::{
+    ceil_sliding_window, floor_sliding_window, DEFAULT_TIME_WINDOW_START,
+};
 
 /// The parameters to gap filling. Included here are the parameters
 /// that remain constant during gap filling, i.e., not the streaming table
@@ -21,6 +23,7 @@ use super::{try_map_bound, try_map_range, FillStrategy, GapFillExecParams};
 pub(crate) struct GapFillParams {
     /// The stride in nanoseconds of the timestamps to be output.
     pub stride: i64,
+    pub sliding: i64,
     /// The first timestamp (inclusive) to be output for each series,
     /// in nanoseconds since the epoch. `None` means gap filling should
     /// start from the first timestamp in each series.
@@ -39,11 +42,13 @@ impl GapFillParams {
     pub(super) fn try_new(schema: SchemaRef, params: &GapFillExecParams) -> Result<Self> {
         let batch = RecordBatch::new_empty(schema);
         let stride = params.stride.evaluate(&batch)?;
+        let sliding = params.sliding.evaluate(&batch)?;
         let origin = params
             .origin
             .as_ref()
             .map(|e| e.evaluate(&batch))
-            .transpose()?;
+            .transpose()?
+            .unwrap_or(ColumnarValue::Scalar(DEFAULT_TIME_WINDOW_START.clone()));
 
         // Evaluate the upper and lower bounds of the time range
         let range = try_map_range(&params.time_range, |b| {
@@ -72,17 +77,15 @@ impl GapFillParams {
             }
         };
 
-        // Call date_bin on the timestamps to find the first and last time bins
-        // for each series
-        let mut args = vec![stride, i64_to_columnar_ts(first_ts)];
-        if let Some(v) = origin {
-            args.push(v)
-        }
+        // Find the first and last time bins for each series
         let first_ts = first_ts
-            .map(|_| extract_timestamp_nanos(&date_bin(&args)?))
+            .map(|e| {
+                let bound = ceil_sliding_window(e, &stride, &sliding, &origin)?.0;
+
+                Ok::<i64, DataFusionError>(bound)
+            })
             .transpose()?;
-        args[1] = i64_to_columnar_ts(Some(last_ts));
-        let last_ts = extract_timestamp_nanos(&date_bin(&args)?)?;
+        let last_ts = floor_sliding_window(last_ts, &stride, &sliding, &origin)?.0;
 
         let fill_strategy = params
             .fill_strategy
@@ -99,28 +102,26 @@ impl GapFillParams {
             })
             .collect::<Result<HashMap<usize, FillStrategy>>>()?;
 
-        Ok(Self {
-            stride: extract_interval_nanos(&args[0])?,
+        let result = Self {
+            stride: extract_interval_nanos(&stride)?,
+            sliding: extract_interval_nanos(&sliding)?,
             first_ts,
             last_ts,
             fill_strategy,
-        })
+        };
+
+        trace::trace!("{result:?}");
+
+        Ok(result)
     }
 
     /// Returns the number of rows remaining for a series that starts with first_ts.
     pub fn valid_row_count(&self, first_ts: i64) -> usize {
         if self.last_ts >= first_ts {
-            ((self.last_ts - first_ts) / self.stride + 1) as usize
+            ((self.last_ts - first_ts) / self.sliding + 1) as usize
         } else {
             0
         }
-    }
-}
-
-fn i64_to_columnar_ts(i: Option<i64>) -> ColumnarValue {
-    match i {
-        Some(i) => ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(i), None)),
-        None => ColumnarValue::Scalar(ScalarValue::Null),
     }
 }
 

--- a/query_server/query/src/extension/physical/transform_rule/gapfill.rs
+++ b/query_server/query/src/extension/physical/transform_rule/gapfill.rs
@@ -99,6 +99,13 @@ fn plan_gap_fill(
         execution_props,
     )?;
 
+    let sliding = create_physical_expr(
+        &gap_fill.params.sliding,
+        input_dfschema,
+        input_schema,
+        execution_props,
+    )?;
+
     let time_range = &gap_fill.params.time_range;
     let time_range = try_map_range(time_range, |b| {
         try_map_bound(b.as_ref(), |e| {
@@ -125,7 +132,14 @@ fn plan_gap_fill(
         })
         .collect::<Result<Vec<(Arc<dyn PhysicalExpr>, FillStrategy)>>>()?;
 
-    let params = GapFillExecParams::new(stride, time_column, origin, time_range, fill_strategy);
+    let params = GapFillExecParams::new(
+        stride,
+        sliding,
+        time_column,
+        origin,
+        time_range,
+        fill_strategy,
+    );
     GapFillExec::try_new(
         Arc::clone(&physical_inputs[0]),
         group_expr,

--- a/query_server/sqllogicaltests/cases/function/gapfill.slt
+++ b/query_server/sqllogicaltests/cases/function/gapfill.slt
@@ -216,3 +216,302 @@ where time between timestamp '1999-12-31T00:00:00.000Z' and timestamp '1999-12-3
 group by four_minute;
 ----
 1999-12-30T23:59:59.999954455 111 111.0 8
+
+statement ok
+INSERT gapfill_db.m2(TIME, f0, f1, t0, t1)
+VALUES
+    ('1999-12-31 00:00:00.055', 1, 222, 'tag14', 'tag24');
+
+# gap filling works with sliding window
+query 
+SELECT
+  t0,
+  time_window_gapfill(time, interval '10 milliseconds', interval '5 milliseconds') as minute,
+  locf(avg(f1))
+from gapfill_db.m2
+where time between timestamp '1999-12-31T00:00:00.000Z' and timestamp '1999-12-31T00:00:00.055Z'
+group by t0, minute;
+----
+tag11 1999-12-30T23:59:59.995 444.0
+tag11 1999-12-31T00:00:00 444.0
+tag11 1999-12-31T00:00:00.005 444.0
+tag11 1999-12-31T00:00:00.010 444.0
+tag11 1999-12-31T00:00:00.015 555.0
+tag11 1999-12-31T00:00:00.020 555.0
+tag11 1999-12-31T00:00:00.025 555.0
+tag11 1999-12-31T00:00:00.030 555.0
+tag11 1999-12-31T00:00:00.035 555.0
+tag11 1999-12-31T00:00:00.040 555.0
+tag11 1999-12-31T00:00:00.045 555.0
+tag11 1999-12-31T00:00:00.050 555.0
+tag11 1999-12-31T00:00:00.055 555.0
+tag12 1999-12-30T23:59:59.995 NULL
+tag12 1999-12-31T00:00:00 333.0
+tag12 1999-12-31T00:00:00.005 333.0
+tag12 1999-12-31T00:00:00.010 333.0
+tag12 1999-12-31T00:00:00.015 333.0
+tag12 1999-12-31T00:00:00.020 444.0
+tag12 1999-12-31T00:00:00.025 444.0
+tag12 1999-12-31T00:00:00.030 444.0
+tag12 1999-12-31T00:00:00.035 444.0
+tag12 1999-12-31T00:00:00.040 444.0
+tag12 1999-12-31T00:00:00.045 444.0
+tag12 1999-12-31T00:00:00.050 444.0
+tag12 1999-12-31T00:00:00.055 444.0
+tag13 1999-12-30T23:59:59.995 NULL
+tag13 1999-12-31T00:00:00 NULL
+tag13 1999-12-31T00:00:00.005 222.0
+tag13 1999-12-31T00:00:00.010 222.0
+tag13 1999-12-31T00:00:00.015 222.0
+tag13 1999-12-31T00:00:00.020 222.0
+tag13 1999-12-31T00:00:00.025 333.0
+tag13 1999-12-31T00:00:00.030 333.0
+tag13 1999-12-31T00:00:00.035 333.0
+tag13 1999-12-31T00:00:00.040 333.0
+tag13 1999-12-31T00:00:00.045 333.0
+tag13 1999-12-31T00:00:00.050 333.0
+tag13 1999-12-31T00:00:00.055 333.0
+tag14 1999-12-30T23:59:59.995 NULL
+tag14 1999-12-31T00:00:00 NULL
+tag14 1999-12-31T00:00:00.005 NULL
+tag14 1999-12-31T00:00:00.010 111.0
+tag14 1999-12-31T00:00:00.015 111.0
+tag14 1999-12-31T00:00:00.020 111.0
+tag14 1999-12-31T00:00:00.025 111.0
+tag14 1999-12-31T00:00:00.030 222.0
+tag14 1999-12-31T00:00:00.035 222.0
+tag14 1999-12-31T00:00:00.040 222.0
+tag14 1999-12-31T00:00:00.045 222.0
+tag14 1999-12-31T00:00:00.050 222.0
+tag14 1999-12-31T00:00:00.055 222.0
+
+# gap filling works with sliding window
+query 
+SELECT
+  t0,
+  time_window_gapfill(time, interval '10 milliseconds', interval '5 milliseconds') as minute,
+  locf(avg(f1))
+from gapfill_db.m2
+where time between timestamp '1999-12-31T00:00:00.020Z' and timestamp '1999-12-31T00:00:00.055Z'
+group by t0, minute;
+----
+tag11 1999-12-31T00:00:00.015 555.0
+tag11 1999-12-31T00:00:00.020 555.0
+tag11 1999-12-31T00:00:00.025 555.0
+tag11 1999-12-31T00:00:00.030 555.0
+tag11 1999-12-31T00:00:00.035 555.0
+tag11 1999-12-31T00:00:00.040 555.0
+tag11 1999-12-31T00:00:00.045 555.0
+tag11 1999-12-31T00:00:00.050 555.0
+tag11 1999-12-31T00:00:00.055 555.0
+tag12 1999-12-31T00:00:00.015 NULL
+tag12 1999-12-31T00:00:00.020 444.0
+tag12 1999-12-31T00:00:00.025 444.0
+tag12 1999-12-31T00:00:00.030 444.0
+tag12 1999-12-31T00:00:00.035 444.0
+tag12 1999-12-31T00:00:00.040 444.0
+tag12 1999-12-31T00:00:00.045 444.0
+tag12 1999-12-31T00:00:00.050 444.0
+tag12 1999-12-31T00:00:00.055 444.0
+tag13 1999-12-31T00:00:00.015 NULL
+tag13 1999-12-31T00:00:00.020 NULL
+tag13 1999-12-31T00:00:00.025 333.0
+tag13 1999-12-31T00:00:00.030 333.0
+tag13 1999-12-31T00:00:00.035 333.0
+tag13 1999-12-31T00:00:00.040 333.0
+tag13 1999-12-31T00:00:00.045 333.0
+tag13 1999-12-31T00:00:00.050 333.0
+tag13 1999-12-31T00:00:00.055 333.0
+tag14 1999-12-31T00:00:00.015 NULL
+tag14 1999-12-31T00:00:00.020 NULL
+tag14 1999-12-31T00:00:00.025 NULL
+tag14 1999-12-31T00:00:00.030 222.0
+tag14 1999-12-31T00:00:00.035 222.0
+tag14 1999-12-31T00:00:00.040 222.0
+tag14 1999-12-31T00:00:00.045 222.0
+tag14 1999-12-31T00:00:00.050 222.0
+tag14 1999-12-31T00:00:00.055 222.0
+
+# gap filling works with sliding window and start time
+query 
+SELECT
+  t0,
+  time_window_gapfill(time, interval '10 milliseconds', interval '5 milliseconds', timestamp '1970-01-01T00:00:00.002Z') as minute,
+  locf(avg(f1))
+from gapfill_db.m2
+where time between timestamp '1999-12-31T00:00:00.000Z' and timestamp '1999-12-31T00:00:00.055Z'
+group by t0, minute;
+----
+tag11 1999-12-30T23:59:59.992 444.0
+tag11 1999-12-30T23:59:59.997 444.0
+tag11 1999-12-31T00:00:00.002 444.0
+tag11 1999-12-31T00:00:00.007 444.0
+tag11 1999-12-31T00:00:00.012 555.0
+tag11 1999-12-31T00:00:00.017 555.0
+tag11 1999-12-31T00:00:00.022 555.0
+tag11 1999-12-31T00:00:00.027 555.0
+tag11 1999-12-31T00:00:00.032 555.0
+tag11 1999-12-31T00:00:00.037 555.0
+tag11 1999-12-31T00:00:00.042 555.0
+tag11 1999-12-31T00:00:00.047 555.0
+tag11 1999-12-31T00:00:00.052 555.0
+tag12 1999-12-30T23:59:59.992 NULL
+tag12 1999-12-30T23:59:59.997 333.0
+tag12 1999-12-31T00:00:00.002 333.0
+tag12 1999-12-31T00:00:00.007 333.0
+tag12 1999-12-31T00:00:00.012 333.0
+tag12 1999-12-31T00:00:00.017 444.0
+tag12 1999-12-31T00:00:00.022 444.0
+tag12 1999-12-31T00:00:00.027 444.0
+tag12 1999-12-31T00:00:00.032 444.0
+tag12 1999-12-31T00:00:00.037 444.0
+tag12 1999-12-31T00:00:00.042 444.0
+tag12 1999-12-31T00:00:00.047 444.0
+tag12 1999-12-31T00:00:00.052 444.0
+tag13 1999-12-30T23:59:59.992 NULL
+tag13 1999-12-30T23:59:59.997 NULL
+tag13 1999-12-31T00:00:00.002 222.0
+tag13 1999-12-31T00:00:00.007 222.0
+tag13 1999-12-31T00:00:00.012 222.0
+tag13 1999-12-31T00:00:00.017 222.0
+tag13 1999-12-31T00:00:00.022 333.0
+tag13 1999-12-31T00:00:00.027 333.0
+tag13 1999-12-31T00:00:00.032 333.0
+tag13 1999-12-31T00:00:00.037 333.0
+tag13 1999-12-31T00:00:00.042 333.0
+tag13 1999-12-31T00:00:00.047 333.0
+tag13 1999-12-31T00:00:00.052 333.0
+tag14 1999-12-30T23:59:59.992 NULL
+tag14 1999-12-30T23:59:59.997 NULL
+tag14 1999-12-31T00:00:00.002 NULL
+tag14 1999-12-31T00:00:00.007 111.0
+tag14 1999-12-31T00:00:00.012 111.0
+tag14 1999-12-31T00:00:00.017 111.0
+tag14 1999-12-31T00:00:00.022 111.0
+tag14 1999-12-31T00:00:00.027 222.0
+tag14 1999-12-31T00:00:00.032 222.0
+tag14 1999-12-31T00:00:00.037 222.0
+tag14 1999-12-31T00:00:00.042 222.0
+tag14 1999-12-31T00:00:00.047 222.0
+tag14 1999-12-31T00:00:00.052 222.0
+
+# gap filling works with sliding window
+query 
+SELECT
+  t0,
+  time_window_gapfill(time, interval '5 milliseconds', interval '10 milliseconds') as minute,
+  locf(avg(f1))
+from gapfill_db.m2
+where time between timestamp '1999-12-31T00:00:00.000Z' and timestamp '1999-12-31T00:00:00.055Z'
+group by t0, minute;
+----
+tag11 1999-12-31T00:00:00 444.0
+tag11 1999-12-31T00:00:00.010 444.0
+tag11 1999-12-31T00:00:00.020 555.0
+tag11 1999-12-31T00:00:00.030 555.0
+tag11 1999-12-31T00:00:00.040 555.0
+tag11 1999-12-31T00:00:00.050 555.0
+tag13 1999-12-31T00:00:00 NULL
+tag13 1999-12-31T00:00:00.010 222.0
+tag13 1999-12-31T00:00:00.020 222.0
+tag13 1999-12-31T00:00:00.030 333.0
+tag13 1999-12-31T00:00:00.040 333.0
+tag13 1999-12-31T00:00:00.050 333.0
+
+# gap filling works with sliding window and start time
+query 
+SELECT
+  t0,
+  time_window_gapfill(time, interval '5 milliseconds', interval '10 milliseconds', timestamp '1970-01-01T00:00:00.002Z') as minute,
+  locf(avg(f1))
+from gapfill_db.m2
+where time between timestamp '1999-12-31T00:00:00.000Z' and timestamp '1999-12-31T00:00:00.055Z'
+group by t0, minute;
+----
+tag12 1999-12-31T00:00:00.002 333.0
+tag12 1999-12-31T00:00:00.012 333.0
+tag12 1999-12-31T00:00:00.022 444.0
+tag12 1999-12-31T00:00:00.032 444.0
+tag12 1999-12-31T00:00:00.042 444.0
+tag12 1999-12-31T00:00:00.052 444.0
+tag14 1999-12-31T00:00:00.002 NULL
+tag14 1999-12-31T00:00:00.012 111.0
+tag14 1999-12-31T00:00:00.022 111.0
+tag14 1999-12-31T00:00:00.032 222.0
+tag14 1999-12-31T00:00:00.042 222.0
+tag14 1999-12-31T00:00:00.052 222.0
+
+# gap filling works with sliding window and start time
+query 
+SELECT
+  t0,
+  time_window_gapfill(time, interval '5 milliseconds', interval '10 milliseconds', timestamp '1970-01-01T00:00:00.002Z') as minute,
+  interpolate(avg(f1))
+from gapfill_db.m2
+where time between timestamp '1999-12-31T00:00:00.000Z' and timestamp '1999-12-31T00:00:00.055Z'
+group by t0, minute;
+----
+tag12 1999-12-31T00:00:00.002 333.0
+tag12 1999-12-31T00:00:00.012 388.5
+tag12 1999-12-31T00:00:00.022 444.0
+tag12 1999-12-31T00:00:00.032 NULL
+tag12 1999-12-31T00:00:00.042 NULL
+tag12 1999-12-31T00:00:00.052 NULL
+tag14 1999-12-31T00:00:00.002 NULL
+tag14 1999-12-31T00:00:00.012 111.0
+tag14 1999-12-31T00:00:00.022 166.5
+tag14 1999-12-31T00:00:00.032 222.0
+tag14 1999-12-31T00:00:00.042 222.0
+tag14 1999-12-31T00:00:00.052 222.0
+
+# Too many overlapping windows
+query error Arrow error: Io error: Status \{ code: Internal, message: "Datafusion: Error during planning: Too many overlapping windows: 500000000", .*
+SELECT
+  t0,
+  time_window_gapfill(time, interval '5000000000 milliseconds', interval '10 milliseconds', timestamp '1970-01-01T00:00:00.002Z') as minute,
+  interpolate(avg(f1))
+from gapfill_db.m2
+where time between timestamp '1999-12-31T00:00:00.000Z' and timestamp '1999-12-31T00:00:00.055Z'
+group by t0, minute;
+
+# no data falls in the window
+statement ok
+SELECT
+  t0,
+  time_window_gapfill(time, interval '5 milliseconds', interval '5000000000 milliseconds', timestamp '1970-01-01T00:00:00.002Z') as minute,
+  interpolate(avg(f1))
+from gapfill_db.m2
+where time between timestamp '1999-12-31T00:00:00.000Z' and timestamp '1999-12-31T00:00:00.055Z'
+group by t0, minute;
+
+# Too many overlapping windows
+query error Arrow error: Io error: Status \{ code: Internal, message: "Datafusion: Error during planning: Too many overlapping windows: 101", .*
+SELECT
+  t0,
+  time_window_gapfill(time, interval '101 milliseconds', interval '1 milliseconds', timestamp '1970-01-01T00:00:00.002Z') as minute,
+  interpolate(avg(f1))
+from gapfill_db.m2
+where time between timestamp '1999-12-31T00:00:00.000Z' and timestamp '1999-12-31T00:00:00.055Z'
+group by t0, minute;
+
+# Maximum bounds of overlapping windows
+query 
+SELECT
+  t0,
+  time_window_gapfill(time, interval '100 milliseconds', interval '1 milliseconds', timestamp '1970-01-01T00:00:00.002Z') as minute,
+  interpolate(avg(f1))
+from gapfill_db.m2
+where time between timestamp '1999-12-31T00:00:00.000Z' and timestamp '1999-12-31T00:00:00.055Z'
+group by t0, minute
+limit 10;
+----
+tag11 1999-12-30T23:59:59.901 444.0
+tag11 1999-12-30T23:59:59.902 444.0
+tag11 1999-12-30T23:59:59.903 444.0
+tag11 1999-12-30T23:59:59.904 444.0
+tag11 1999-12-30T23:59:59.905 444.0
+tag11 1999-12-30T23:59:59.906 444.0
+tag11 1999-12-30T23:59:59.907 444.0
+tag11 1999-12-30T23:59:59.908 444.0
+tag11 1999-12-30T23:59:59.909 444.0
+tag11 1999-12-30T23:59:59.910 444.0


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

gap filling function supports sliding window

reuse time window
```
time_window_gapfill(<time column>, <window interval>, <sliding interval>, <start time>): <time window struct>
```

**time column**: Columns of type timestamp 
**window interval**: The size of the window, interval type
**sliding interval**: The moving distance of the window, interval type. When the moving distance is equal to the window size, it is a tumbling window, otherwise it is a sliding window
**start time**: When the window starts to calculate, default to unix EPOCH

Supported interpolation methods are consistent with tumbling window

> Note: The number of overlapping windows cannot be greater than 100

link: https://github.com/cnosdb/cnosdb/pull/1149

Closes #.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
