### PR TITLE
fix(config): failed to parse str with missing toml table key

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -36,20 +36,56 @@ mod wal_config;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Config {
+    ///
     #[serde(default = "Config::default_reporting_disabled")]
     pub reporting_disabled: bool,
+
+    ///
     #[serde(default = "Config::default_host")]
     pub host: String,
+
+    ///
+    #[serde(default = "Default::default")]
     pub deployment: DeploymentConfig,
+
+    ///
+    #[serde(default = "Default::default")]
     pub query: QueryConfig,
+
+    ///
+    #[serde(default = "Default::default")]
     pub storage: StorageConfig,
+
+    ///
+    #[serde(default = "Default::default")]
     pub wal: WalConfig,
+
+    ///
+    #[serde(default = "Default::default")]
     pub cache: CacheConfig,
+
+    ///
+    #[serde(default = "Default::default")]
     pub log: LogConfig,
+
+    ///
+    #[serde(default = "Default::default")]
     pub security: SecurityConfig,
+
+    ///
+    #[serde(default = "Default::default")]
     pub cluster: ClusterConfig,
+
+    ///
+    #[serde(default = "Default::default")]
     pub hinted_off: HintedOffConfig,
+
+    ///
+    #[serde(default = "Default::default")]
     pub heartbeat: HeartBeatConfig,
+
+    ///
+    #[serde(default = "Default::default")]
     pub node_basic: NodeBasicConfig,
 }
 
@@ -92,7 +128,7 @@ impl Config {
     }
 
     pub fn to_string_pretty(&self) -> String {
-        toml::to_string_pretty(self).unwrap_or_else(|_| "Failed to stringfy Config".to_string())
+        toml::to_string_pretty(self).unwrap_or_else(|_| "Failed to stringify Config".to_string())
     }
 }
 
@@ -321,7 +357,7 @@ http_listen_port = 31007
 grpc_listen_port = 31008
 
 [node_basic]
-node_id = 1001 
+node_id = 1001
 cold_data_server = false
 store_metrics = true
 
@@ -332,6 +368,15 @@ report_time_interval_secs = 30
 enable = true
 path = '/tmp/cnosdb/hh'
 "#;
+
+        let config: Config = toml::from_str(config_str).unwrap();
+        assert!(toml::to_string_pretty(&config).is_ok());
+        dbg!(config);
+    }
+
+    #[test]
+    fn test_parse_empty() {
+        let config_str = "";
 
         let config: Config = toml::from_str(config_str).unwrap();
         assert!(toml::to_string_pretty(&config).is_ok());


### PR DESCRIPTION
# Rationale for this change

If we add a new TOML table in our configuration, then it will failed to parse the old version of config-file because it does not contains the TOML talbe key.