### PR TITLE
feat(client): add https support for cnosdb-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2920,6 +2920,7 @@ dependencies = [
  "models",
  "reqwest",
  "serde",
+ "snafu",
 ]
 
 [[package]]

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -11,3 +11,9 @@ pub mod print_format;
 pub mod print_options;
 
 pub type Result<T> = std::result::Result<T, anyhow::Error>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(i32)]
+pub enum ExitCode {
+    HttpClientInitFailed = 10,
+}

--- a/common/http_protocol/Cargo.toml
+++ b/common/http_protocol/Cargo.toml
@@ -8,9 +8,10 @@ edition.workspace = true
 [dependencies]
 models = { path = "../models" }
 
+async-backtrace = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["native-tls", "__rustls"] }
 serde = { workspace = true }
-async-backtrace = { workspace = true, optional = true }
+snafu = { workspace = true }
 
 [features]
 default = []

--- a/common/http_protocol/src/lib.rs
+++ b/common/http_protocol/src/lib.rs
@@ -4,3 +4,6 @@ pub mod http_client;
 pub mod parameter;
 pub mod response;
 pub mod status_code;
+
+#[cfg(feature = "http_client")]
+pub use http_client::Error;

--- a/e2e_test/src/http_api_tests.rs
+++ b/e2e_test/src/http_api_tests.rs
@@ -6,7 +6,7 @@ mod test {
     use http_protocol::status_code;
 
     fn client() -> HttpClient {
-        HttpClient::from_addr("127.0.0.1".to_string(), 8902)
+        HttpClient::new("127.0.0.1", 8902, false, false, &[]).unwrap()
     }
 
     #[tokio::test]

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -76,8 +76,8 @@ default = []
 backtrace = ["async-backtrace"]
 
 [dev-dependencies]
-prost-types = { version = "0.11.2" }
-reqwest = "0.11"
+prost-types = { workspace = true }
+reqwest = { workspace = true }
 
 
 [[example]]


### PR DESCRIPTION
# Which issue does this PR close?

Related #.

# Rationale for this change

Add HTTPS support for `cnosdb-cli` .

# What changes are included in this PR?

# Are there any user-facing changes?

- `--ssl` - use `https://{host}:{port}` as request url.
- `--unsafe-ssl` - allow unsafe HTTPS connections.
- `--cacert <FILE>` - add root certificate from a file.