### PR TITLE
feat: support granting admin privilege

### DIFF
--- a/meta/src/store/state_machine.rs
+++ b/meta/src/store/state_machine.rs
@@ -1112,7 +1112,7 @@ impl StateMachine {
                         *old_user_desc.id(),
                         user_name.to_string(),
                         new_options,
-                        old_user_desc.is_admin(),
+                        old_user_desc.is_root_admin(),
                     );
                     let value = serde_json::to_string(&new_user_desc).unwrap();
                     let _ = self.insert(&key, &value);

--- a/query_server/spi/src/query/logical_planner.rs
+++ b/query_server/spi/src/query/logical_planner.rs
@@ -387,11 +387,14 @@ pub fn sql_options_to_user_options(
             "comment" => {
                 builder.comment(parse_string_value(value)?);
             }
+            "granted_admin" => {
+                builder.granted_admin(parse_bool_value(value)?);
+            }
             _ => {
                 return Err(ParserError::ParserError(format!(
-                    "Expected option [comment], found [{}]",
-                    name
-                )))
+                "Expected option [password | rsa_public_key | comment | granted_admin], found [{}]",
+                name
+            )))
             }
         }
     }

--- a/query_server/sqllogicaltests/cases/ddl/user.slt
+++ b/query_server/sqllogicaltests/cases/ddl/user.slt
@@ -8,7 +8,7 @@ alter user test_alter_options_u set comment = 'xxx ccc';
 query I
 select * from cluster_schema.users where user_name = 'test_alter_options_u';
 ----
-test_alter_options_u false {"password":"*****","must_change_password":null,"rsa_public_key":null,"comment":"xxx ccc"}
+test_alter_options_u false {"password":"*****","must_change_password":false,"comment":"xxx ccc","granted_admin":false}
 
 statement ok
 alter user test_alter_options_u set comment = 'ooo ooo';
@@ -17,7 +17,7 @@ alter user test_alter_options_u set comment = 'ooo ooo';
 query I
 select * from cluster_schema.users where user_name = 'test_alter_options_u';
 ----
-test_alter_options_u false {"password":"*****","must_change_password":null,"rsa_public_key":null,"comment":"ooo ooo"}
+test_alter_options_u false {"password":"*****","must_change_password":false,"comment":"ooo ooo","granted_admin":false}
 
 statement ok
 alter user test_alter_options_u set must_change_password = false;
@@ -26,7 +26,7 @@ alter user test_alter_options_u set must_change_password = false;
 query I
 select * from cluster_schema.users where user_name = 'test_alter_options_u';
 ----
-test_alter_options_u false {"password":"*****","must_change_password":false,"rsa_public_key":null,"comment":"ooo ooo"}
+test_alter_options_u false {"password":"*****","must_change_password":false,"comment":"ooo ooo","granted_admin":false}
 
 statement ok
 alter user test_alter_options_u set must_change_password = true;
@@ -35,4 +35,4 @@ alter user test_alter_options_u set must_change_password = true;
 query I
 select * from cluster_schema.users where user_name = 'test_alter_options_u';
 ----
-test_alter_options_u false {"password":"*****","must_change_password":true,"rsa_public_key":null,"comment":"ooo ooo"}
+test_alter_options_u false {"password":"*****","must_change_password":true,"comment":"ooo ooo","granted_admin":false}

--- a/query_server/test/cases/dcl/alter_user.result
+++ b/query_server/test/cases/dcl/alter_user.result
@@ -1,0 +1,69 @@
+-- EXECUTE SQL: drop user if exists test_au_u1; --
+200 OK
+
+
+-- EXECUTE SQL: drop user if exists test_au_u2; --
+200 OK
+
+
+-- EXECUTE SQL: create user if not exists test_au_u1; --
+200 OK
+
+
+-- EXECUTE SQL: create user if not exists test_au_u2; --
+200 OK
+
+
+-- EXECUTE SQL: alter tenant cnosdb add user test_au_u1 as member; --
+200 OK
+
+
+-- EXECUTE SQL: alter tenant cnosdb add user test_au_u2 as member; --
+200 OK
+
+
+-- EXECUTE SQL: select * from cluster_schema.users where user_name in ('root', 'test_au_u1', 'test_au_u2'); --
+-- AFTER_SORT --
+200 OK
+user_name,is_admin,user_options
+root,true,"{""password"":""*****"",""must_change_password"":true,""comment"":""system admin"",""granted_admin"":false}"
+test_au_u1,false,"{""password"":""*****"",""must_change_password"":false,""granted_admin"":false}"
+test_au_u2,false,"{""password"":""*****"",""must_change_password"":false,""granted_admin"":false}"
+
+-- EXECUTE SQL: alter user test_au_u1 set granted_admin = true; --
+422 Unprocessable Entity
+{"error_code":"010004","error_message":"Insufficient privileges, expected [maintainer for system]"}
+-- ERROR:  --
+
+-- EXECUTE SQL: alter user test_au_u1 set granted_admin = true; --
+200 OK
+
+
+-- EXECUTE SQL: select * from cluster_schema.users where user_name in ('root', 'test_au_u1', 'test_au_u2'); --
+-- AFTER_SORT --
+200 OK
+user_name,is_admin,user_options
+root,true,"{""password"":""*****"",""must_change_password"":true,""comment"":""system admin"",""granted_admin"":false}"
+test_au_u1,true,"{""password"":""*****"",""must_change_password"":false,""granted_admin"":true}"
+test_au_u2,false,"{""password"":""*****"",""must_change_password"":false,""granted_admin"":false}"
+
+-- EXECUTE SQL: alter user test_au_u2 set granted_admin = true; --
+200 OK
+
+
+-- EXECUTE SQL: select * from cluster_schema.users where user_name in ('root', 'test_au_u1', 'test_au_u2'); --
+-- AFTER_SORT --
+200 OK
+user_name,is_admin,user_options
+root,true,"{""password"":""*****"",""must_change_password"":true,""comment"":""system admin"",""granted_admin"":false}"
+test_au_u1,true,"{""password"":""*****"",""must_change_password"":false,""granted_admin"":true}"
+test_au_u2,true,"{""password"":""*****"",""must_change_password"":false,""granted_admin"":true}"
+
+-- EXECUTE SQL: alter user test_au_u1 set granted_admin = false; --
+200 OK
+
+
+-- EXECUTE SQL: alter user test_au_u2 set granted_admin = false; --
+422 Unprocessable Entity
+{"error_code":"010004","error_message":"Insufficient privileges, expected [maintainer for system]"}
+-- ERROR:  --

