### PR TITLE
fix(server): remove tls support on grpc server

### DIFF
--- a/main/src/server.rs
+++ b/main/src/server.rs
@@ -317,7 +317,7 @@ impl ServiceBuilder {
             kv,
             coord,
             addr,
-            self.config.security.tls_config.clone(),
+            None,
             self.metrics_register.clone(),
         )
     }


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

# Rationale for this change

Remove TLS support in gRPC server, because coordinator does not support that.

# What changes are included in this PR?


# Are there any user-facing changes?
