### PR TITLE
fix move vnode

### DIFF
--- a/common/models/src/meta_data.rs
+++ b/common/models/src/meta_data.rs
@@ -94,7 +94,7 @@ impl BucketInfo {
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct ReplicationSet {
     pub id: ReplicationSetId,
-    pub vnode_list: Vec<VnodeInfo>,
+    pub vnodes: Vec<VnodeInfo>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
@@ -118,7 +118,7 @@ impl VnodeInfo {
 pub enum VnodeStatus {
     #[default]
     Running,
-    Moving,
+    Copying,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
@@ -293,12 +293,15 @@ pub fn allocation_replication_set(
     for _ in 0..shards {
         let mut repl_set = ReplicationSet {
             id: incr_id,
-            vnode_list: vec![],
+            vnodes: vec![],
         };
         incr_id += 1;
 
         for _ in 0..replica {
-            repl_set.vnode_list.push(VnodeInfo::new(incr_id, nodes.get((index % node_count) as usize).unwrap().id));
+            repl_set.vnodes.push(VnodeInfo::new(
+                incr_id,
+                nodes.get((index % node_count) as usize).unwrap().id,
+            ));
             incr_id += 1;
             index += 1;
         }

--- a/common/models/src/node_info.rs
+++ b/common/models/src/node_info.rs
@@ -21,13 +21,13 @@ pub struct Node {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone)]
-
 pub enum NodeStatus {
     #[default]
     Healthy,
     Broken,
     Unreachable,
     NoDiskSpace,
+    Cordon,
 }
 
 #[allow(dead_code)]
@@ -40,7 +40,10 @@ pub struct Location {
 
 #[allow(dead_code)]
 pub struct Flavor {
-    memory: f64, // M
-    cpu: f64,    // core
-    disk: f64,   // G
+    // M
+    memory: f64,
+    // core
+    cpu: f64,
+    // G
+    disk: f64,
 }

--- a/coordinator/src/reader/query_executor.rs
+++ b/coordinator/src/reader/query_executor.rs
@@ -441,12 +441,12 @@ impl QueryExecutor {
         )?;
         for bucket in buckets.iter() {
             for repl in bucket.shard_group.iter() {
-                if repl.vnodes.is_empty() {
+                if repl.vnode_list.is_empty() {
                     continue;
                 }
 
-                let random = now_timestamp_nanos() as usize % repl.vnodes.len();
-                let vnode = repl.vnodes[random].clone();
+                let random = now_timestamp_nanos() as usize % repl.vnode_list.len();
+                let vnode = repl.vnode_list[random].clone();
 
                 let list = vnode_mapping.entry(vnode.node_id).or_default();
                 list.push(vnode);
@@ -478,15 +478,15 @@ impl QueryExecutor {
                 .get_vnode_repl_set(item.id)
                 .ok_or(CoordinatorError::VnodeNotFound { id: item.id })?;
 
-            repl.vnodes.retain(|x| x.node_id != item.node_id);
-            if repl.vnodes.is_empty() {
+            repl.vnode_list.retain(|x| x.node_id != item.node_id);
+            if repl.vnode_list.is_empty() {
                 return Err(CoordinatorError::CommonError {
                     msg: format!("try map vnode:{} failed,not found replication", item.id),
                 });
             }
 
-            let random = now_timestamp_nanos() as usize % repl.vnodes.len();
-            let vnode = repl.vnodes[random].clone();
+            let random = now_timestamp_nanos() as usize % repl.vnode_list.len();
+            let vnode = repl.vnode_list[random].clone();
 
             let list = vnode_mapping.entry(vnode.node_id).or_default();
             list.push(vnode);

--- a/coordinator/src/reader/query_executor.rs
+++ b/coordinator/src/reader/query_executor.rs
@@ -441,12 +441,12 @@ impl QueryExecutor {
         )?;
         for bucket in buckets.iter() {
             for repl in bucket.shard_group.iter() {
-                if repl.vnode_list.is_empty() {
+                if repl.vnodes.is_empty() {
                     continue;
                 }
 
-                let random = now_timestamp_nanos() as usize % repl.vnode_list.len();
-                let vnode = repl.vnode_list[random].clone();
+                let random = now_timestamp_nanos() as usize % repl.vnodes.len();
+                let vnode = repl.vnodes[random].clone();
 
                 let list = vnode_mapping.entry(vnode.node_id).or_default();
                 list.push(vnode);
@@ -478,15 +478,15 @@ impl QueryExecutor {
                 .get_vnode_repl_set(item.id)
                 .ok_or(CoordinatorError::VnodeNotFound { id: item.id })?;
 
-            repl.vnode_list.retain(|x| x.node_id != item.node_id);
-            if repl.vnode_list.is_empty() {
+            repl.vnodes.retain(|x| x.node_id != item.node_id);
+            if repl.vnodes.is_empty() {
                 return Err(CoordinatorError::CommonError {
                     msg: format!("try map vnode:{} failed,not found replication", item.id),
                 });
             }
 
-            let random = now_timestamp_nanos() as usize % repl.vnode_list.len();
-            let vnode = repl.vnode_list[random].clone();
+            let random = now_timestamp_nanos() as usize % repl.vnodes.len();
+            let vnode = repl.vnodes[random].clone();
 
             let list = vnode_mapping.entry(vnode.node_id).or_default();
             list.push(vnode);

--- a/coordinator/src/service.rs
+++ b/coordinator/src/service.rs
@@ -165,7 +165,7 @@ impl CoordService {
 
     async fn delete_expired_bucket(&self, info: &ExpiredBucketInfo) -> CoordinatorResult<()> {
         for repl_set in info.bucket.shard_group.iter() {
-            for vnode in repl_set.vnode_list.iter() {
+            for vnode in repl_set.vnodes.iter() {
                 let cmd = AdminCommandRequest {
                     tenant: info.tenant.clone(),
                     command: Some(DelVnode(DeleteVnodeRequest {

--- a/coordinator/src/service.rs
+++ b/coordinator/src/service.rs
@@ -165,7 +165,7 @@ impl CoordService {
 
     async fn delete_expired_bucket(&self, info: &ExpiredBucketInfo) -> CoordinatorResult<()> {
         for repl_set in info.bucket.shard_group.iter() {
-            for vnode in repl_set.vnodes.iter() {
+            for vnode in repl_set.vnode_list.iter() {
                 let cmd = AdminCommandRequest {
                     tenant: info.tenant.clone(),
                     command: Some(DelVnode(DeleteVnodeRequest {

--- a/coordinator/src/writer.rs
+++ b/coordinator/src/writer.rs
@@ -348,14 +348,14 @@ impl PointWriter {
         let now = tokio::time::Instant::now();
         for (_id, points) in mapping.points.iter_mut() {
             points.finish()?;
-            if points.repl_set.vnode_list.is_empty() {
+            if points.repl_set.vnodes.is_empty() {
                 return Err(CoordinatorError::CommonError {
                     msg: "no available vnode in replication set".to_string(),
                 });
             }
-            for vnode in points.repl_set.vnode_list.iter() {
+            for vnode in points.repl_set.vnodes.iter() {
                 debug!("write points on vnode {:?},  now: {:?}", vnode, now);
-                if vnode.status == VnodeStatus::Moving {
+                if vnode.status == VnodeStatus::Copying {
                     return Err(CoordinatorError::CommonError {
                         msg: "vnode is moving write forbidden ".to_string(),
                     });

--- a/main/src/http/http_service.rs
+++ b/main/src/http/http_service.rs
@@ -47,7 +47,7 @@ use warp::{header, reject, Filter, Rejection, Reply};
 use super::header::Header;
 use super::Error as HttpError;
 use crate::http::metrics::HttpMetrics;
-use crate::http::response::{HttpRespone, ResponseBuilder};
+use crate::http::response::{HttpResponse, ResponseBuilder};
 use crate::http::result_format::{get_result_format_from_header, ResultFormat};
 use crate::http::QuerySnafu;
 use crate::server::ServiceHandle;
@@ -880,7 +880,7 @@ async fn sql_handle(
     debug!("prepare to execute: {:?}", query.content());
     let handle = dbms.execute(query).await?;
     let out = handle.result();
-    let resp = HttpRespone::new(out, fmt);
+    let resp = HttpResponse::new(out, fmt);
     if !query.context().chunked() {
         resp.wrap_batches_to_response().await
     } else {

--- a/main/src/http/response.rs
+++ b/main/src/http/response.rs
@@ -21,14 +21,14 @@ use super::Error as HttpError;
 
 #[derive(Default)]
 pub struct ResponseBuilder {
-    status_code: Option<StatusCode>,
+    status_code: StatusCode,
     headers: HeaderMap<HeaderValue>,
 }
 
 impl ResponseBuilder {
     pub fn new(status_code: StatusCode) -> Self {
         Self {
-            status_code: Some(status_code),
+            status_code,
             ..Default::default()
         }
     }
@@ -45,7 +45,7 @@ impl ResponseBuilder {
 
         *res.headers_mut() = self.headers;
 
-        *res.status_mut() = self.status_code.unwrap();
+        *res.status_mut() = self.status_code;
 
         res
     }
@@ -55,7 +55,7 @@ impl ResponseBuilder {
 
         *res.headers_mut() = self.headers;
 
-        *res.status_mut() = self.status_code.unwrap();
+        *res.status_mut() = self.status_code;
 
         res
     }
@@ -106,14 +106,14 @@ impl ResponseBuilder {
     }
 }
 
-pub struct HttpRespone {
+pub struct HttpResponse {
     result: Output,
     format: ResultFormat,
     done: bool,
     schema: Option<SchemaRef>,
 }
 
-impl HttpRespone {
+impl HttpResponse {
     pub fn new(result: Output, format: ResultFormat) -> Self {
         let schema = result.schema();
         Self {
@@ -135,7 +135,7 @@ impl HttpRespone {
     }
 }
 
-impl Stream for HttpRespone {
+impl Stream for HttpResponse {
     type Item = std::result::Result<Vec<u8>, HttpError>;
 
     fn poll_next(
@@ -185,7 +185,7 @@ impl Stream for HttpRespone {
     }
 }
 
-impl Reply for HttpRespone {
+impl Reply for HttpResponse {
     fn into_response(self) -> Response {
         let body = hyper::Body::wrap_stream(self);
         Response::new(body)

--- a/main/src/rpc/tskv.rs
+++ b/main/src/rpc/tskv.rs
@@ -448,7 +448,7 @@ impl TskvService for TskvServiceImpl {
 
         if let Err(err) = self
             .kv_inst
-            .prepare_move_vnode(&inner.tenant, &inner.db, inner.vnode_id)
+            .prepare_copy_vnode(&inner.tenant, &inner.db, inner.vnode_id)
             .await
         {
             return Err(tonic::Status::new(tonic::Code::Internal, err.to_string()));

--- a/main/src/rpc/tskv.rs
+++ b/main/src/rpc/tskv.rs
@@ -207,7 +207,7 @@ impl TskvServiceImpl {
         let node_id = meta.node_id();
         let mut vnodes = Vec::with_capacity(args.vnode_ids.len());
         for id in args.vnode_ids.iter() {
-            vnodes.push(VnodeInfo { id: *id, node_id })
+            vnodes.push(VnodeInfo::new(*id, node_id))
         }
 
         let executor = QueryExecutor::new(
@@ -253,7 +253,7 @@ impl TskvServiceImpl {
         let vnodes = args
             .vnode_ids
             .iter()
-            .map(|id| VnodeInfo { id: *id, node_id })
+            .map(|id| VnodeInfo::new(*id, node_id))
             .collect::<Vec<_>>();
 
         let executor = QueryExecutor::new(
@@ -448,7 +448,7 @@ impl TskvService for TskvServiceImpl {
 
         if let Err(err) = self
             .kv_inst
-            .flush_tsfamily(&inner.tenant, &inner.db, inner.vnode_id)
+            .prepare_move_vnode(&inner.tenant, &inner.db, inner.vnode_id)
             .await
         {
             return Err(tonic::Status::new(tonic::Code::Internal, err.to_string()));

--- a/meta/src/client.rs
+++ b/meta/src/client.rs
@@ -304,16 +304,10 @@ mod test {
             db_name,
             bucket_id: 8,
             repl_id: 9,
-            del_info: vec![VnodeInfo { id: 11, node_id: 0 }],
+            del_info: vec![VnodeInfo::new(11,0)],
             add_info: vec![
-                VnodeInfo {
-                    id: 333,
-                    node_id: 1333,
-                },
-                VnodeInfo {
-                    id: 444,
-                    node_id: 1444,
-                },
+                VnodeInfo::new(333, 1333),
+                VnodeInfo::new(444, 1444),
             ],
         };
 

--- a/meta/src/client.rs
+++ b/meta/src/client.rs
@@ -304,11 +304,8 @@ mod test {
             db_name,
             bucket_id: 8,
             repl_id: 9,
-            del_info: vec![VnodeInfo::new(11,0)],
-            add_info: vec![
-                VnodeInfo::new(333, 1333),
-                VnodeInfo::new(444, 1444),
-            ],
+            del_info: vec![VnodeInfo::new(11, 0)],
+            add_info: vec![VnodeInfo::new(333, 1333), VnodeInfo::new(444, 1444)],
         };
 
         let req = command::WriteCommand::UpdateVnodeReplSet(args);

--- a/meta/src/model/meta_client.rs
+++ b/meta/src/model/meta_client.rs
@@ -720,7 +720,7 @@ impl MetaClient for RemoteMetaClient {
         for (db_name, db_info) in data.dbs.iter() {
             for bucket in db_info.buckets.iter() {
                 for repl_set in bucket.shard_group.iter() {
-                    for vnode_info in repl_set.vnode_list.iter() {
+                    for vnode_info in repl_set.vnodes.iter() {
                         if vnode_info.id == id {
                             return Some(VnodeAllInfo {
                                 vnode_id: vnode_info.id,
@@ -748,7 +748,7 @@ impl MetaClient for RemoteMetaClient {
         for (_db_name, db_info) in data.dbs.iter() {
             for bucket in db_info.buckets.iter() {
                 for repl_set in bucket.shard_group.iter() {
-                    for vnode_info in repl_set.vnode_list.iter() {
+                    for vnode_info in repl_set.vnodes.iter() {
                         if vnode_info.id == id {
                             return Some(repl_set.clone());
                         }

--- a/meta/src/model/meta_client_mock.rs
+++ b/meta/src/model/meta_client_mock.rs
@@ -145,7 +145,7 @@ impl MetaClient for MockMetaClient {
         Some(0)
     }
 
-    async fn locate_replcation_set_for_write(
+    async fn locate_replication_set_for_write(
         &self,
         db: &str,
         hash_id: u64,
@@ -248,6 +248,10 @@ impl MetaClient for MockMetaClient {
 
     async fn version(&self) -> u64 {
         0
+    }
+
+    async fn update_vnode(&self, info: &VnodeAllInfo) -> MetaResult<()> {
+        Ok(())
     }
 
     fn get_vnode_all_info(&self, id: u32) -> Option<VnodeAllInfo> {

--- a/meta/src/model/mod.rs
+++ b/meta/src/model/mod.rs
@@ -130,7 +130,7 @@ pub trait MetaClient: Send + Sync + Debug {
 
     fn mapping_bucket(&self, db_name: &str, start: i64, end: i64) -> MetaResult<Vec<BucketInfo>>;
 
-    async fn locate_replcation_set_for_write(
+    async fn locate_replication_set_for_write(
         &self,
         db: &str,
         hash_id: u64,
@@ -151,6 +151,8 @@ pub trait MetaClient: Send + Sync + Debug {
     async fn process_watch_log(&self, entry: &EntryLog) -> MetaResult<()>;
 
     fn print_data(&self) -> String;
+
+    async fn update_vnode(&self, info: &VnodeAllInfo) -> MetaResult<()>;
 }
 
 #[async_trait]

--- a/meta/src/store/command.rs
+++ b/meta/src/store/command.rs
@@ -26,6 +26,12 @@ pub struct UpdateVnodeReplSetArgs {
     pub add_info: Vec<VnodeInfo>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UpdateVnodeArgs {
+    pub cluster: String,
+    pub vnode_info: VnodeAllInfo,
+}
+
 /******************* write command *************************/
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum WriteCommand {
@@ -34,6 +40,7 @@ pub enum WriteCommand {
 
     UpdateVnodeReplSet(UpdateVnodeReplSetArgs),
 
+    UpdateVnode(UpdateVnodeArgs),
     // cluster, node info
     AddDataNode(String, NodeInfo),
 
@@ -168,7 +175,7 @@ impl StatusResponse {
 
 impl ToString for StatusResponse {
     fn to_string(&self) -> String {
-        serde_json::to_string(&self).unwrap()
+        serde_json::to_string(&self).unwrap_or("".to_string())
     }
 }
 

--- a/meta/src/store/state_machine.rs
+++ b/meta/src/store/state_machine.rs
@@ -633,7 +633,7 @@ impl StateMachine {
             if set.id != args.vnode_info.repl_set_id {
                 continue;
             }
-            for vnode in set.vnode_list.iter_mut() {
+            for vnode in set.vnodes.iter_mut() {
                 if vnode.id == args.vnode_info.vnode_id {
                     vnode.status = args.vnode_info.status.clone();
                     break;
@@ -670,11 +670,11 @@ impl StateMachine {
             }
 
             for info in args.del_info.iter() {
-                set.vnode_list.retain(|item| item.id != info.id);
+                set.vnodes.retain(|item| item.id != info.id);
             }
 
             for info in args.add_info.iter() {
-                set.vnode_list.push(info.clone());
+                set.vnodes.push(info.clone());
             }
         }
 

--- a/query_server/query/src/sql/parser.rs
+++ b/query_server/query/src/sql/parser.rs
@@ -516,7 +516,7 @@ impl<'a> ExtParser<'a> {
         } else if self.parser.parse_keyword(Keyword::DATABASE) {
             self.parse_describe_database()
         } else {
-            self.expected("tables/databases", self.parser.peek_token())
+            self.expected("table/database", self.parser.peek_token())
         }
     }
 

--- a/tskv/src/compaction/check.rs
+++ b/tskv/src/compaction/check.rs
@@ -446,6 +446,7 @@ mod test {
 
     use super::{calc_block_partial_time_range, find_timestamp, hash_partial_datablock, Hash};
     use crate::compaction::check::{get_default_time_range, TimeRangeHashTreeNode};
+    use crate::context::GlobalContext;
     use crate::tsm::codec::DataBlockEncoding;
     use crate::tsm::DataBlock;
     use crate::{Engine, Options, TsKv, TseriesFamilyId};
@@ -925,6 +926,7 @@ mod test {
                 .await
                 .unwrap();
             let mut db = db.write().await;
+            let cxt = Arc::new(GlobalContext::new());
             let tsf = db
                 .add_tsfamily(
                     ts_family_id,
@@ -933,8 +935,10 @@ mod test {
                     engine.summary_task_sender(),
                     engine.flush_task_sender(),
                     engine.compact_task_sender(),
+                    cxt.clone(),
                 )
-                .await;
+                .await
+                .unwrap();
             let tsf = tsf.read().await;
             assert_eq!(1, tsf.tf_id());
         });

--- a/tskv/src/compaction/job.rs
+++ b/tskv/src/compaction/job.rs
@@ -43,7 +43,9 @@ pub fn run(
             if let Some(tsf) = ts_family {
                 info!("Starting compaction on ts_family {}", vnode_id);
                 let start = Instant::now();
-
+                if !tsf.read().await.is_can_compaction() {
+                    return;
+                }
                 let picker = LevelCompactionPicker::new(storage_opt.clone());
                 let version = tsf.read().await.version();
                 let compact_req = picker.pick_compaction(version);

--- a/tskv/src/compaction/job.rs
+++ b/tskv/src/compaction/job.rs
@@ -43,7 +43,8 @@ pub fn run(
             if let Some(tsf) = ts_family {
                 info!("Starting compaction on ts_family {}", vnode_id);
                 let start = Instant::now();
-                if !tsf.read().await.is_can_compaction() {
+                if !tsf.read().await.can_compaction() {
+                    info!("forbidden compaction on moving vnode {}", vnode_id);
                     return;
                 }
                 let picker = LevelCompactionPicker::new(storage_opt.clone());

--- a/tskv/src/engine_mock.rs
+++ b/tskv/src/engine_mock.rs
@@ -195,7 +195,7 @@ impl Engine for MockEngine {
 
     async fn close(&self) {}
 
-    async fn prepare_move_vnode(&self, tenant: &str, database: &str, vnode_id: u32) -> Result<()> {
+    async fn prepare_copy_vnode(&self, tenant: &str, database: &str, vnode_id: u32) -> Result<()> {
         todo!()
     }
 }

--- a/tskv/src/engine_mock.rs
+++ b/tskv/src/engine_mock.rs
@@ -194,4 +194,8 @@ impl Engine for MockEngine {
     }
 
     async fn close(&self) {}
+
+    async fn prepare_move_vnode(&self, tenant: &str, database: &str, vnode_id: u32) -> Result<()> {
+        todo!()
+    }
 }

--- a/tskv/src/kv_option.rs
+++ b/tskv/src/kv_option.rs
@@ -9,10 +9,11 @@ use config::Config;
 use crate::TseriesFamilyId;
 
 const SUMMARY_PATH: &str = "summary";
-const INDEX_PATH: &str = "index";
+pub const INDEX_PATH: &str = "index";
 const DATA_PATH: &str = "data";
-const TSM_PATH: &str = "tsm";
-const DELTA_PATH: &str = "delta";
+pub const TSM_PATH: &str = "tsm";
+pub const DELTA_PATH: &str = "delta";
+pub const MOVE_PATH: &str = "move";
 
 #[derive(Debug, Clone)]
 pub struct Options {
@@ -77,6 +78,12 @@ impl StorageOptions {
         self.database_dir(database)
             .join(ts_family_id.to_string())
             .join(TSM_PATH)
+    }
+
+    pub fn move_dir(&self, database: &str, ts_family_id: TseriesFamilyId) -> PathBuf {
+        self.database_dir(database)
+            .join(ts_family_id.to_string())
+            .join(MOVE_PATH)
     }
 
     pub fn delta_dir(&self, database: &str, ts_family_id: TseriesFamilyId) -> PathBuf {

--- a/tskv/src/lib.rs
+++ b/tskv/src/lib.rs
@@ -78,7 +78,7 @@ pub trait Engine: Send + Sync + Debug {
 
     async fn remove_tsfamily(&self, tenant: &str, database: &str, id: u32) -> Result<()>;
 
-    async fn prepare_move_vnode(&self, tenant: &str, database: &str, vnode_id: u32) -> Result<()>;
+    async fn prepare_copy_vnode(&self, tenant: &str, database: &str, vnode_id: u32) -> Result<()>;
     async fn flush_tsfamily(&self, tenant: &str, database: &str, id: u32) -> Result<()>;
 
     async fn add_table_column(

--- a/tskv/src/lib.rs
+++ b/tskv/src/lib.rs
@@ -78,6 +78,7 @@ pub trait Engine: Send + Sync + Debug {
 
     async fn remove_tsfamily(&self, tenant: &str, database: &str, id: u32) -> Result<()>;
 
+    async fn prepare_move_vnode(&self, tenant: &str, database: &str, vnode_id: u32) -> Result<()>;
     async fn flush_tsfamily(&self, tenant: &str, database: &str, id: u32) -> Result<()>;
 
     async fn add_table_column(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1151 #1160

# Rationale for this change

## Features

### Vnode status

Add `status: VnodeStatus` to `TseriesFamily`.

```rust
pub enum VnodeStatus {
    Running,
    Copying,
}
```

- `Running`: the default state.
- `Copying`: prevent vnode writing points and compaction.

Add `status: VnodeStatus` to `VnodeInfo` and `VnodeAllInfo`.

Add command `WriteCommand::UpdateVnode` in meta state machine, to change meta data `VnodeInfo::status`.

### Node status

Add `Cordon` to `NodeStatus`, now it doesn't works, we can ignore it.

### Transfer Vnode

#### 1. In mod coordinator

1. Generate new Vnode id.
2. Change vnode status in meta data `VnodeInfo` to `VnodeStatus::Copying`.
3. Transfer Vnode files to the destination node.
4. Fetch old Vnode summary.
5. Apply old Vnode summary to the destination node.
6. Change vnode status in meta data `VnodeInfo` to `VnodeStatus::Running`.

#### 2. In mod tskv

- For the **index** files, downlaod to `$database/$vnode/move/index`, then move to `$database/$vnode/index`.
- For the **delta** files, download to `$database/$vnode/move/delta`, then move to `$database/$vnode/delta`.
- For the **tsm** files, download to `$database/$vnode/move/tsm`, then move to `$database/$vnode/tsm.`

If an error occurs during file moving, stop the `MOVE VNODE`.

## Fixes

- Hints for statement  `DESCRIBE <object>` parsing received unexpected `<object>`, form `expected tables/databases` to `expected table/database`.
- Typos `locate_replcation_set_for_write` to `locate_replication_set_for_write`.

# Are there any user-facing changes?
