### PR TITLE
feat(query): implement CHECKSUM GROUP <replication_set_id>

### DIFF
--- a/common/protos/proto/kv_service.proto
+++ b/common/protos/proto/kv_service.proto
@@ -120,6 +120,17 @@ message AdminCommandRequest {
   }
 }
 
+message FetchVnodeChecksumRequest {
+    uint32 vnode_id = 1;
+}
+
+message AdminFetchCommandRequest {
+  string tenant = 1;
+  oneof command {
+    FetchVnodeChecksumRequest fetch_vnode_checksum = 8;
+  }
+}
+
 /* -------------------------------------------------------------------- */
 
 message BatchBytesResponse {
@@ -154,6 +165,7 @@ service TSKVService {
   rpc WriteVnodePoints(WriteVnodeRequest) returns (StatusResponse) {};
   rpc QueryRecordBatch(QueryRecordBatchRequest) returns (stream BatchBytesResponse) {};
   rpc ExecAdminCommand(AdminCommandRequest) returns (StatusResponse) {};
+  rpc ExecAdminFetchCommand(AdminFetchCommandRequest) returns (BatchBytesResponse) {};
 
   rpc DownloadFile(DownloadFileRequest) returns (stream BatchBytesResponse) {};
   rpc GetVnodeFilesMeta(GetVnodeFilesMetaRequest) returns (GetVnodeFilesMetaResponse) {};

--- a/coordinator/src/errors.rs
+++ b/coordinator/src/errors.rs
@@ -142,6 +142,12 @@ pub enum CoordinatorError {
     FBPoints {
         source: PointsError,
     },
+
+    #[snafu(display("ReplicationSet not found: {}", id))]
+    #[error_code(code = 22)]
+    ReplicationSetNotFound {
+        id: u32,
+    },
 }
 
 impl From<PointsError> for CoordinatorError {

--- a/coordinator/src/service.rs
+++ b/coordinator/src/service.rs
@@ -12,7 +12,8 @@ use metrics::label::Labels;
 use metrics::metric::Metric;
 use metrics::metric_register::MetricsRegister;
 use models::consistency_level::ConsistencyLevel;
-use models::meta_data::{ExpiredBucketInfo, VnodeAllInfo};
+use models::meta_data::{ExpiredBucketInfo, ReplicationSet, VnodeAllInfo};
+use models::record_batch_decode;
 use models::schema::{Precision, DEFAULT_CATALOG};
 use protos::get_db_from_fb_points;
 use protos::kv_service::admin_command_request::Command::*;
@@ -32,7 +33,8 @@ use crate::metrics::LPReporter;
 use crate::reader::{QueryExecutor, ReaderIterator};
 use crate::writer::PointWriter;
 use crate::{
-    status_response_to_result, Coordinator, QueryOption, VnodeManagerCmdType, WriteRequest,
+    status_response_to_result, Coordinator, QueryOption, VnodeManagerCmdType,
+    VnodeSummarizerCmdType, WriteRequest,
 };
 
 pub type CoordinatorRef = Arc<dyn Coordinator>;
@@ -207,6 +209,25 @@ impl CoordService {
         }
     }
 
+    async fn get_replication_set(
+        &self,
+        tenant: &str,
+        replication_set_id: u32,
+    ) -> CoordinatorResult<ReplicationSet> {
+        match self.tenant_meta(tenant).await {
+            Some(meta_client) => match meta_client.get_replication_set(replication_set_id) {
+                Some(repl_set) => Ok(repl_set),
+                None => Err(CoordinatorError::ReplicationSetNotFound {
+                    id: replication_set_id,
+                }),
+            },
+
+            None => Err(CoordinatorError::TenantNotFound {
+                name: tenant.to_string(),
+            }),
+        }
+    }
+
     async fn select_statement_request(
         self,
         option: QueryOption,
@@ -320,6 +341,25 @@ impl CoordService {
 
         let response = client.exec_admin_command(request).await?.into_inner();
         status_response_to_result(&response)
+    }
+
+    async fn exec_admin_fetch_command_on_node(
+        &self,
+        node_id: u64,
+        req: AdminFetchCommandRequest,
+    ) -> CoordinatorResult<RecordBatch> {
+        let channel = self.meta.admin_meta().get_node_conn(node_id).await?;
+
+        let timeout_channel = Timeout::new(channel, Duration::from_secs(60 * 60));
+
+        let mut client = TskvServiceClient::<Timeout<Channel>>::new(timeout_channel);
+        let request = tonic::Request::new(req.clone());
+
+        let response = client.exec_admin_fetch_command(request).await?.into_inner();
+        match record_batch_decode(&response.data) {
+            Ok(r) => Ok(r),
+            Err(e) => Err(CoordinatorError::ArrowError { source: e }),
+        }
     }
 }
 
@@ -511,6 +551,53 @@ impl Coordinator for CoordService {
             }
         };
 
-        self.exec_admin_command_on_node(req_node_id, grpc_req).await
+        self.exec_admin_command_on_node(req_node_id, grpc_req)
+            .await
+            .map(|_| ())
+    }
+
+    async fn vnode_summarizer(
+        &self,
+        tenant: &str,
+        cmd_type: VnodeSummarizerCmdType,
+    ) -> CoordinatorResult<Vec<RecordBatch>> {
+        match cmd_type {
+            VnodeSummarizerCmdType::Checksum(replication_set_id) => {
+                let replication_set = self.get_replication_set(tenant, replication_set_id).await?;
+
+                // Group vnode ids by node id.
+                let mut node_vnode_ids_map: HashMap<u64, Vec<u32>> = HashMap::new();
+                for vnode in replication_set.vnodes {
+                    node_vnode_ids_map
+                        .entry(vnode.node_id)
+                        .or_default()
+                        .push(vnode.id);
+                }
+
+                let meta = self.meta.admin_meta();
+                let nodes = meta.data_nodes().await;
+
+                // Send grouped vnode ids to nodes.
+                let mut req_futures = vec![];
+                for node in nodes {
+                    if let Some(vnode_ids) = node_vnode_ids_map.remove(&node.id) {
+                        for vnode_id in vnode_ids {
+                            let cmd = AdminFetchCommandRequest {
+                                tenant: tenant.to_string(),
+                                command: Some(
+                                    admin_fetch_command_request::Command::FetchVnodeChecksum(
+                                        FetchVnodeChecksumRequest { vnode_id },
+                                    ),
+                                ),
+                            };
+                            req_futures.push(self.exec_admin_fetch_command_on_node(node.id, cmd));
+                        }
+                    }
+                }
+                let record_batches = futures::future::try_join_all(req_futures).await?;
+
+                return Ok(record_batches);
+            }
+        }
     }
 }

--- a/coordinator/src/service_mock.rs
+++ b/coordinator/src/service_mock.rs
@@ -3,6 +3,7 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use datafusion::arrow::record_batch::RecordBatch;
 use meta::model::meta_client_mock::{MockMetaClient, MockMetaManager};
 use meta::model::{MetaClientRef, MetaRef};
 use models::consistency_level::ConsistencyLevel;
@@ -14,7 +15,7 @@ use tskv::EngineRef;
 
 use crate::errors::CoordinatorResult;
 use crate::reader::ReaderIterator;
-use crate::{Coordinator, VnodeManagerCmdType};
+use crate::{Coordinator, VnodeManagerCmdType, VnodeSummarizerCmdType};
 
 #[derive(Debug, Default)]
 pub struct MockCoordinator {}
@@ -67,5 +68,13 @@ impl Coordinator for MockCoordinator {
         cmd_type: VnodeManagerCmdType,
     ) -> CoordinatorResult<()> {
         Ok(())
+    }
+
+    async fn vnode_summarizer(
+        &self,
+        tenant: &str,
+        cmd_type: VnodeSummarizerCmdType,
+    ) -> CoordinatorResult<Vec<RecordBatch>> {
+        Ok(vec![])
     }
 }

--- a/meta/src/model/meta_client.rs
+++ b/meta/src/model/meta_client.rs
@@ -246,7 +246,7 @@ impl MetaClient for RemoteMetaClient {
         }
     }
 
