### PR TITLE
fix(tskv): old wal files may not be deleted

### DIFF
--- a/tskv/src/compaction/job.rs
+++ b/tskv/src/compaction/job.rs
@@ -7,7 +7,7 @@ use tokio::time::Instant;
 use trace::{error, info};
 
 use crate::compaction::{flush, CompactTask, LevelCompactionPicker, Picker};
-use crate::context::GlobalContext;
+use crate::context::{GlobalContext, GlobalSequenceContext};
 use crate::kv_option::StorageOptions;
 use crate::summary::SummaryTask;
 use crate::version_set::VersionSet;
@@ -17,6 +17,7 @@ pub fn run(
     runtime: Arc<Runtime>,
     mut receiver: Receiver<CompactTask>,
     ctx: Arc<GlobalContext>,
+    seq_ctx: Arc<GlobalSequenceContext>,
     version_set: Arc<RwLock<VersionSet>>,
     summary_task_sender: Sender<SummaryTask>,
 ) {
@@ -52,6 +53,7 @@ pub fn run(
                     let out_level = req.out_level;
 
                     let ctx_inner = ctx.clone();
+                    let seq_ctx_inner = seq_ctx.clone();
                     let version_set_inner = version_set.clone();
                     let summary_task_sender_inner = summary_task_sender.clone();
 
@@ -66,6 +68,7 @@ pub fn run(
                                 if let Err(e) = flush::run_flush_memtable_job(
                                     req,
                                     ctx_inner.clone(),
+                                    seq_ctx_inner.clone(),
                                     version_set_inner,
                                     summary_task_sender_inner.clone(),
                                     None,

--- a/tskv/src/compaction/mod.rs
+++ b/tskv/src/compaction/mod.rs
@@ -34,11 +34,7 @@ pub struct CompactReq {
 
 #[derive(Debug)]
 pub struct FlushReq {
-    pub mems: Vec<(TseriesFamilyId, Arc<RwLock<MemCache>>)>,
-}
-
-impl FlushReq {
-    pub fn new(mems: Vec<(TseriesFamilyId, Arc<RwLock<MemCache>>)>) -> Self {
-        Self { mems }
-    }
+    pub ts_family_id: TseriesFamilyId,
+    pub mems: Vec<Arc<RwLock<MemCache>>>,
+    pub force_flush: bool,
 }

--- a/tskv/src/context.rs
+++ b/tskv/src/context.rs
@@ -104,10 +104,16 @@ impl GlobalSequenceContext {
         self.min_seq.store(inner.min_seq, Ordering::Release);
     }
 
-    /// Get minimum sequence number of presisted write request
+    /// Get the minimum sequence number of persisted write request
     /// of all `TseriesFamily`s in all `Database`s
     pub fn min_seq(&self) -> u64 {
         self.min_seq.load(Ordering::Acquire)
+    }
+
+    /// Get the maximum sequence number of persisted write request
+    /// of all `TseriesFamily`s in all `Database`s
+    pub fn max_seq(&self) -> u64 {
+        self.inner.read().max_seq()
     }
 
     pub fn cloned(&self) -> HashMap<TseriesFamilyId, u64> {
@@ -155,6 +161,14 @@ impl GlobalSequenceContextInner {
             }
             self.min_seq = min_seq;
         }
+    }
+
+    fn max_seq(&self) -> u64 {
+        let mut max_seq = 0_u64;
+        for seq in self.tsf_seq_map.values() {
+            max_seq = max_seq.max(*seq);
+        }
+        max_seq
     }
 }
 

--- a/tskv/src/context.rs
+++ b/tskv/src/context.rs
@@ -72,13 +72,15 @@ pub struct GlobalSequenceContext {
 }
 
 impl GlobalSequenceContext {
-    pub fn new(min_seq: u64, tsf_seq_map: HashMap<TseriesFamilyId, u64>) -> Self {
+    pub fn new(tsf_seq_map: HashMap<TseriesFamilyId, u64>) -> Self {
+        let mut inner = GlobalSequenceContextInner {
+            min_seq: 0_u64,
+            tsf_seq_map,
+        };
+        inner.reset_min_seq();
         Self {
-            min_seq: AtomicU64::new(min_seq),
-            inner: Arc::new(RwLock::new(GlobalSequenceContextInner {
-                min_seq,
-                tsf_seq_map,
-            })),
+            min_seq: AtomicU64::new(inner.min_seq),
+            inner: Arc::new(RwLock::new(inner)),
         }
     }
 
@@ -181,7 +183,16 @@ mod test_context {
     use super::GlobalSequenceContext;
 
     #[test]
-    fn test_global_sequence_context() {
+    fn test_global_sequence_context_new() {
+        let ctx = GlobalSequenceContext::new(HashMap::from([(1, 2), (2, 3), (3, 4)]));
+        assert_eq!(ctx.min_seq(), 2);
+
+        let ctx = GlobalSequenceContext::new(HashMap::new());
+        assert_eq!(ctx.min_seq(), 0);
+    }
+
+    #[test]
+    fn test_global_sequence_context_next_stage() {
         let ctx = GlobalSequenceContext::empty();
         assert_eq!(ctx.min_seq(), 0);
 

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -127,6 +127,8 @@ impl Database {
         let (seq_no, version_edits, file_metas) = match version_edit {
             Some(mut ve) => {
                 ve.tsf_id = tsf_id;
+                ve.has_seq_no = true;
+                ve.seq_no = seq_no;
                 let mut file_metas = HashMap::with_capacity(ve.add_files.len());
                 for f in ve.add_files.iter_mut() {
                     f.tsf_id = tsf_id;

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -143,6 +143,7 @@ impl Database {
                 vec![VersionEdit::new_add_vnode(
                     tsf_id,
                     self.owner.as_ref().clone(),
+                    seq_no,
                 )],
                 None,
             ),
@@ -393,25 +394,18 @@ impl Database {
     /// (field-id filter) of db-files.
     pub async fn snapshot(
         &self,
-        last_seq: u64,
         vnode_id: Option<TseriesFamilyId>,
         version_edits: &mut Vec<VersionEdit>,
         file_metas: &mut HashMap<ColumnFileId, Arc<BloomFilter>>,
     ) {
         if let Some(tsf_id) = vnode_id.as_ref() {
             if let Some(tsf) = self.ts_families.get(tsf_id) {
-                let ve = tsf
-                    .read()
-                    .await
-                    .snapshot(last_seq, self.owner.clone(), file_metas);
+                let ve = tsf.read().await.snapshot(self.owner.clone(), file_metas);
                 version_edits.push(ve);
             }
         } else {
             for tsf in self.ts_families.values() {
-                let ve = tsf
-                    .read()
-                    .await
-                    .snapshot(last_seq, self.owner.clone(), file_metas);
+                let ve = tsf.read().await.snapshot(self.owner.clone(), file_metas);
                 version_edits.push(ve);
             }
         }

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -219,11 +219,12 @@ impl TsKv {
 
         async fn on_tick_check_total_size(
             version_set: Arc<RwLock<VersionSet>>,
-            wal_manager: &WalManager,
+            wal_manager: &mut WalManager,
         ) {
             // TODO(zipper): This may cause flushing too frequent.
             if wal_manager.is_total_file_size_exceed() {
                 version_set.read().await.send_flush_req().await;
+                wal_manager.check_to_delete().await;
             }
         }
 
@@ -253,7 +254,7 @@ impl TsKv {
                             }
                         }
                         _ = check_total_size_ticker.tick() => {
-                            on_tick_check_total_size(version_set.clone(), &wal_manager).await;
+                            on_tick_check_total_size(version_set.clone(), &mut wal_manager).await;
                         }
                         _ = close_receiver.recv() => {
                             on_cancel(wal_manager).await;
@@ -275,7 +276,7 @@ impl TsKv {
                             on_tick_sync(&wal_manager).await;
                         }
                         _ = check_total_size_ticker.tick() => {
-                            on_tick_check_total_size(version_set.clone(), &wal_manager).await;
+                            on_tick_check_total_size(version_set.clone(), &mut wal_manager).await;
                         }
                         _ = close_receiver.recv() => {
                             on_cancel(wal_manager).await;
@@ -861,7 +862,7 @@ impl Engine for TsKv {
         db_wlock
             .add_tsfamily(
                 vnode_id,
-                0,
+                self.global_seq_ctx.max_seq(),
                 Some(summary),
                 self.summary_task_sender.clone(),
                 self.flush_task_sender.clone(),

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -117,6 +117,7 @@ impl TsKv {
         core.run_flush_job(
             flush_task_receiver,
             summary.global_context(),
+            global_seq_ctx.clone(),
             summary.version_set(),
             summary_task_sender.clone(),
             compact_task_sender.clone(),
@@ -126,6 +127,7 @@ impl TsKv {
             runtime,
             compact_task_receiver,
             summary.global_context(),
+            global_seq_ctx.clone(),
             summary.version_set(),
             summary_task_sender.clone(),
         );
@@ -289,6 +291,7 @@ impl TsKv {
         &self,
         mut receiver: Receiver<FlushReq>,
         ctx: Arc<GlobalContext>,
+        seq_ctx: Arc<GlobalSequenceContext>,
         version_set: Arc<RwLock<VersionSet>>,
         summary_task_sender: Sender<SummaryTask>,
         compact_task_sender: Sender<CompactTask>,
@@ -299,6 +302,7 @@ impl TsKv {
                 runtime.spawn(run_flush_memtable_job(
                     x,
                     ctx.clone(),
+                    seq_ctx.clone(),
                     version_set.clone(),
                     summary_task_sender.clone(),
                     Some(compact_task_sender.clone()),
@@ -610,6 +614,7 @@ impl Engine for TsKv {
                     run_flush_memtable_job(
                         req,
                         self.global_ctx.clone(),
+                        self.global_seq_ctx.clone(),
                         self.version_set.clone(),
                         self.summary_task_sender.clone(),
                         Some(self.compact_task_sender.clone()),
@@ -912,6 +917,7 @@ impl Engine for TsKv {
                     if let Err(e) = run_flush_memtable_job(
                         req,
                         self.global_ctx.clone(),
+                        self.global_seq_ctx.clone(),
                         self.version_set.clone(),
                         self.summary_task_sender.clone(),
                         None,

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -219,6 +219,7 @@ impl TsKv {
             version_set: Arc<RwLock<VersionSet>>,
             wal_manager: &WalManager,
         ) {
+            // TODO(zipper): This may cause flushing too frequent.
             if wal_manager.is_total_file_size_exceed() {
                 version_set.read().await.send_flush_req().await;
             }
@@ -810,11 +811,7 @@ impl Engine for TsKv {
             // TODO: Send file_metas to the destination node.
             let mut file_metas = HashMap::new();
             if let Some(tsf) = db.get_tsfamily(vnode_id) {
-                let ve = tsf.read().await.snapshot(
-                    self.global_ctx.last_seq(),
-                    db.owner(),
-                    &mut file_metas,
-                );
+                let ve = tsf.read().await.snapshot(db.owner(), &mut file_metas);
                 Ok(Some(ve))
             } else {
                 warn!(

--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -895,23 +895,23 @@ impl TseriesFamily {
         self.cancellation_token.cancel();
     }
 
-    /// Snashots last version before `last_seq` of this vnode.
+    /// Snapshots last version before `last_seq` of this vnode.
     ///
     /// Db-files' index data (field-id filter) will be inserted into `file_metas`.
     pub fn snapshot(
         &self,
-        last_seq: u64,
         owner: Arc<String>,
         file_metas: &mut HashMap<ColumnFileId, Arc<BloomFilter>>,
     ) -> VersionEdit {
-        let mut version_edit = VersionEdit::new_add_vnode(self.tf_id, owner.as_ref().clone());
+        let mut version_edit =
+            VersionEdit::new_add_vnode(self.tf_id, owner.as_ref().clone(), self.seq_no);
         let version = self.version();
         let max_level_ts = version.max_level_ts;
         for files in version.levels_info.iter() {
             for file in files.files.iter() {
                 let mut meta = CompactMeta::from(file.as_ref());
                 meta.tsf_id = files.tsf_id;
-                meta.high_seq = last_seq;
+                meta.high_seq = self.seq_no;
                 version_edit.add_file(meta, max_level_ts);
                 file_metas.insert(file.file_id, file.field_id_filter.clone());
             }

--- a/tskv/src/wal.rs
+++ b/tskv/src/wal.rs
@@ -362,7 +362,7 @@ impl WalManager {
         Ok(())
     }
 
-    async fn check_to_delete(&mut self) {
+    pub async fn check_to_delete(&mut self) {
         let min_seq = self.global_seq_ctx.min_seq();
         let mut old_files_to_delete: Vec<u64> = Vec::new();
         for (old_file_id, old_file_max_seq) in self.old_file_max_sequence.iter() {


### PR DESCRIPTION
# Which issue does this PR close?

# Rationale for this change

Fixes:

1. `GlobalSequenceContext` sometimes not properly set when recover.
2. `VersionEdit::seq_no` not set when creating `TseriesFamily` or rolling a summary file.
3. Check to delete wal files after `flush_trigger_total_file_size` triggered.

# What changes are included in this PR?

# Are there any user-facing changes?