--- a/query_server/test/cases/dcl/alter_user.sql
+++ b/query_server/test/cases/dcl/alter_user.sql
@@ -1,0 +1,44 @@
+drop user if exists test_au_u1;
+drop user if exists test_au_u2;
+
+create user if not exists test_au_u1;
+create user if not exists test_au_u2;
+
+alter tenant cnosdb add user test_au_u1 as member;
+alter tenant cnosdb add user test_au_u2 as member;
+
+--#TENANT=cnosdb
+--#USER_NAME=root
+--#SORT=true
+select * from cluster_schema.users where user_name in ('root', 'test_au_u1', 'test_au_u2');
+
+--#TENANT=cnosdb
+--#USER_NAME=test_au_u1
+alter user test_au_u1 set granted_admin = true;
+
+--#TENANT=cnosdb
+--#USER_NAME=root
+alter user test_au_u1 set granted_admin = true;
+
+--#TENANT=cnosdb
+--#USER_NAME=root
+--#SORT=true
+select * from cluster_schema.users where user_name in ('root', 'test_au_u1', 'test_au_u2');
+
+--#TENANT=cnosdb
+--#USER_NAME=test_au_u1
+--#SORT=true
+alter user test_au_u2 set granted_admin = true;
+
+--#TENANT=cnosdb
+--#USER_NAME=root
+--#SORT=true
+select * from cluster_schema.users where user_name in ('root', 'test_au_u1', 'test_au_u2');
+
+--#TENANT=cnosdb
+--#USER_NAME=root
+alter user test_au_u1 set granted_admin = false;
+
+--#TENANT=cnosdb
+--#USER_NAME=test_au_u1
+alter user test_au_u2 set granted_admin = false;

--- a/query_server/test/cases/sys_table/cluster_schema/users.result
+++ b/query_server/test/cases/sys_table/cluster_schema/users.result
@@ -29,7 +29,7 @@
 -- EXECUTE SQL: select * from cluster_schema.users where user_name = 'test_us_u1'; --
 200 OK
 user_name,is_admin,user_options
-test_us_u1,false,"{""password"":""*****"",""must_change_password"":null,""rsa_public_key"":null,""comment"":""test comment""}"
+test_us_u1,false,"{""password"":""*****"",""must_change_password"":false,""comment"":""test comment"",""granted_admin"":false}"
 
 -- EXECUTE SQL: alter tenant cnosdb add user test_us_u1 as owner; --
 200 OK
@@ -51,9 +51,9 @@ test_us_u1,false,"{""password"":""*****"",""must_change_password"":null,""rsa_pu
 -- AFTER_SORT --
 200 OK
 user_name,is_admin,user_options
-root,true,"{""password"":""*****"",""must_change_password"":true,""rsa_public_key"":null,""comment"":""system admin""}"
-test_us_u1,false,"{""password"":""*****"",""must_change_password"":null,""rsa_public_key"":null,""comment"":""test comment""}"
-test_us_u2,false,"{""password"":""*****"",""must_change_password"":null,""rsa_public_key"":null,""comment"":null}"
+root,true,"{""password"":""*****"",""must_change_password"":true,""comment"":""system admin"",""granted_admin"":false}"
+test_us_u1,false,"{""password"":""*****"",""must_change_password"":false,""comment"":""test comment"",""granted_admin"":false}"
+test_us_u2,false,"{""password"":""*****"",""must_change_password"":false,""granted_admin"":false}"
 
 -- EXECUTE SQL: select * from cluster_schema.users where user_name in ('root', 'test_us_u1', 'test_us_u2'); --
 -- AFTER_SORT --


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1210 .

1. admin权限分为两种
  - 初始的admin权限（可在系统表cluster_schema.users中查看，
  - 被授予的admin权限（可在系统表cluster_schema.users中查看，
2. 支持拥有admim权限的人将admin权限授予其他人
3. 系统表cluster_schema.users中is_admin字段标记是否拥有admin权限（包括初始的和被授予的）
4. 系统表cluster_schema.users中的user_options的granted_admin为true，表示被授予的admin权限
5. 拥有admin权限的人可以回收其他人被赋予的admin权限
6. 初始的admin权限不会被回收

**授予admin权限**
```sql
alter user <user_name> set granted_admin = true
```

**撤销admin权限**
```sql
alter user <user_name> set granted_admin = false
```

**查看admin权限**
```sql
select * from cluster_schema.users;
```

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