-    async fn reasign_member_role(
+    async fn reassign_member_role(
         &self,
         user_id: Oid,
         role: TenantRoleIdentifier,
@@ -743,13 +743,13 @@ impl MetaClient for RemoteMetaClient {
         None
     }
 
-    fn get_vnode_repl_set(&self, id: u32) -> Option<ReplicationSet> {
+    fn get_vnode_repl_set(&self, vnode_id: u32) -> Option<ReplicationSet> {
         let data = self.data.read();
         for (_db_name, db_info) in data.dbs.iter() {
             for bucket in db_info.buckets.iter() {
                 for repl_set in bucket.shard_group.iter() {
                     for vnode_info in repl_set.vnodes.iter() {
-                        if vnode_info.id == id {
+                        if vnode_info.id == vnode_id {
                             return Some(repl_set.clone());
                         }
                     }
@@ -779,6 +779,21 @@ impl MetaClient for RemoteMetaClient {
         let bucket = self.create_bucket(db, ts).await?;
 
         Ok(bucket.vnode_for(hash_id))
+    }
+
+    fn get_replication_set(&self, repl_id: u32) -> Option<ReplicationSet> {
+        let data = self.data.read();
+        for (_db_name, db_info) in data.dbs.iter() {
+            for bucket in db_info.buckets.iter() {
+                for repl_set in bucket.shard_group.iter() {
+                    if repl_set.id == repl_id {
+                        return Some(repl_set.clone());
+                    }
+                }
+            }
+        }
+
+        None
     }
 
     async fn update_vnode(&self, info: &VnodeAllInfo) -> MetaResult<()> {

--- a/meta/src/model/meta_client_mock.rs
+++ b/meta/src/model/meta_client_mock.rs
@@ -178,7 +178,7 @@ impl MetaClient for MockMetaClient {
         todo!()
     }
 
-    async fn reasign_member_role(
+    async fn reassign_member_role(
         &self,
         user_id: Oid,
         role: TenantRoleIdentifier,
@@ -229,6 +229,10 @@ impl MetaClient for MockMetaClient {
 
     fn expired_bucket(&self) -> Vec<ExpiredBucketInfo> {
         vec![]
+    }
+
+    fn get_replication_set(&self, repl_id: u32) -> Option<ReplicationSet> {
+        todo!()
     }
 
     async fn update_replication_set(

--- a/meta/src/model/mod.rs
+++ b/meta/src/model/mod.rs
@@ -71,8 +71,11 @@ pub trait MetaClient: Send + Sync + Debug {
     ) -> MetaResult<()>;
     async fn member_role(&self, user_id: &Oid) -> MetaResult<Option<TenantRoleIdentifier>>;
     async fn members(&self) -> MetaResult<HashMap<String, TenantRoleIdentifier>>;
-    async fn reasign_member_role(&self, user_id: Oid, role: TenantRoleIdentifier)
-        -> MetaResult<()>;
+    async fn reassign_member_role(
+        &self,
+        user_id: Oid,
+        role: TenantRoleIdentifier,
+    ) -> MetaResult<()>;
     async fn remove_member(&self, user_id: Oid) -> MetaResult<()>;
 
     // tenant role
@@ -80,7 +83,7 @@ pub trait MetaClient: Send + Sync + Debug {
         &self,
         role_name: String,
         system_role: SystemTenantRole,
-        additiona_privileges: HashMap<String, DatabasePrivilege>,
+        additional_privileges: HashMap<String, DatabasePrivilege>,
     ) -> MetaResult<()>;
     async fn custom_role(&self, role_name: &str) -> MetaResult<Option<CustomTenantRole<Oid>>>;
     async fn custom_roles(&self) -> MetaResult<Vec<CustomTenantRole<Oid>>>;
@@ -125,8 +128,8 @@ pub trait MetaClient: Send + Sync + Debug {
     fn database_min_ts(&self, db: &str) -> Option<i64>;
     fn expired_bucket(&self) -> Vec<ExpiredBucketInfo>;
 
-    fn get_vnode_all_info(&self, id: u32) -> Option<VnodeAllInfo>;
-    fn get_vnode_repl_set(&self, id: u32) -> Option<ReplicationSet>;
+    fn get_vnode_all_info(&self, vnode_id: u32) -> Option<VnodeAllInfo>;
+    fn get_vnode_repl_set(&self, vnode_id: u32) -> Option<ReplicationSet>;
 
     fn mapping_bucket(&self, db_name: &str, start: i64, end: i64) -> MetaResult<Vec<BucketInfo>>;
 
@@ -136,6 +139,8 @@ pub trait MetaClient: Send + Sync + Debug {
         hash_id: u64,
         ts: i64,
     ) -> MetaResult<ReplicationSet>;
+
+    fn get_replication_set(&self, repl_id: u32) -> Option<ReplicationSet>;
 
     async fn update_replication_set(
         &self,

--- a/query_server/query/src/execution/ddl/alter_tenant.rs
+++ b/query_server/query/src/execution/ddl/alter_tenant.rs
@@ -65,17 +65,17 @@ impl DDLDefinitionTask for AlterTenantTask {
                 // user_id: Oid,
                 // role: TenantRoleIdentifier,
                 // tenant_id: Oid,
-                // fn reasign_member_role_in_tenant(
+                // fn reassign_member_role_in_tenant(
                 //     &mut self,
                 //     user_id: Oid,
                 //     role: TenantRoleIdentifier,
                 //     tenant_id: Oid,
                 // ) -> Result<()>;
                 debug!(
-                    "Reasign role {:?} of user {} in tenant {}",
+                    "Reassign role {:?} of user {} in tenant {}",
                     role, user_id, tenant_name
                 );
-                meta.reasign_member_role(*user_id, role.clone()).await?;
+                meta.reassign_member_role(*user_id, role.clone()).await?;
                 // .context(MetaSnafu)?;
             }
             AlterTenantAction::RemoveUser(user_id) => {

--- a/query_server/query/src/execution/ddl/checksum_group.rs
+++ b/query_server/query/src/execution/ddl/checksum_group.rs
@@ -27,7 +27,7 @@ impl DDLDefinitionTask for ChecksumGroupTask {
         let coord = query_state_machine.coord.clone();
         let cmd_type = VnodeSummarizerCmdType::Checksum(replication_set_id);
         let checksums = coord.vnode_summarizer(tenant, cmd_type).await?;
-        let stream = RecordBatchStreamWrapper::new(tskv::vnode_checksum_schema(), checksums);
+        let stream = RecordBatchStreamWrapper::new(tskv::vnode_table_checksum_schema(), checksums);
         Ok(Output::StreamData(Box::pin(stream)))
     }
 }

--- a/tskv/src/compaction/check.rs
+++ b/tskv/src/compaction/check.rs
@@ -1,28 +1,26 @@
-use std::collections::{BTreeMap, HashMap};
+use std::cmp;
+use std::collections::HashMap;
 use std::fmt::{Display, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use blake3::Hasher;
-use chrono::{Duration, DurationRound, NaiveDateTime};
-use datafusion::arrow::array::{Int64Array, StringBuilder, UInt32Array};
+use datafusion::arrow::array::{StringBuilder, UInt32Array};
 use datafusion::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Schema, SchemaRef,
 };
 use datafusion::arrow::record_batch::RecordBatch;
 use models::predicate::domain::TimeRange;
-use models::schema::ColumnType;
-use models::{utils, ColumnId, FieldId, Timestamp};
-use snafu::ResultExt;
+use models::{utils as model_utils, ColumnId, FieldId, SeriesId, Timestamp};
 use tokio::sync::RwLock;
-use trace::warn;
 
 use crate::compaction::{CompactIterator, CompactingBlock};
-use crate::error::{self, Error, Result};
-use crate::schema::schemas::DBschemas;
+use crate::error::{Error, Result};
 use crate::tseries_family::TseriesFamily;
 use crate::tsm::{DataBlock, TsmReader};
 use crate::TseriesFamilyId;
+
+const DEFAULT_DURATION: i64 = 24 * 60 * 60 * 1_000_000_000;
 
 pub type Hash = [u8; 32];
 
@@ -35,28 +33,46 @@ pub fn hash_to_string(hash: Hash) -> String {
 }
 
 #[derive(Default, Debug)]
-pub struct TableHashTreeNode {
-    pub table: String,
-    pub columns: Vec<ColumnHashTreeNode>,
+pub struct VnodeHashTreeNode {
+    pub vnode_id: TseriesFamilyId,
+    pub fields: Vec<FieldHashTreeNode>,
+    min_ts: Timestamp,
+    max_ts: Timestamp,
 }
 
-impl TableHashTreeNode {
-    pub fn with_capacity(table: String, capacity: usize) -> Self {
+impl VnodeHashTreeNode {
+    pub fn with_capacity(vnode_id: TseriesFamilyId, capacity: usize) -> Self {
         Self {
-            table,
-            columns: Vec::with_capacity(capacity),
+            vnode_id,
+            fields: Vec::with_capacity(capacity),
+            min_ts: Timestamp::MAX,
+            max_ts: Timestamp::MIN,
         }
     }
 
-    pub fn push(&mut self, value: ColumnHashTreeNode) {
-        self.columns.push(value);
+    pub fn push(&mut self, value: FieldHashTreeNode) {
+        self.min_ts = self.min_ts.min(value.min_ts);
+        self.max_ts = self.max_ts.max(value.max_ts);
+        self.fields.push(value);
+    }
+
+    pub fn checksum(&self) -> Hash {
+        let mut hasher = Hasher::new();
+        for f in self.fields.iter() {
+            hasher.update(&f.checksum());
+        }
+        hasher.finalize().into()
+    }
+
+    pub fn len(&self) -> usize {
+        self.fields.iter().map(|f| f.len()).sum()
     }
 }
 
-impl Display for TableHashTreeNode {
+impl Display for VnodeHashTreeNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("{{ table: {}, values: [ ", self.table))?;
-        for v in self.columns.iter() {
+        f.write_fmt(format_args!("{{ VnodeId: {}, fields: [ ", self.vnode_id))?;
+        for v in self.fields.iter() {
             v.fmt(f)?;
             f.write_str(", ")?;
         }
@@ -66,28 +82,54 @@ impl Display for TableHashTreeNode {
 }
 
 #[derive(Default, Debug)]
-pub struct ColumnHashTreeNode {
-    pub column: String,
-    pub values: Vec<TimeRangeHashTreeNode>,
+pub struct FieldHashTreeNode {
+    pub field_id: FieldId,
+    pub time_ranges: Vec<TimeRangeHashTreeNode>,
+    min_ts: Timestamp,
+    max_ts: Timestamp,
 }
 
-impl ColumnHashTreeNode {
-    pub fn with_capacity(column: String, capacity: usize) -> Self {
+impl FieldHashTreeNode {
+    pub fn with_capacity(field_id: FieldId, capacity: usize) -> Self {
         Self {
-            column,
-            values: Vec::with_capacity(capacity),
+            field_id,
+            time_ranges: Vec::with_capacity(capacity),
+            min_ts: Timestamp::MAX,
+            max_ts: Timestamp::MIN,
         }
     }
 
     pub fn push(&mut self, value: TimeRangeHashTreeNode) {
-        self.values.push(value);
+        self.min_ts = self.min_ts.min(value.min_ts);
+        self.max_ts = self.max_ts.max(value.max_ts);
+        self.time_ranges.push(value);
+    }
+
+    pub fn checksum(&self) -> Hash {
+        let mut hasher = Hasher::new();
+        for v in self.time_ranges.iter() {
+            hasher.update(&v.hash);
+        }
+        hasher.finalize().into()
+    }
+
+    pub fn column_series(&self) -> (ColumnId, SeriesId) {
+        model_utils::split_id(self.field_id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.time_ranges.len()
     }
 }
 
-impl Display for ColumnHashTreeNode {
+impl Display for FieldHashTreeNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("{{ column: {}, values: [ ", self.column))?;
-        for v in self.values.iter() {
+        let (cid, sid) = self.column_series();
+        f.write_fmt(format_args!(
+            "{{ SeriesId: {}, ColumnId: {}, values: [ ",
+            sid, cid
+        ))?;
+        for v in self.time_ranges.iter() {
             v.fmt(f)?;
             f.write_str(", ")?;
         }
@@ -111,6 +153,10 @@ impl TimeRangeHashTreeNode {
             hash,
         }
     }
+
+    pub fn checksum(&self) -> Hash {
+        self.hash
+    }
 }
 
 impl Display for TimeRangeHashTreeNode {
@@ -127,52 +173,43 @@ impl Display for TimeRangeHashTreeNode {
     }
 }
 
-pub fn vnode_checksum_schema() -> SchemaRef {
+pub fn vnode_table_checksum_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
         ArrowField::new("VNODE_ID", ArrowDataType::UInt32, false),
-        ArrowField::new("TABLE", ArrowDataType::Utf8, false),
-        ArrowField::new("COLUMN", ArrowDataType::Utf8, false),
-        ArrowField::new("MIN_TIME", ArrowDataType::Int64, false),
-        ArrowField::new("MAX_TIME", ArrowDataType::Int64, false),
         ArrowField::new("CHECK_SUM", ArrowDataType::Utf8, false),
     ]))
 }
 
-pub(crate) async fn vnode_checksum(
-    ts_family: Arc<RwLock<TseriesFamily>>,
-    schemas: Arc<DBschemas>,
-) -> Result<RecordBatch> {
-    let vnode_id = ts_family.read().await.tf_id();
-    let tree_nodes = ts_family_hash_tree(ts_family, schemas).await?;
+pub(crate) async fn vnode_checksum(vnode: Arc<RwLock<TseriesFamily>>) -> Result<RecordBatch> {
+    let vnode_id = vnode.read().await.tf_id();
+    let root_node = vnode_hash_tree(vnode).await?;
 
-    let capacity = 1024;
+    let capacity = root_node.len();
     let mut vnode_id_array = UInt32Array::builder(capacity);
-    let mut table_array = StringBuilder::new();
-    let mut column_array = StringBuilder::new();
-    let mut min_time_array = Int64Array::builder(capacity);
-    let mut max_time_array = Int64Array::builder(capacity);
-    let mut check_sum_array = StringBuilder::new();
-    for tn in tree_nodes {
-        for col in tn.columns {
-            for tr in col.values {
-                vnode_id_array.append_value(vnode_id);
-                table_array.append_value(tn.table.as_str());
-                column_array.append_value(col.column.as_str());
-                min_time_array.append_value(tr.min_ts);
-                max_time_array.append_value(tr.max_ts);
-                check_sum_array.append_value(hash_to_string(tr.hash));
-            }
-        }
-    }
+    // let mut field_id_array = UInt64Array::builder(capacity);
+    // let mut min_time_array = TimestampNanosecondArray::builder(capacity);
+    // let mut max_time_array = TimestampNanosecondArray::builder(capacity);
+    let mut check_sum_array = StringBuilder::with_capacity(capacity, 32 * capacity);
+
+    // for field in root_node.fields {
+    //     for time_range in field.time_ranges {
+    //         vnode_id_array.append_value(vnode_id);
+    //         field_id_array.append_value(field.field_id);
+    //         min_time_array.append_value(time_range.min_ts);
+    //         max_time_array.append_value(time_range.max_ts);
+    //         check_sum_array.append_value(hash_to_string(time_range.checksum()));
+    //     }
+    // }
+    vnode_id_array.append_value(vnode_id);
+    check_sum_array.append_value(hash_to_string(root_node.checksum()));
 
     RecordBatch::try_new(
-        vnode_checksum_schema(),
+        vnode_table_checksum_schema(),
         vec![
             Arc::new(vnode_id_array.finish()),
-            Arc::new(table_array.finish()),
-            Arc::new(column_array.finish()),
-            Arc::new(min_time_array.finish()),
-            Arc::new(max_time_array.finish()),
+            // Arc::new(field_id_array.finish()),
+            // Arc::new(min_time_array.finish()),
+            // Arc::new(max_time_array.finish()),
             Arc::new(check_sum_array.finish()),
         ],
     )
@@ -181,35 +218,14 @@ pub(crate) async fn vnode_checksum(
     })
 }
 
-pub(crate) async fn ts_family_hash_tree(
-    ts_family: Arc<RwLock<TseriesFamily>>,
-    schemas: Arc<DBschemas>,
-) -> Result<Vec<TableHashTreeNode>> {
+pub(crate) async fn vnode_hash_tree(
+    vnode: Arc<RwLock<TseriesFamily>>,
+) -> Result<VnodeHashTreeNode> {
     const MAX_DATA_BLOCK_SIZE: u32 = 1000;
 
-    let mut cid_table_name_map: HashMap<ColumnId, Arc<String>> = HashMap::new();
-    let mut cid_col_name_map: HashMap<ColumnId, String> = HashMap::new();
-    for tab in schemas.list_tables()? {
-        match schemas.get_table_schema(&tab)? {
-            Some(sch) => {
-                let shared_tab = Arc::new(tab);
-                for col in sch.columns() {
-                    if matches!(col.column_type, ColumnType::Field(_)) {
-                        cid_table_name_map.insert(col.id, shared_tab.clone());
-                        cid_col_name_map.insert(col.id, col.name.clone());
-                    }
-                }
-            }
-            None => {
-                warn!("Repair: Can not find schema for table '{}'.", &tab);
-            }
-        }
-    }
-    let time_range_nanosec = default_time_range(schemas)?;
-
-    let (version, ts_family_id) = {
-        let ts_family_rlock = ts_family.read().await;
-        (ts_family_rlock.version(), ts_family_rlock.tf_id())
+    let (version, vnode_id) = {
+        let vnode_rlock = vnode.read().await;
+        (vnode_rlock.version(), vnode_rlock.tf_id())
     };
     let mut readers: Vec<Arc<TsmReader>> = Vec::new();
     let tsm_paths: Vec<PathBuf> = version
@@ -222,98 +238,51 @@ pub(crate) async fn ts_family_hash_tree(
         readers.push(r);
     }
 
-    // Build a compact iterator, read data, slite by time range and then calculate hash.
+    // Build a compact iterator, read data, split by time range and then calculate hash.
     let iter = CompactIterator::new(readers, MAX_DATA_BLOCK_SIZE, true);
-    let (fid_tr_hash_val_map, mut cid_fid_count_map) =
-        read_from_compact_iterator(iter, ts_family_id, time_range_nanosec, &cid_col_name_map)
-            .await?;
+    let mut fid_tr_hash_val_map: HashMap<FieldId, Vec<(TimeRange, Hash)>> =
+        read_from_compact_iterator(iter, vnode_id, DEFAULT_DURATION).await?;
 
-    // Transform hashed data into TableHashTreeNode list.
-    let mut cid_tr_hasher_map: HashMap<ColumnId, BTreeMap<TimeRange, Hasher>> = HashMap::new();
-    let mut hash_tree_builder: HashMap<String, TableHashTreeNode> = HashMap::new();
-    for (fid, tr_hashes) in fid_tr_hash_val_map.into_iter() {
-        if tr_hashes.is_empty() {
-            continue;
+    let mut field_ids: Vec<FieldId> = fid_tr_hash_val_map.keys().cloned().collect();
+    field_ids.sort();
+    let mut vnode_hash_tree_node = VnodeHashTreeNode::with_capacity(vnode_id, field_ids.len());
+    for fid in field_ids {
+        let tr_hashes = fid_tr_hash_val_map.remove(&fid).unwrap();
+        let mut filed_hash_tree_node = FieldHashTreeNode::with_capacity(fid, tr_hashes.len());
+        for (tr, hash) in tr_hashes {
+            filed_hash_tree_node.push(TimeRangeHashTreeNode::new(tr, hash));
         }
-        let (column_id, _) = utils::split_id(fid);
-        if !cid_col_name_map.contains_key(&column_id) {
-            continue;
-        }
-        let tr_hasher_map = cid_tr_hasher_map.entry(column_id).or_default();
-        for (tr, hash) in tr_hashes.into_iter() {
-            tr_hasher_map.entry(tr).or_default().update(&hash);
-        }
-        if let Some(fid_count) = cid_fid_count_map.get_mut(&column_id) {
-            *fid_count -= 1;
-            if *fid_count == 0 {
-                let table_name = cid_table_name_map.get(&column_id).unwrap();
-                let table_node = match hash_tree_builder.get_mut(table_name.as_ref()) {
-                    Some(t) => t,
-                    None => hash_tree_builder
-                        .entry((**table_name).clone())
-                        .or_insert_with(|| {
-                            TableHashTreeNode::with_capacity(
-                                (**table_name).clone(),
-                                cid_fid_count_map.len(),
-                            )
-                        }),
-                };
-
-                // cid_col_name_map must contains key column_id
-                let column_name = cid_col_name_map.remove(&column_id).unwrap();
-                // tr_hasher_map must contains key column_id
-                let tr_hasher_map = cid_tr_hasher_map.remove(&column_id).unwrap();
-                let mut column_node =
-                    ColumnHashTreeNode::with_capacity(column_name, tr_hasher_map.len());
-                for (tr, hasher) in tr_hasher_map.into_iter() {
-                    column_node.push(TimeRangeHashTreeNode::new(tr, hasher.finalize().into()));
-                }
-                table_node.push(column_node);
-            }
-        };
+        vnode_hash_tree_node.push(filed_hash_tree_node);
     }
 
-    Ok(hash_tree_builder
-        .into_values()
-        .collect::<Vec<TableHashTreeNode>>())
+    Ok(vnode_hash_tree_node)
 }
 
-fn default_time_range(db_schemas: Arc<DBschemas>) -> Result<i64> {
-    let db_schema = db_schemas.db_schema().context(error::SchemaSnafu)?;
-    let _tenant_name = db_schema.tenant_name();
-    let _database_name = db_schema.database_name();
-    Ok(db_schema
-        .config
-        .ttl()
-        .as_ref()
-        .map(|t| t.to_nanoseconds() / 1000)
-        .unwrap_or(5 * 60 * 1_000_000_000))
-}
-
+/// Returns a time range calculated by the given `blk_min_ts1`
+/// and `split_time_range_nanosecs`.
+///
+/// **NOTE**: `split_time_range_nanosecs` must not greater than `blk_min_ts_nanosecs`.
 fn calc_block_partial_time_range(
-    timestamp: Timestamp,
-    time_range: Duration,
-    time_range_nanosecs: i64,
+    blk_min_ts_nanosecs: Timestamp,
+    split_time_range_nanosecs: i64,
 ) -> Result<(Timestamp, Timestamp)> {
-    let secs: i64 = timestamp / 1_000_000_000;
-    let nsecs: u32 = (timestamp % 1_000_000_000) as u32;
-    match NaiveDateTime::from_timestamp_opt(secs, nsecs) {
-        Some(datetime) => {
-            let min_ts = match datetime.duration_trunc(time_range) {
-                Ok(date_time) => date_time.timestamp_nanos(),
-                Err(e) => {
-                    return Err(Error::Transform {
-                        reason: format!("error truncing timestamp {}: {:?}", datetime, e),
-                    });
-                }
-            };
-            let max_ts = min_ts + time_range_nanosecs;
-            Ok((min_ts, max_ts))
-        }
-        None => Err(Error::Transform {
-            reason: format!("error parsing timestamp to NaiveDateTime: {}", timestamp),
-        }),
+    if split_time_range_nanosecs > blk_min_ts_nanosecs.abs() {
+        return Err(Error::Transform {
+            reason: format!(
+                "duration({}) > timestamp({}) in duration_trunc",
+                split_time_range_nanosecs, blk_min_ts_nanosecs,
+            ),
+        });
     }
+
+    let delta_down = blk_min_ts_nanosecs % split_time_range_nanosecs;
+    // Copy from: chrono::round.rs duration_trunc()
+    let min_ts = match delta_down.cmp(&0) {
+        cmp::Ordering::Equal => blk_min_ts_nanosecs,
+        cmp::Ordering::Greater => blk_min_ts_nanosecs - delta_down,
+        cmp::Ordering::Less => blk_min_ts_nanosecs - (split_time_range_nanosecs - delta_down.abs()),
+    };
+    Ok((min_ts, min_ts + split_time_range_nanosecs))
 }
 
 fn find_timestamp(timestamps: &[Timestamp], max_timestamp: Timestamp) -> usize {
@@ -374,16 +343,10 @@ fn hash_partial_datablock(
 
 async fn read_from_compact_iterator(
     mut iter: CompactIterator,
-    ts_family_id: TseriesFamilyId,
+    vnode_id: TseriesFamilyId,
     time_range_nanosec: i64,
-    cid_col_name_map: &HashMap<ColumnId, String>,
-) -> Result<(
-    HashMap<FieldId, Vec<(TimeRange, Hash)>>,
-    HashMap<ColumnId, usize>,
-)> {
-    let time_range = Duration::nanoseconds(time_range_nanosec);
+) -> Result<HashMap<FieldId, Vec<(TimeRange, Hash)>>> {
     let mut fid_tr_hash_val_map: HashMap<FieldId, Vec<(TimeRange, Hash)>> = HashMap::new();
-    let mut cid_fid_count_map: HashMap<ColumnId, usize> = HashMap::new();
     let mut last_hashed_tr_fid: Option<(TimeRange, FieldId)> = None;
     let mut hasher = Hasher::new();
     loop {
@@ -396,12 +359,6 @@ async fn read_from_compact_iterator(
                     ..
                 } = blk
                 {
-                    let (column_id, _) = utils::split_id(field_id);
-                    if !cid_col_name_map.contains_key(&column_id) {
-                        continue;
-                    }
-                    *cid_fid_count_map.entry(column_id).or_default() += 1;
-
                     // Check if there is last hash value that not stored.
                     if let Some((time_range, last_fid)) = last_hashed_tr_fid {
                         if last_fid != field_id {
@@ -414,10 +371,9 @@ async fn read_from_compact_iterator(
                     }
                     if let Some(blk_time_range) = data_block.time_range() {
                         // Get trunced time range by DataBlock.time[0]
-                        // TODO: Data block may be split into multi time ranges.
+                        // TODO: Support data block to be split into multi time ranges.
                         let (min_ts, max_ts) = match calc_block_partial_time_range(
                             blk_time_range.0,
-                            time_range,
                             time_range_nanosec,
                         ) {
                             Ok(tr) => tr,
@@ -454,8 +410,8 @@ async fn read_from_compact_iterator(
             Some(Err(e)) => {
                 return Err(Error::CommonError {
                     reason: format!(
-                        "error getting hashes for ts_family {} when compacting: {:?}",
-                        ts_family_id, e
+                        "error getting hashes for vnode {} when compacting: {:?}",
+                        vnode_id, e
                     ),
                 });
             }
@@ -468,7 +424,7 @@ async fn read_from_compact_iterator(
             .push((tr, hasher.finalize().into()));
     }
 
-    Ok((fid_tr_hash_val_map, cid_fid_count_map))
+    Ok(fid_tr_hash_val_map)
 }
 
 #[cfg(test)]
@@ -478,28 +434,30 @@ mod test {
 
     use blake3::Hasher;
     use chrono::{Duration, NaiveDateTime};
+    use config::Config;
     use datafusion::arrow::datatypes::TimeUnit;
     use memory_pool::GreedyMemoryPool;
     use meta::model::meta_manager::RemoteMetaManager;
-    use meta::model::MetaRef;
+    use meta::model::{MetaClient, MetaManager};
     use metrics::metric_register::MetricsRegister;
     use minivec::MiniVec;
     use models::predicate::domain::TimeRange;
     use models::schema::{
-        ColumnType, DatabaseOptions, DatabaseSchema, Precision, TableColumn, TableSchema,
-        TenantOptions, TskvTableSchema,
+        make_owner, ColumnType, DatabaseOptions, DatabaseSchema, Precision, TableColumn,
+        TableSchema, TenantOptions, TskvTableSchema,
     };
     use models::{Timestamp, ValueType};
     use protos::kv_service::{Meta, WritePointsRequest};
     use protos::models::{self as fb_models, FieldType, Points, PointsArgs, TableBuilder};
     use protos::{build_fb_schema_offset, models_helper, FbSchema};
-    use tokio::runtime;
+    use tokio::runtime::{self, Runtime};
+    use tokio::sync::RwLock;
 
     use super::{calc_block_partial_time_range, find_timestamp, hash_partial_datablock, Hash};
-    use crate::compaction::check::{
-        default_time_range, ts_family_hash_tree, TimeRangeHashTreeNode,
-    };
+    use crate::compaction::check::{vnode_hash_tree, TimeRangeHashTreeNode, DEFAULT_DURATION};
+    use crate::compaction::flush;
     use crate::context::GlobalContext;
+    use crate::tseries_family::TseriesFamily;
     use crate::tsm::codec::DataBlockEncoding;
     use crate::tsm::DataBlock;
     use crate::{Engine, Options, TsKv, TseriesFamilyId};
@@ -512,30 +470,30 @@ mod test {
 
     #[test]
     fn test_calc_blcok_time_range() {
-        fn get_args(datetime: &str) -> (Timestamp, Duration, i64) {
+        fn get_args(datetime: &str) -> (Timestamp, i64) {
             let datetime = NaiveDateTime::parse_from_str(datetime, "%Y-%m-%d %H:%M:%S").unwrap();
             let timestamp = datetime.timestamp_nanos();
             let duration = Duration::minutes(30);
             let duration_nanos = duration.num_nanoseconds().unwrap();
-            (timestamp, duration, duration_nanos)
+            (timestamp, duration_nanos)
         }
 
-        let (a, b, c) = get_args("2023-01-01 00:29:01");
+        let (stamp, span) = get_args("2023-01-01 00:29:01");
         assert_eq!(
             (
                 parse_nanos("2023-01-01 00:00:00"),
                 parse_nanos("2023-01-01 00:30:00")
             ),
-            calc_block_partial_time_range(a, b, c).unwrap(),
+            calc_block_partial_time_range(stamp, span).unwrap(),
         );
 
-        let (a, b, c) = get_args("2023-01-01 00:30:01");
+        let (stamp, span) = get_args("2023-01-01 00:30:01");
         assert_eq!(
             (
                 parse_nanos("2023-01-01 00:30:00"),
                 parse_nanos("2023-01-01 01:00:00")
             ),
-            calc_block_partial_time_range(a, b, c).unwrap(),
+            calc_block_partial_time_range(stamp, span).unwrap(),
         );
     }
 
@@ -635,14 +593,14 @@ mod test {
         }
     }
 
-    const TIME_COL_NAME: &str = "time";
     const U64_COL_NAME: &str = "col_u64";
     const I64_COL_NAME: &str = "col_i64";
     const F64_COL_NAME: &str = "col_f64";
     const STR_COL_NAME: &str = "col_str";
     const BOOL_COL_NAME: &str = "col_bool";
+    const TIME_COL_NAME: &str = "time";
 
-    fn create_write_batch_args(
+    fn data_blocks_to_write_batch_args(
         data_blocks: &[DataBlock],
         timestamps: &mut Vec<Timestamp>,
         fields: &mut Vec<Vec<(&str, Vec<u8>)>>,
@@ -713,13 +671,15 @@ mod test {
         });
     }
 
-    fn create_write_batch(
+    async fn do_write_batch(
+        engine: &TsKv,
+        vnode_id: TseriesFamilyId,
         timestamps: Vec<i64>,
         tenant: &str,
         database: &str,
         table: &str,
         rows: Vec<Vec<(&str, Vec<u8>)>>,
-    ) -> WritePointsRequest {
+    ) {
         let mut fbb = flatbuffers::FlatBufferBuilder::new();
 
         let db = fbb.create_vector(database.as_bytes());
@@ -796,7 +756,7 @@ mod test {
         );
         fbb.finish(points, None);
         let points = fbb.finished_data().to_vec();
-        WritePointsRequest {
+        let write_batch = WritePointsRequest {
             version: 1,
             meta: Some(Meta {
                 tenant: tenant.to_string(),
@@ -804,22 +764,26 @@ mod test {
                 password: None,
             }),
             points,
-        }
+        };
+        let points = flatbuffers::root::<fb_models::Points>(&write_batch.points).unwrap();
+        models_helper::print_points(points);
+        engine
+            .write(vnode_id, Precision::NS, write_batch)
+            .await
+            .unwrap();
     }
 
     fn data_block_to_hash_tree(
         data_block: &DataBlock,
-        time_range_nanosec: i64,
+        duration_nanosecs: i64,
     ) -> Vec<(TimeRange, Hash)> {
-        let time_range = Duration::nanoseconds(time_range_nanosec);
         let mut tr_hashes: Vec<(TimeRange, Hash)> = Vec::new();
         let mut hasher = Hasher::new();
 
         if let Some(blk_time_range) = data_block.time_range() {
             // Get trunced time range by DataBlock.time[0]
             let (min_ts, max_ts) =
-                calc_block_partial_time_range(blk_time_range.0, time_range, time_range_nanosec)
-                    .unwrap();
+                calc_block_partial_time_range(blk_time_range.0, duration_nanosecs).unwrap();
 
             // Calculate and store the hash value of data in time range
             if blk_time_range.1 > max_ts {
@@ -839,40 +803,162 @@ mod test {
         }
 
         tr_hashes
-            .into_iter()
-            .map(|(tr, hash)| {
-                let mut hasher = Hasher::new();
-                hasher.update(&hash);
-                (tr, hasher.finalize().into())
-            })
-            .collect()
     }
 
     fn check_hash_tree_node(
         col_values: &[TimeRangeHashTreeNode],
         cmp_values: &[(TimeRange, Hash)],
-        col_name: &str,
+        column_name: &str,
     ) {
         assert_eq!(col_values.len(), cmp_values.len());
         for (a, b) in col_values.iter().zip(cmp_values.iter()) {
-            assert_eq!(a.min_ts, b.0.min_ts, "Col '{}' min_ts compare", col_name);
-            assert_eq!(a.max_ts, b.0.max_ts, "Col '{}' max_ts compare", col_name);
-            assert_eq!(a.hash, b.1, "Col '{}' hash compare", col_name);
+            assert_eq!(a.min_ts, b.0.min_ts, "col '{}' min_ts compare", column_name);
+            assert_eq!(a.max_ts, b.0.max_ts, "col '{}' max_ts compare", column_name);
+            assert_eq!(a.hash, b.1, "col '{}' hash compare", column_name);
+        }
+    }
+
+    async fn init_meta(
+        config: &Config,
+        tenant: &str,
+    ) -> (Arc<dyn MetaManager>, Arc<dyn MetaClient>) {
+        let meta: Arc<dyn MetaManager> =
+            RemoteMetaManager::new(config.clone(), config.storage.path.clone()).await;
+
+        meta.admin_meta().add_data_node().await.unwrap();
+        let _ = meta
+            .tenant_manager()
+            .create_tenant(tenant.to_string(), TenantOptions::default())
+            .await;
+        let meta_client = meta.tenant_manager().tenant_meta(tenant).await.unwrap();
+
+        (meta, meta_client)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn init_tskv(
+        options: &Options,
+        runtime: Arc<Runtime>,
+        meta_manager: Arc<dyn MetaManager>,
+        meta_client: Arc<dyn MetaClient>,
+        vnode_id: TseriesFamilyId,
+        tenant: &str,
+        database: &str,
+        table: &str,
+        columns: Vec<TableColumn>,
+    ) -> TsKv {
+        let engine = TsKv::open(
+            meta_manager,
+            options.clone(),
+            runtime.clone(),
+            Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024)),
+            Arc::new(MetricsRegister::default()),
+        )
+        .await
+        .unwrap();
+        let _ = engine.drop_database(tenant, database).await;
+        let _ = meta_client
+            .drop_db(make_owner(tenant, database).as_str())
+            .await;
+
+        // Create database and vnode
+        let mut database_schema = DatabaseSchema::new(tenant, database);
+        database_schema
+            .config
+            .with_ttl(DatabaseOptions::DEFAULT_TTL);
+        meta_client
+            .create_db(database_schema.clone())
+            .await
+            .unwrap();
+        meta_client
+            .create_table(&TableSchema::TsKvTableSchema(
+                TskvTableSchema::new(
+                    tenant.to_string(),
+                    database.to_string(),
+                    table.to_string(),
+                    columns,
+                )
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let db = engine
+            .get_db_or_else_create(tenant, database)
+            .await
+            .unwrap();
+        let mut db = db.write().await;
+        let tsf = db
+            .add_tsfamily(
+                vnode_id,
+                1,
+                None,
+                engine.summary_task_sender(),
+                engine.flush_task_sender(),
+                engine.compact_task_sender(),
+                Arc::new(GlobalContext::new()),
+            )
+            .await
+            .unwrap();
+        let tsf = tsf.read().await;
+        assert_eq!(vnode_id, tsf.tf_id());
+
+        engine
+    }
+
+    #[rustfmt::skip]
+    async fn write_tskv(
+        engine: &TsKv,
+        vnode: Arc<RwLock<TseriesFamily>>,
+        tenant: &str,
+        database: &str,
+        table: &str,
+        data_blocks: &[DataBlock],
+    ) {
+        let vnode_id = vnode.read().await.tf_id();
+        // Write data to database and vnode
+        let mut timestamps: Vec<Timestamp> = Vec::new();
+        let mut fields: Vec<Vec<(&str, Vec<u8>)>> = Vec::new();
+        data_blocks_to_write_batch_args(data_blocks, &mut timestamps, &mut fields);
+        do_write_batch(engine, vnode_id, timestamps, tenant, database, table, fields).await;
+
+        let flush_req = {
+            let mut vnode = vnode.write().await;
+            vnode.switch_to_immutable();
+            vnode.build_flush_req(true).unwrap()
+        };
+        flush::run_flush_memtable_job(
+            flush_req, engine.global_ctx(), engine.global_sql_ctx(),
+            engine.version_set(), engine.summary_task_sender(), None,
+        ).await.unwrap();
+
+        let sec_1 = Duration::seconds(1).to_std().unwrap();
+        let mut check_num = 0;
+        loop {
+            tokio::time::sleep(sec_1).await;
+            // If flushing is finished, the newest super_version contains a level 1 file.
+            let vnode = vnode.read().await;
+            let super_version = vnode.super_version();
+            if !super_version.version.levels_info[1].files.is_empty() {
+                break;
+            }
+            check_num += 1;
+            if check_num >= 10 {
+                println!("Checksum: warn: flushing takes more than {} seconds.", check_num);
+            }
         }
     }
 
     #[test]
-    fn test_get_ts_family_hash_tree() {
+    fn test_get_vnode_hash_tree() {
         let base_dir = "/tmp/test/repair/1".to_string();
         let wal_dir = "/tmp/test/repair/1/wal".to_string();
         let log_dir = "/tmp/test/repair/1/log".to_string();
-        trace::init_default_global_tracing(&log_dir, "test.log", "debug");
+        // trace::init_default_global_tracing(&log_dir, "test.log", "debug");
         let _ = std::fs::remove_dir(&base_dir);
         let tenant_name = "cnosdb".to_string();
-        let database_name = "test_get_ts_family_hash_tree".to_string();
-        let ts_family_id: TseriesFamilyId = 1;
+        let database_name = "test_get_vnode_hash_tree".to_string();
+        let vnode_id: TseriesFamilyId = 1;
         let table_name = "test_table".to_string();
-        let sec_1 = Duration::seconds(1).to_std().unwrap();
 
         let timestamps = vec![
             parse_nanos("2023-01-01 00:01:00"),
@@ -883,7 +969,7 @@ mod test {
             parse_nanos("2023-02-01 00:03:00"),
         ];
         #[rustfmt::skip]
-            let data_blocks = vec![
+        let data_blocks = vec![
             DataBlock::U64 { ts: timestamps.clone(), val: vec![1, 2, 3, 4, 5, 6], enc: DataBlockEncoding::default() },
             DataBlock::I64 { ts: timestamps.clone(), val: vec![1, 2, 3, 4, 5, 6], enc: DataBlockEncoding::default() },
             DataBlock::F64 { ts: timestamps.clone(), val: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], enc: DataBlockEncoding::default() },
@@ -896,14 +982,21 @@ mod test {
             },
             DataBlock::Bool { ts: timestamps, val: vec![true, false, true, false, true, false], enc: DataBlockEncoding::default() },
         ];
+        let data_block_tr_hashes = vec![
+            data_block_to_hash_tree(&data_blocks[0], DEFAULT_DURATION),
+            data_block_to_hash_tree(&data_blocks[1], DEFAULT_DURATION),
+            data_block_to_hash_tree(&data_blocks[2], DEFAULT_DURATION),
+            data_block_to_hash_tree(&data_blocks[3], DEFAULT_DURATION),
+            data_block_to_hash_tree(&data_blocks[4], DEFAULT_DURATION),
+        ];
         #[rustfmt::skip]
-            let columns = vec![
-            TableColumn::new(0, TIME_COL_NAME.to_string(), ColumnType::Time(TimeUnit::Nanosecond), Default::default()),
-            TableColumn::new(1, U64_COL_NAME.to_string(), ColumnType::Field(ValueType::Unsigned), Default::default()),
-            TableColumn::new(2, I64_COL_NAME.to_string(), ColumnType::Field(ValueType::Integer), Default::default()),
-            TableColumn::new(3, F64_COL_NAME.to_string(), ColumnType::Field(ValueType::Float), Default::default()),
-            TableColumn::new(4, STR_COL_NAME.to_string(), ColumnType::Field(ValueType::String), Default::default()),
-            TableColumn::new(5, BOOL_COL_NAME.to_string(), ColumnType::Field(ValueType::Boolean), Default::default()),
+        let columns = vec![
+            TableColumn::new(0, U64_COL_NAME.to_string(), ColumnType::Field(ValueType::Unsigned), Default::default()),
+            TableColumn::new(1, I64_COL_NAME.to_string(), ColumnType::Field(ValueType::Integer), Default::default()),
+            TableColumn::new(2, F64_COL_NAME.to_string(), ColumnType::Field(ValueType::Float), Default::default()),
+            TableColumn::new(3, STR_COL_NAME.to_string(), ColumnType::Field(ValueType::String), Default::default()),
+            TableColumn::new(4, BOOL_COL_NAME.to_string(), ColumnType::Field(ValueType::Boolean), Default::default()),
+            TableColumn::new(5, TIME_COL_NAME.to_string(), ColumnType::Time(TimeUnit::Nanosecond), Default::default()),
         ];
 
         let mut config = config::get_config_for_test();
@@ -911,7 +1004,7 @@ mod test {
         config.wal.path = wal_dir;
         config.wal.sync = true;
         config.log.path = log_dir;
-        let opt = Options::from(&config);
+        let options = Options::from(&config);
 
         let rt = Arc::new(
             runtime::Builder::new_multi_thread()
@@ -919,181 +1012,54 @@ mod test {
                 .build()
                 .unwrap(),
         );
-        let (meta, meta_client) = rt.block_on(async {
-            let meta: MetaRef =
-                RemoteMetaManager::new(config.clone(), config.storage.path.clone()).await;
-
-            meta.admin_meta().add_data_node().await.unwrap();
-            let _ = meta
-                .tenant_manager()
-                .create_tenant(tenant_name.clone(), TenantOptions::default())
-                .await;
-            let meta_client = meta
-                .tenant_manager()
-                .tenant_meta(&tenant_name)
-                .await
-                .unwrap();
-            let _ = meta_client.drop_db(&database_name).await;
-
-            (meta, meta_client)
-        });
-
-        let engine = rt.block_on(async {
-            let engine = TsKv::open(
-                meta,
-                opt,
-                rt.clone(),
-                Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024)),
-                Arc::new(MetricsRegister::default()),
-            )
-            .await
-            .unwrap();
-            let _ = engine.drop_database(&tenant_name, &database_name).await;
-            engine
-        });
-
-        // Create database and ts_family
-        rt.block_on(async {
-            let mut database_schema = DatabaseSchema::new(&tenant_name, &database_name);
-            database_schema
-                .config
-                .with_ttl(DatabaseOptions::DEFAULT_TTL);
-            meta_client
-                .create_db(database_schema.clone())
-                .await
-                .unwrap();
-            meta_client
-                .create_table(&TableSchema::TsKvTableSchema(
-                    TskvTableSchema::new(
-                        tenant_name.clone(),
-                        database_name.clone(),
-                        table_name.clone(),
-                        columns,
-                    )
-                    .into(),
-                ))
-                .await
-                .unwrap();
-            let db = engine
-                .get_db_or_else_create(&tenant_name, &database_name)
-                .await
-                .unwrap();
-            let mut db = db.write().await;
-            let cxt = Arc::new(GlobalContext::new());
-            let tsf = db
-                .add_tsfamily(
-                    ts_family_id,
-                    1,
-                    None,
-                    engine.summary_task_sender(),
-                    engine.flush_task_sender(),
-                    engine.compact_task_sender(),
-                    cxt.clone(),
-                )
-                .await
-                .unwrap();
-            let tsf = tsf.read().await;
-            assert_eq!(1, tsf.tf_id());
-        });
+        let (meta_manager, meta_client) = rt.block_on(init_meta(&config, &tenant_name));
+        let engine = rt.block_on(init_tskv(
+            &options,
+            rt.clone(),
+            meta_manager.clone(),
+            meta_client.clone(),
+            vnode_id,
+            &tenant_name,
+            &database_name,
+            &table_name,
+            columns.clone(),
+        ));
 
         rt.block_on(async {
-            // Get created database and ts_family
+            // Get created database and vnode
             let database_ref = engine
                 .get_db(&tenant_name, &database_name)
                 .await
                 .unwrap_or_else(|e| {
                     panic!("created database '{}' exists: {:?}", &database_name, e)
                 });
-            let schemas = database_ref.read().await.get_schemas();
-            let time_range_nanosec = default_time_range(schemas.clone()).unwrap();
-            let ts_family_ref = database_ref
+            let vnode_ref = database_ref
                 .read()
                 .await
-                .get_tsfamily(ts_family_id)
+                .get_tsfamily(vnode_id)
                 .unwrap_or_else(|| {
-                    panic!("created ts_family '{}' not exist", ts_family_id);
+                    panic!("created vnode '{}' not exist", vnode_id);
                 });
-
-            // Write data to database and ts_family
-            let mut timestamps: Vec<Timestamp> = Vec::new();
-            let mut fields: Vec<Vec<(&str, Vec<u8>)>> = Vec::new();
-            create_write_batch_args(&data_blocks, &mut timestamps, &mut fields);
-            let write_batch = create_write_batch(
-                timestamps,
+            write_tskv(
+                &engine,
+                vnode_ref.clone(),
                 &tenant_name,
                 &database_name,
                 &table_name,
-                fields,
-            );
-            let points = flatbuffers::root::<fb_models::Points>(&write_batch.points).unwrap();
-            models_helper::print_points(points);
-            engine
-                .write(ts_family_id, Precision::NS, write_batch)
-                .await
-                .unwrap();
-
-            let mut ts_family_wlock = ts_family_ref.write().await;
-            ts_family_wlock.switch_to_immutable();
-            ts_family_wlock.send_flush_req(true).await;
-            drop(ts_family_wlock);
-
-            let mut check_num = 0;
-            loop {
-                tokio::time::sleep(sec_1).await;
-                // If flushing is finished, the newest super_version contains no immut_cache.
-                if ts_family_ref
-                    .read()
-                    .await
-                    .super_version()
-                    .caches
-                    .immut_cache
-                    .is_empty()
-                {
-                    break;
-                }
-                check_num += 1;
-                if check_num >= 10 {
-                    println!(
-                        "Repair: warn: flushing takes more than {} seconds.",
-                        check_num
-                    );
-                }
-            }
+                &data_blocks,
+            )
+            .await;
 
             // Get hash values and check them.
-            let trees = ts_family_hash_tree(ts_family_ref, schemas).await.unwrap();
-            assert_eq!(trees.len(), 1);
-            assert_eq!(trees[0].table, table_name);
-            assert_eq!(trees[0].columns.len(), 5);
-            for col in trees[0].columns.iter() {
-                match col.column.as_str() {
-                    U64_COL_NAME => {
-                        let col_u64_hashes =
-                            data_block_to_hash_tree(&data_blocks[0], time_range_nanosec);
-                        check_hash_tree_node(&col.values, &col_u64_hashes, col.column.as_str());
-                    }
-                    I64_COL_NAME => {
-                        let col_i64_hashes =
-                            data_block_to_hash_tree(&data_blocks[1], time_range_nanosec);
-                        check_hash_tree_node(&col.values, &col_i64_hashes, col.column.as_str());
-                    }
-                    F64_COL_NAME => {
-                        let col_f64_hashes =
-                            data_block_to_hash_tree(&data_blocks[2], time_range_nanosec);
-                        check_hash_tree_node(&col.values, &col_f64_hashes, col.column.as_str());
-                    }
-                    STR_COL_NAME => {
-                        let col_str_hashes =
-                            data_block_to_hash_tree(&data_blocks[3], time_range_nanosec);
-                        check_hash_tree_node(&col.values, &col_str_hashes, col.column.as_str());
-                    }
-                    BOOL_COL_NAME => {
-                        let col_bool_hashes =
-                            data_block_to_hash_tree(&data_blocks[4], time_range_nanosec);
-                        check_hash_tree_node(&col.values, &col_bool_hashes, col.column.as_str());
-                    }
-                    _ => {}
-                }
+            let tree_root = vnode_hash_tree(vnode_ref).await.unwrap();
+            assert_eq!(tree_root.len(), 10);
+            assert_eq!(tree_root.vnode_id, vnode_id);
+            assert_eq!(tree_root.fields.len(), 5);
+            for field in tree_root.fields.iter() {
+                let (cid, _) = field.column_series();
+                let col_tr_hashes = &data_block_tr_hashes[cid as usize];
+                let col_name = &columns[cid as usize].name;
+                check_hash_tree_node(&field.time_ranges, col_tr_hashes, col_name);
             }
 
             engine.close().await;

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -19,7 +19,7 @@ use tokio::sync::{oneshot, RwLock};
 use trace::{debug, error, info};
 use utils::BloomFilter;
 
-use crate::compaction::{check, CompactTask, FlushReq};
+use crate::compaction::{CompactTask, FlushReq};
 use crate::context::GlobalContext;
 use crate::error::{self, Result, SchemaSnafu};
 use crate::index::{self, IndexResult};
@@ -495,13 +495,6 @@ impl Database {
 
     pub fn get_schema(&self) -> Result<DatabaseSchema> {
         Ok(self.schemas.db_schema()?)
-    }
-
-    pub async fn get_ts_family_hash_tree(
-        &self,
-        ts_family_id: TseriesFamilyId,
-    ) -> Result<Vec<check::TableHashTreeNode>> {
-        check::get_ts_family_hash_tree(self, ts_family_id).await
     }
 
     pub fn owner(&self) -> Arc<String> {

--- a/tskv/src/engine_mock.rs
+++ b/tskv/src/engine_mock.rs
@@ -4,6 +4,8 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use datafusion::arrow::record_batch::RecordBatch;
+use models::meta_data::VnodeId;
 use models::predicate::domain::{ColumnDomains, TimeRange};
 use models::schema::{Precision, TableColumn};
 use models::{ColumnId, SeriesId, SeriesKey};
@@ -190,6 +192,10 @@ impl Engine for MockEngine {
     }
 
     async fn compact(&self, vnode_ids: Vec<TseriesFamilyId>) -> Result<()> {
+        todo!()
+    }
+
+    async fn get_vnode_hash_tree(&self, vnode_ids: VnodeId) -> Result<RecordBatch> {
         todo!()
     }
 

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -982,7 +982,6 @@ impl Engine for TsKv {
         for database in self.version_set.read().await.get_all_db().values() {
             let db = database.read().await;
             if let Some(vnode) = db.ts_families().get(&vnode_id).cloned() {
-                let schemas = db.get_schemas();
                 drop(db);
                 let request = {
                     let mut tsfamily = vnode.write().await;
@@ -1002,11 +1001,11 @@ impl Engine for TsKv {
                     )
                     .await?
                 }
-                return check::vnode_checksum(vnode, schemas).await;
+                return check::vnode_checksum(vnode).await;
             }
         }
 
-        Ok(RecordBatch::new_empty(check::vnode_checksum_schema()))
+        Ok(RecordBatch::new_empty(check::vnode_table_checksum_schema()))
     }
 
     async fn close(&self) {
@@ -1023,6 +1022,18 @@ impl Engine for TsKv {
 
 #[cfg(test)]
 impl TsKv {
+    pub(crate) fn global_ctx(&self) -> Arc<GlobalContext> {
+        self.global_ctx.clone()
+    }
+
+    pub(crate) fn global_sql_ctx(&self) -> Arc<GlobalSequenceContext> {
+        self.global_seq_ctx.clone()
+    }
+
+    pub(crate) fn version_set(&self) -> Arc<RwLock<VersionSet>> {
+        self.version_set.clone()
+    }
+
     pub(crate) fn summary_task_sender(&self) -> Sender<SummaryTask> {
         self.summary_task_sender.clone()
     }

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -3,11 +3,12 @@ use std::panic;
 use std::sync::Arc;
 use std::time::Duration;
 
+use datafusion::arrow::record_batch::RecordBatch;
 use memory_pool::{MemoryPool, MemoryPoolRef};
 use meta::model::MetaRef;
 use metrics::metric_register::MetricsRegister;
 use models::codec::Encoding;
-use models::meta_data::VnodeStatus;
+use models::meta_data::{VnodeId, VnodeStatus};
 use models::predicate::domain::{ColumnDomains, TimeRange};
 use models::schema::{make_owner, DatabaseSchema, Precision, TableColumn};
 use models::utils::unite_id;
@@ -22,7 +23,7 @@ use tokio::sync::{oneshot, RwLock};
 use trace::{debug, error, info, warn};
 
 use crate::compaction::{
-    self, run_flush_memtable_job, CompactTask, FlushReq, LevelCompactionPicker, Picker,
+    self, check, run_flush_memtable_job, CompactTask, FlushReq, LevelCompactionPicker, Picker,
 };
 use crate::context::{self, GlobalContext, GlobalSequenceContext, GlobalSequenceTask};
 use crate::database::Database;
@@ -302,6 +303,7 @@ impl TsKv {
         let f = async move {
             while let Some(x) = receiver.recv().await {
                 // TODO(zipper): this make config `flush_req_channel_cap` wasted
+                // Run flush job and trigger compaction.
                 runtime.spawn(run_flush_memtable_job(
                     x,
                     ctx.clone(),
@@ -625,6 +627,7 @@ impl Engine for TsKv {
                 };
 
                 if let Some(req) = request {
+                    // Run flush job and trigger compaction.
                     run_flush_memtable_job(
                         req,
                         self.global_ctx.clone(),
@@ -633,8 +636,7 @@ impl Engine for TsKv {
                         self.summary_task_sender.clone(),
                         Some(self.compact_task_sender.clone()),
                     )
-                    .await
-                    .unwrap()
+                    .await?;
                 }
             }
 
@@ -929,6 +931,7 @@ impl Engine for TsKv {
                 let flush_req = tsf_wlock.build_flush_req(true);
                 drop(tsf_wlock);
                 if let Some(req) = flush_req {
+                    // Run flush job but do not trigger compaction.
                     if let Err(e) = run_flush_memtable_job(
                         req,
                         self.global_ctx.clone(),
@@ -973,6 +976,37 @@ impl Engine for TsKv {
         }
 
         Ok(())
+    }
+
+    async fn get_vnode_hash_tree(&self, vnode_id: VnodeId) -> Result<RecordBatch> {
+        for database in self.version_set.read().await.get_all_db().values() {
+            let db = database.read().await;
+            if let Some(vnode) = db.ts_families().get(&vnode_id).cloned() {
+                let schemas = db.get_schemas();
+                drop(db);
+                let request = {
+                    let mut tsfamily = vnode.write().await;
+                    tsfamily.switch_to_immutable();
+                    tsfamily.build_flush_req(true)
+                };
+
+                if let Some(req) = request {
+                    // Run flush job but do not trigger compaction.
+                    run_flush_memtable_job(
+                        req,
+                        self.global_ctx.clone(),
+                        self.global_seq_ctx.clone(),
+                        self.version_set.clone(),
+                        self.summary_task_sender.clone(),
+                        None,
+                    )
+                    .await?
+                }
+                return check::vnode_checksum(vnode, schemas).await;
+            }
+        }
+
+        Ok(RecordBatch::new_empty(check::vnode_checksum_schema()))
     }
 
     async fn close(&self) {

--- a/tskv/src/lib.rs
+++ b/tskv/src/lib.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-pub use compaction::check::vnode_checksum_schema;
+pub use compaction::check::vnode_table_checksum_schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use models::meta_data::VnodeId;
 use models::predicate::domain::{ColumnDomains, TimeRange};

--- a/tskv/src/lib.rs
+++ b/tskv/src/lib.rs
@@ -5,20 +5,22 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-pub use error::{Error, Result};
-pub use kv_option::Options;
-pub use kvcore::TsKv;
+pub use compaction::check::vnode_checksum_schema;
+use datafusion::arrow::record_batch::RecordBatch;
 use models::meta_data::VnodeId;
 use models::predicate::domain::{ColumnDomains, TimeRange};
 use models::schema::{Precision, TableColumn};
 use models::{ColumnId, SeriesId, SeriesKey};
 use protos::kv_service::{WritePointsRequest, WritePointsResponse};
-pub use summary::{print_summary_statistics, Summary, VersionEdit};
-pub use tsm::print_tsm_statistics;
-pub use wal::print_wal_statistics;
 
+pub use crate::error::{Error, Result};
+pub use crate::kv_option::Options;
 use crate::kv_option::StorageOptions;
+pub use crate::kvcore::TsKv;
+pub use crate::summary::{print_summary_statistics, Summary, VersionEdit};
 use crate::tseries_family::SuperVersion;
+pub use crate::tsm::print_tsm_statistics;
+pub use crate::wal::print_wal_statistics;
 
 pub mod byte_utils;
 mod compaction;
@@ -159,6 +161,8 @@ pub trait Engine: Send + Sync + Debug {
     async fn drop_vnode(&self, id: TseriesFamilyId) -> Result<()>;
 
     async fn compact(&self, vnode_ids: Vec<TseriesFamilyId>) -> Result<()>;
+
+    async fn get_vnode_hash_tree(&self, vnode_id: VnodeId) -> Result<RecordBatch>;
 
     async fn close(&self);
 }

--- a/tskv/src/memcache.rs
+++ b/tskv/src/memcache.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::iter::FromIterator;
 use std::mem::size_of_val;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -578,13 +577,40 @@ impl DataType {
         }
     }
 
+    #[cfg(test)]
     pub fn to_bytes(&self) -> MiniVec<u8> {
         match self {
-            DataType::U64(_, val) => MiniVec::from_iter(val.to_be_bytes()),
-            DataType::I64(_, val) => MiniVec::from_iter(val.to_be_bytes()),
-            DataType::F64(_, val) => MiniVec::from_iter(val.to_be_bytes()),
-            DataType::Str(_, val) => val.clone(),
-            DataType::Bool(_, val) => MiniVec::from_iter(if *val { [1_u8] } else { [0_u8] }),
+            DataType::U64(t, val) => {
+                let mut buf = mini_vec![0; 16];
+                buf[0..8].copy_from_slice(t.to_be_bytes().as_slice());
+                buf[8..16].copy_from_slice(val.to_be_bytes().as_slice());
+                buf
+            }
+            DataType::I64(t, val) => {
+                let mut buf = mini_vec![0; 16];
+                buf[0..8].copy_from_slice(t.to_be_bytes().as_slice());
+                buf[8..16].copy_from_slice(val.to_be_bytes().as_slice());
+                buf
+            }
+            DataType::F64(t, val) => {
+                let mut buf = mini_vec![0; 16];
+                buf[0..8].copy_from_slice(t.to_be_bytes().as_slice());
+                buf[8..16].copy_from_slice(val.to_be_bytes().as_slice());
+                buf
+            }
+            DataType::Str(t, val) => {
+                let buf_len = 8 + val.len();
+                let mut buf = mini_vec![0; buf_len];
+                buf[0..8].copy_from_slice(t.to_be_bytes().as_slice());
+                buf[8..buf_len].copy_from_slice(val);
+                buf
+            }
+            DataType::Bool(t, val) => {
+                let mut buf = mini_vec![0; 9];
+                buf[0..8].copy_from_slice(t.to_be_bytes().as_slice());
+                buf[8] = if *val { 1_u8 } else { 0_u8 };
+                buf
+            }
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

This PR implements admin query statement `CHECKSUM GROUP <replication_set_id>`.

Feature group in #806 .

# Rationale for this change

Add a command to print the root level check sum (formatted `[u8; 32]`) of Vnodes in  a replication set.

```
public ❯ create database dba with replica 2;
public ❯ \c dba
dba ❯ create table ma(fa double, tags(ta));
dba ❯ create table mb(fb double, tags(tb));
dba ❯ insert into ma(time,ta,fa) values('2023-05-01 00:00:00', 'a1', 1);
dba ❯ insert into ma(time,ta,fa) values('2024-05-01 00:00:00', 'a1', 1);
dba ❯ insert into mb(time,tb,fb) values('2023-05-01 00:00:00', 'a1', 1);
dba ❯ insert into mb(time,tb,fb) values('2024-05-01 00:00:00', 'a1', 1);
dba ❯ checksum group 9;
+----------+------------------------------------------------------------------+
| VNODE_ID | CHECK_SUM                                                        |
+----------+------------------------------------------------------------------+
| 10       | 52ff3f3e2178b3daeb437f5ba18f68444525dbf28ebe719b256b7547fafa3785 |
| 11       | 52ff3f3e2178b3daeb437f5ba18f68444525dbf28ebe719b256b7547fafa3785 |
+----------+------------------------------------------------------------------+
dba ❯ checksum group 5;
+----------+------------------------------------------------------------------+
| VNODE_ID | CHECK_SUM                                                        |
+----------+------------------------------------------------------------------+
| 6        | 5eabc794643ade16f5adc345a0c55e1a8777985eeea0bdbe4bbcc92baac34f9f |
| 7        | 5eabc794643ade16f5adc345a0c55e1a8777985eeea0bdbe4bbcc92baac34f9f |
+----------+------------------------------------------------------------------+
```

# What changes are included in this PR?

## Protobuf

- Add `AdminFetchCommandRequest` to fetch something using admin privilege.
  - Add inner fetch command `FetchVnodeChecksumRequest` to fetch vnode checksum.

## Coordinator

- While method `vnode_manager()` is only for sending manage commands without a meaningful response, added method `vnode_summarizer()` is for summarizing Vnode information with a byte array response, such as `checksum`.

# Are there any user-facing changes?
