### PR TITLE
fix(tskv): old wal files may not be deleted

### DIFF
--- a/tskv/src/context.rs
+++ b/tskv/src/context.rs
@@ -72,13 +72,15 @@ pub struct GlobalSequenceContext {
 }
 
 impl GlobalSequenceContext {
-    pub fn new(min_seq: u64, tsf_seq_map: HashMap<TseriesFamilyId, u64>) -> Self {
+    pub fn new(tsf_seq_map: HashMap<TseriesFamilyId, u64>) -> Self {
+        let mut inner = GlobalSequenceContextInner {
+            min_seq: 0_u64,
+            tsf_seq_map,
+        };
+        inner.reset_min_seq();
         Self {
-            min_seq: AtomicU64::new(min_seq),
-            inner: Arc::new(RwLock::new(GlobalSequenceContextInner {
-                min_seq,
-                tsf_seq_map,
-            })),
+            min_seq: AtomicU64::new(inner.min_seq),
+            inner: Arc::new(RwLock::new(inner)),
         }
     }
 
@@ -181,7 +183,16 @@ mod test_context {
     use super::GlobalSequenceContext;
 
     #[test]
-    fn test_global_sequence_context() {
+    fn test_global_sequence_context_new() {
+        let ctx = GlobalSequenceContext::new(HashMap::from([(1, 2), (2, 3), (3, 4)]));
+        assert_eq!(ctx.min_seq(), 2);
+
+        let ctx = GlobalSequenceContext::new(HashMap::new());
+        assert_eq!(ctx.min_seq(), 0);
+    }
+
+    #[test]
+    fn test_global_sequence_context_next_stage() {
         let ctx = GlobalSequenceContext::empty();
         assert_eq!(ctx.min_seq(), 0);
 

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -143,6 +143,7 @@ impl Database {
                 vec![VersionEdit::new_add_vnode(
                     tsf_id,
                     self.owner.as_ref().clone(),
+                    seq_no,
                 )],
                 None,
             ),
@@ -393,25 +394,18 @@ impl Database {
     /// (field-id filter) of db-files.
     pub async fn snapshot(
         &self,
-        last_seq: u64,
         vnode_id: Option<TseriesFamilyId>,
         version_edits: &mut Vec<VersionEdit>,
         file_metas: &mut HashMap<ColumnFileId, Arc<BloomFilter>>,
     ) {
         if let Some(tsf_id) = vnode_id.as_ref() {
             if let Some(tsf) = self.ts_families.get(tsf_id) {
-                let ve = tsf
-                    .read()
-                    .await
-                    .snapshot(last_seq, self.owner.clone(), file_metas);
+                let ve = tsf.read().await.snapshot(self.owner.clone(), file_metas);
                 version_edits.push(ve);
             }
         } else {
             for tsf in self.ts_families.values() {
-                let ve = tsf
-                    .read()
-                    .await
-                    .snapshot(last_seq, self.owner.clone(), file_metas);
+                let ve = tsf.read().await.snapshot(self.owner.clone(), file_metas);
                 version_edits.push(ve);
             }
         }

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -219,6 +219,7 @@ impl TsKv {
             version_set: Arc<RwLock<VersionSet>>,
             wal_manager: &WalManager,
         ) {
+            // TODO(zipper): This may cause flushing too frequent.
             if wal_manager.is_total_file_size_exceed() {
                 version_set.read().await.send_flush_req().await;
             }
@@ -810,11 +811,7 @@ impl Engine for TsKv {
             // TODO: Send file_metas to the destination node.
             let mut file_metas = HashMap::new();
             if let Some(tsf) = db.get_tsfamily(vnode_id) {
-                let ve = tsf.read().await.snapshot(
-                    self.global_ctx.last_seq(),
-                    db.owner(),
-                    &mut file_metas,
-                );
+                let ve = tsf.read().await.snapshot(db.owner(), &mut file_metas);
                 Ok(Some(ve))
             } else {
                 warn!(

--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -895,23 +895,23 @@ impl TseriesFamily {
         self.cancellation_token.cancel();
     }
 
-    /// Snashots last version before `last_seq` of this vnode.
+    /// Snapshots last version before `last_seq` of this vnode.
     ///
     /// Db-files' index data (field-id filter) will be inserted into `file_metas`.
     pub fn snapshot(
         &self,
-        last_seq: u64,
         owner: Arc<String>,
         file_metas: &mut HashMap<ColumnFileId, Arc<BloomFilter>>,
     ) -> VersionEdit {
-        let mut version_edit = VersionEdit::new_add_vnode(self.tf_id, owner.as_ref().clone());
+        let mut version_edit =
+            VersionEdit::new_add_vnode(self.tf_id, owner.as_ref().clone(), self.seq_no);
         let version = self.version();
         let max_level_ts = version.max_level_ts;
         for files in version.levels_info.iter() {
             for file in files.files.iter() {
                 let mut meta = CompactMeta::from(file.as_ref());
                 meta.tsf_id = files.tsf_id;
-                meta.high_seq = last_seq;
+                meta.high_seq = self.seq_no;
                 version_edit.add_file(meta, max_level_ts);
                 file_metas.insert(file.file_id, file.field_id_filter.clone());
             }

--- a/tskv/src/wal.rs
+++ b/tskv/src/wal.rs
@@ -362,7 +362,7 @@ impl WalManager {
         Ok(())
     }
 
-    async fn check_to_delete(&mut self) {
+    pub async fn check_to_delete(&mut self) {
         let min_seq = self.global_seq_ctx.min_seq();
         let mut old_files_to_delete: Vec<u64> = Vec::new();
         for (old_file_id, old_file_max_seq) in self.old_file_max_sequence.iter() {


### PR DESCRIPTION
# Which issue does this PR close?

# Rationale for this change

Fixes:

1. `GlobalSequenceContext` sometimes not properly set when recover.
2. `VersionEdit::seq_no` not set when creating `TseriesFamily` or rolling a summary file.

# What changes are included in this PR?

# Are there any user-facing changes?
