### PR TITLE
Fix: compaction may costs too much memory

### DIFF
--- a/common/models/src/predicate/domain.rs
+++ b/common/models/src/predicate/domain.rs
@@ -65,6 +65,13 @@ impl TimeRange {
         }
     }
 
+    pub fn none() -> Self {
+        Self {
+            min_ts: Timestamp::MAX,
+            max_ts: Timestamp::MIN,
+        }
+    }
+
     #[inline(always)]
     pub fn is_boundless(&self) -> bool {
         self.min_ts == Timestamp::MIN && self.max_ts == Timestamp::MAX

--- a/tskv/src/compaction/compact.rs
+++ b/tskv/src/compaction/compact.rs
@@ -417,9 +417,12 @@ pub(crate) struct CompactIterator {
     tsm_readers: Vec<Arc<TsmReader>>,
     compacting_files: BinaryHeap<Pin<Box<CompactingFile>>>,
     /// Maximum values in generated CompactingBlock
-    max_datablock_values: usize,
+    max_data_block_size: usize,
+    // /// The time range of data to be merged of level-0 data blocks.
+    // /// The level-0 data that out of the thime range will write back to level-0.
+    // level_time_range: TimeRange,
     /// Decode a data block even though it doesn't need to merge with others,
-    /// return CompactingBlock::DataBlock rather than CompactingBlock::Raw
+    /// return CompactingBlock::DataBlock rather than CompactingBlock::Raw .
     decode_non_overlap_blocks: bool,
 
     tmp_tsm_blk_meta_iters: Vec<BlockMetaIterator>,
@@ -428,7 +431,7 @@ pub(crate) struct CompactIterator {
     tmp_tsm_blk_tsm_reader_idx: Vec<usize>,
     /// When a TSM file at index i is ended, finished_idxes[i] is set to true.
     finished_readers: Vec<bool>,
-    /// How many finished_idxes is set to true
+    /// How many finished_idxes is set to true.
     finished_reader_cnt: usize,
     curr_fid: Option<FieldId>,
 
@@ -441,7 +444,7 @@ impl Default for CompactIterator {
         Self {
             tsm_readers: Default::default(),
             compacting_files: Default::default(),
-            max_datablock_values: 0,
+            max_data_block_size: 0,
             decode_non_overlap_blocks: false,
             tmp_tsm_blk_meta_iters: Default::default(),
             tmp_tsm_blk_tsm_reader_idx: Default::default(),
@@ -469,7 +472,7 @@ impl CompactIterator {
         Self {
             tsm_readers,
             compacting_files,
-            max_datablock_values: max_data_block_size,
+            max_data_block_size,
             decode_non_overlap_blocks,
             finished_readers: vec![false; compacting_files_cnt],
             ..Default::default()

--- a/tskv/src/compaction/compact.rs
+++ b/tskv/src/compaction/compact.rs
@@ -1,7 +1,9 @@
 use std::collections::{BinaryHeap, HashMap, VecDeque};
+use std::fmt::{Display, Formatter};
 use std::pin::Pin;
 use std::sync::Arc;
 
+use models::predicate::domain::TimeRange;
 use models::{FieldId, Timestamp};
 use snafu::ResultExt;
 use trace::{error, info, trace};
@@ -14,20 +16,22 @@ use crate::error::{self, Result};
 use crate::summary::{CompactMeta, VersionEdit};
 use crate::tseries_family::TseriesFamily;
 use crate::tsm::{
-    self, BlockMeta, BlockMetaIterator, DataBlock, IndexIterator, IndexMeta, TsmReader, TsmWriter,
+    self, BlockMeta, BlockMetaIterator, DataBlock, EncodedDataBlock, IndexIterator, IndexMeta,
+    TsmReader, TsmWriter,
 };
-use crate::{ColumnFileId, LevelId, TseriesFamilyId};
+use crate::{ColumnFileId, Error, LevelId, TseriesFamilyId};
 
 /// Temporary compacting data block meta
-struct CompactingBlockMeta {
-    readers_idx: usize,
-    has_tombstone: bool,
-    block_meta: BlockMeta,
+#[derive(Clone)]
+pub(crate) struct CompactingBlockMeta {
+    reader_idx: usize,
+    reader: Arc<TsmReader>,
+    meta: BlockMeta,
 }
 
 impl PartialEq for CompactingBlockMeta {
     fn eq(&self, other: &Self) -> bool {
-        self.readers_idx == other.readers_idx && self.block_meta == other.block_meta
+        self.reader.file_id() == other.reader.file_id() && self.meta == other.meta
     }
 }
 
@@ -35,23 +39,222 @@ impl Eq for CompactingBlockMeta {}
 
 impl PartialOrd for CompactingBlockMeta {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.block_meta.cmp(&other.block_meta))
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for CompactingBlockMeta {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.block_meta.cmp(&other.block_meta)
+        self.meta.cmp(&other.meta)
+    }
+}
+
+impl Display for CompactingBlockMeta {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}: {{ len: {}, min_ts: {}, max_ts: {} }}",
+            self.meta.field_type(),
+            self.meta.count(),
+            self.meta.min_ts(),
+            self.meta.max_ts(),
+        )
     }
 }
 
 impl CompactingBlockMeta {
-    pub fn new(readers_idx: usize, has_tombstone: bool, block_meta: BlockMeta) -> Self {
+    pub fn new(tsm_reader_idx: usize, tsm_reader: Arc<TsmReader>, block_meta: BlockMeta) -> Self {
         Self {
-            readers_idx,
-            has_tombstone,
-            block_meta,
+            reader_idx: tsm_reader_idx,
+            reader: tsm_reader,
+            meta: block_meta,
         }
+    }
+
+    pub fn time_range(&self) -> TimeRange {
+        self.meta.time_range()
+    }
+
+    pub fn overlaps(&self, other: &Self) -> bool {
+        self.meta.min_ts() <= other.meta.max_ts() && self.meta.max_ts() >= other.meta.min_ts()
+    }
+
+    pub fn overlaps_time_range(&self, time_range: &TimeRange) -> bool {
+        self.meta.min_ts() <= time_range.max_ts && self.meta.max_ts() >= time_range.min_ts
+    }
+
+    pub async fn get_data_block(&self) -> Result<DataBlock> {
+        self.reader
+            .get_data_block(&self.meta)
+            .await
+            .context(error::ReadTsmSnafu)
+    }
+
+    pub async fn get_raw_data(&self, dst: &mut Vec<u8>) -> Result<usize> {
+        self.reader
+            .get_raw_data(&self.meta, dst)
+            .await
+            .context(error::ReadTsmSnafu)
+    }
+
+    pub fn has_tombstone(&self) -> bool {
+        self.reader.has_tombstone()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CompactingBlockMetaGroup {
+    field_id: FieldId,
+    blk_metas: Vec<CompactingBlockMeta>,
+    time_range: TimeRange,
+}
+impl CompactingBlockMetaGroup {
+    pub fn new(field_id: FieldId, blk_meta: CompactingBlockMeta) -> Self {
+        let time_range = blk_meta.time_range();
+        Self {
+            field_id,
+            blk_metas: vec![blk_meta],
+            time_range,
+        }
+    }
+
+    pub fn overlaps(&self, other: &Self) -> bool {
+        self.time_range.overlaps(&other.time_range)
+    }
+
+    pub fn append(&mut self, other: &mut CompactingBlockMetaGroup) {
+        self.blk_metas.append(&mut other.blk_metas);
+        self.time_range.merge(&other.time_range);
+    }
+
+    pub async fn merge(
+        mut self,
+        previous_block: Option<CompactingBlock>,
+        max_block_size: usize,
+    ) -> Result<Vec<CompactingBlock>> {
+        if self.blk_metas.is_empty() {
+            return Ok(vec![]);
+        }
+        self.blk_metas
+            .sort_by(|a, b| a.reader_idx.cmp(&b.reader_idx).reverse());
+
+        let merged_block;
+        if self.blk_metas.len() == 1 && !self.blk_metas[0].has_tombstone() {
+            // Only one compacting block and has no tombstone, write as raw block.
+            trace!("only one compacting block, write as raw block");
+            let meta_0 = &self.blk_metas[0].meta;
+            let mut buf_0 = Vec::with_capacity(meta_0.size() as usize);
+            let data_len_0 = self.blk_metas[0].get_raw_data(&mut buf_0).await?;
+            buf_0.truncate(data_len_0);
+
+            if meta_0.size() >= max_block_size as u64 {
+                // Raw data block is full, so do not merge with the previous, directly return.
+                let mut merged_blks = Vec::new();
+                if let Some(blk) = previous_block {
+                    merged_blks.push(blk);
+                }
+                merged_blks.push(CompactingBlock::raw(
+                    self.blk_metas[0].reader_idx,
+                    meta_0.clone(),
+                    buf_0,
+                ));
+
+                return Ok(merged_blks);
+            } else if let Some(compacting_block) = previous_block {
+                // Raw block is not full, so decode and merge with compacting_block.
+                let decoded_raw_block = tsm::decode_data_block(
+                    &buf_0,
+                    meta_0.field_type(),
+                    meta_0.val_off() - meta_0.offset(),
+                )
+                .context(error::ReadTsmSnafu)?;
+                let mut data_block = compacting_block.decode()?;
+                data_block.extend(decoded_raw_block);
+
+                merged_block = data_block;
+            } else {
+                // Raw block is not full, but nothing to merge with, directly return.
+
+                return Ok(vec![CompactingBlock::raw(
+                    self.blk_metas[0].reader_idx,
+                    meta_0.clone(),
+                    buf_0,
+                )]);
+            }
+        } else {
+            // One block with tombstone or multi compacting blocks, decode and merge these data block.
+            trace!(
+                "there are {} compacting blocks, need to decode and merge",
+                self.blk_metas.len()
+            );
+            let head = &mut self.blk_metas[0];
+            let mut head_block = head.get_data_block().await?;
+
+            if let Some(compacting_block) = previous_block {
+                let mut data_block = compacting_block.decode()?;
+                data_block.extend(head_block);
+                head_block = data_block;
+            }
+
+            for blk_meta in self.blk_metas[1..].iter_mut() {
+                // Merge decoded data block.
+                let blk_block = blk_meta.get_data_block().await?;
+                head_block = head_block.merge(blk_block);
+            }
+            merged_block = head_block;
+        }
+
+        self.chunk_merged_block(merged_block, max_block_size)
+    }
+
+    fn chunk_merged_block(
+        &self,
+        data_block: DataBlock,
+        max_block_size: usize,
+    ) -> Result<Vec<CompactingBlock>> {
+        let mut merged_blks = Vec::new();
+        if max_block_size == 0 || data_block.len() < max_block_size {
+            // Data block elements less than max_block_size, do not encode it.
+            // Try to merge with the next CompactingBlockMetaGroup.
+            merged_blks.push(CompactingBlock::decoded(0, self.field_id, data_block));
+        } else {
+            let len = data_block.len();
+            let mut start = 0;
+            let mut end = len.min(max_block_size);
+            while start + end < len {
+                // Encode decoded data blocks into chunks.
+                let encoded_blk =
+                    EncodedDataBlock::encode(&data_block, start, end).map_err(|e| {
+                        Error::WriteTsm {
+                            source: tsm::WriteTsmError::Encode { source: e },
+                        }
+                    })?;
+                merged_blks.push(CompactingBlock::encoded(0, self.field_id, encoded_blk));
+
+                start += end;
+                end = len.min(start + max_block_size);
+            }
+            if start < len {
+                // Encode the remaining decoded data blocks.
+                let encoded_blk =
+                    EncodedDataBlock::encode(&data_block, start, len).map_err(|e| {
+                        Error::WriteTsm {
+                            source: tsm::WriteTsmError::Encode { source: e },
+                        }
+                    })?;
+                merged_blks.push(CompactingBlock::encoded(0, self.field_id, encoded_blk));
+            }
+        }
+
+        Ok(merged_blks)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.blk_metas.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.blk_metas.len()
     }
 }
 
@@ -60,10 +263,15 @@ impl CompactingBlockMeta {
 /// timestamp from two data blocks, pair from data block with lower
 /// priority will be discarded.
 pub(crate) enum CompactingBlock {
-    DataBlock {
+    Decoded {
         priority: usize,
         field_id: FieldId,
         data_block: DataBlock,
+    },
+    Encoded {
+        priority: usize,
+        field_id: FieldId,
+        data_block: EncodedDataBlock,
     },
     Raw {
         priority: usize,
@@ -72,34 +280,86 @@ pub(crate) enum CompactingBlock {
     },
 }
 
-impl CompactingBlock {
-    /// Sort the given `CompactingBlock`s by priority, transform all of them
-    /// into CompactingBlock::DataBlock (for CompactingBlock::Raw)
-    fn rebuild_data_blocks(mut source: Vec<Self>) -> Result<Vec<DataBlock>> {
-        source.sort_by_key(|k| match k {
-            CompactingBlock::DataBlock { priority, .. } => *priority,
-            CompactingBlock::Raw { priority, .. } => *priority,
-        });
-
-        let mut res: Vec<DataBlock> = Vec::with_capacity(source.len());
-        for cb in source.into_iter() {
-            match cb {
-                CompactingBlock::DataBlock { data_block, .. } => {
-                    res.push(data_block);
-                }
-                CompactingBlock::Raw { meta, raw, .. } => {
-                    let data_block = tsm::decode_data_block(
-                        &raw,
-                        meta.field_type(),
-                        meta.val_off() - meta.offset(),
-                    )
-                    .context(error::ReadTsmSnafu)?;
-                    res.push(data_block);
-                }
+impl Display for CompactingBlock {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CompactingBlock::Decoded {
+                priority,
+                field_id,
+                data_block,
+            } => {
+                write!(f, "p: {priority}, f: {field_id}, block: {data_block}")
+            }
+            CompactingBlock::Encoded {
+                priority,
+                field_id,
+                data_block,
+            } => {
+                write!(f, "p: {priority}, f: {field_id}, block: {data_block}")
+            }
+            CompactingBlock::Raw { priority, meta, .. } => {
+                write!(
+                    f,
+                    "p: {priority}, f: {}, block: {}: {{ len: {}, min_ts: {}, max_ts: {} }}",
+                    meta.field_id(),
+                    meta.field_type(),
+                    meta.count(),
+                    meta.min_ts(),
+                    meta.max_ts()
+                )
             }
         }
+    }
+}
 
-        Ok(res)
+impl CompactingBlock {
+    pub fn decoded(priority: usize, field_id: FieldId, data_block: DataBlock) -> CompactingBlock {
+        Self::Decoded {
+            priority,
+            field_id,
+            data_block,
+        }
+    }
+
+    pub fn encoded(
+        priority: usize,
+        field_id: FieldId,
+        data_block: EncodedDataBlock,
+    ) -> CompactingBlock {
+        Self::Encoded {
+            priority,
+            field_id,
+            data_block,
+        }
+    }
+
+    pub fn raw(priority: usize, meta: BlockMeta, raw: Vec<u8>) -> CompactingBlock {
+        CompactingBlock::Raw {
+            priority,
+            meta,
+            raw,
+        }
+    }
+
+    pub fn decode(self) -> Result<DataBlock> {
+        match self {
+            CompactingBlock::Decoded { data_block, .. } => Ok(data_block),
+            CompactingBlock::Encoded { data_block, .. } => {
+                data_block.decode().context(error::DecodeSnafu)
+            }
+            CompactingBlock::Raw { raw, meta, .. } => {
+                tsm::decode_data_block(&raw, meta.field_type(), meta.val_off() - meta.offset())
+                    .context(error::ReadTsmSnafu)
+            }
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            CompactingBlock::Decoded { data_block, .. } => data_block.len(),
+            CompactingBlock::Encoded { data_block, .. } => data_block.count as usize,
+            CompactingBlock::Raw { meta, .. } => meta.count() as usize,
+        }
     }
 }
 
@@ -157,12 +417,12 @@ pub(crate) struct CompactIterator {
     tsm_readers: Vec<Arc<TsmReader>>,
     compacting_files: BinaryHeap<Pin<Box<CompactingFile>>>,
     /// Maximum values in generated CompactingBlock
-    max_datablock_values: u32,
+    max_datablock_values: usize,
     /// Decode a data block even though it doesn't need to merge with others,
     /// return CompactingBlock::DataBlock rather than CompactingBlock::Raw
     decode_non_overlap_blocks: bool,
 
-    tmp_tsm_blks: Vec<BlockMetaIterator>,
+    tmp_tsm_blk_meta_iters: Vec<BlockMetaIterator>,
     /// Index to mark `Peekable<BlockMetaIterator>` in witch `TsmReader`,
     /// tmp_tsm_blks[i] is in self.tsm_readers[ tmp_tsm_blk_tsm_reader_idx[i] ]
     tmp_tsm_blk_tsm_reader_idx: Vec<usize>,
@@ -172,7 +432,7 @@ pub(crate) struct CompactIterator {
     finished_reader_cnt: usize,
     curr_fid: Option<FieldId>,
 
-    merged_blocks: VecDeque<CompactingBlock>,
+    merging_blk_meta_groups: VecDeque<CompactingBlockMetaGroup>,
 }
 
 /// To reduce construction code
@@ -183,12 +443,12 @@ impl Default for CompactIterator {
             compacting_files: Default::default(),
             max_datablock_values: 0,
             decode_non_overlap_blocks: false,
-            tmp_tsm_blks: Default::default(),
+            tmp_tsm_blk_meta_iters: Default::default(),
             tmp_tsm_blk_tsm_reader_idx: Default::default(),
             finished_readers: Default::default(),
             finished_reader_cnt: Default::default(),
             curr_fid: Default::default(),
-            merged_blocks: Default::default(),
+            merging_blk_meta_groups: Default::default(),
         }
     }
 }
@@ -196,7 +456,7 @@ impl Default for CompactIterator {
 impl CompactIterator {
     pub(crate) fn new(
         tsm_readers: Vec<Arc<TsmReader>>,
-        max_data_block_size: u32,
+        max_data_block_size: usize,
         decode_non_overlap_blocks: bool,
     ) -> Self {
         let compacting_files: BinaryHeap<Pin<Box<CompactingFile>>> = tsm_readers
@@ -222,10 +482,16 @@ impl CompactIterator {
 
         if let Some(f) = self.compacting_files.peek() {
             if self.curr_fid.is_none() {
+                trace!(
+                    "selected new field {:?} from file {} as current field id",
+                    f.field_id,
+                    f.tsm_reader.file_id()
+                );
                 self.curr_fid = f.field_id
             }
         } else {
             // TODO finished
+            trace!("no file to select, mark finished");
             self.finished_reader_cnt += 1;
         }
         while let Some(mut f) = self.compacting_files.pop() {
@@ -233,7 +499,7 @@ impl CompactIterator {
             let loop_file_i = f.i;
             if self.curr_fid == loop_field_id {
                 if let Some(idx_meta) = f.peek() {
-                    self.tmp_tsm_blks.push(idx_meta.block_iterator());
+                    self.tmp_tsm_blk_meta_iters.push(idx_meta.block_iterator());
                     self.tmp_tsm_blk_tsm_reader_idx.push(loop_file_i);
                     trace!("merging idx_meta: field_id: {}, field_type: {:?}, block_count: {}, time_range: {:?}",
                         idx_meta.field_id(),
@@ -257,228 +523,114 @@ impl CompactIterator {
     }
 
     /// Collect merging `DataBlock`s.
-    async fn next_merging_blocks(&mut self) -> Result<()> {
-        if self.curr_fid.is_none() || self.tmp_tsm_blks.is_empty() {
-            return Ok(());
+    async fn fetch_merging_block_meta_groups(&mut self) -> bool {
+        if self.tmp_tsm_blk_meta_iters.is_empty() {
+            return false;
         }
-        let mut sorted_blk_metas: BinaryHeap<CompactingBlockMeta> =
-            BinaryHeap::with_capacity(self.tmp_tsm_blks.len());
-        let field_id = self.curr_fid.expect("method next_field_id has been called");
+        let field_id = match self.curr_fid {
+            Some(fid) => fid,
+            None => return false,
+        };
+
+        let mut blk_metas: Vec<CompactingBlockMeta> =
+            Vec::with_capacity(self.tmp_tsm_blk_meta_iters.len());
         // Get all block_meta, and check if it's tsm file has a related tombstone file.
-        for (i, blk_iter) in self.tmp_tsm_blks.iter_mut().enumerate() {
+        for (i, blk_iter) in self.tmp_tsm_blk_meta_iters.iter_mut().enumerate() {
             for blk_meta in blk_iter.by_ref() {
-                let tsm_has_tombstone =
-                    self.tsm_readers[self.tmp_tsm_blk_tsm_reader_idx[i]].has_tombstone();
-                sorted_blk_metas.push(CompactingBlockMeta::new(
-                    self.tmp_tsm_blk_tsm_reader_idx[i],
-                    tsm_has_tombstone,
+                let tsm_reader_idx = self.tmp_tsm_blk_tsm_reader_idx[i];
+                let tsm_reader_ptr = self.tsm_readers[tsm_reader_idx].clone();
+                blk_metas.push(CompactingBlockMeta::new(
+                    tsm_reader_idx,
+                    tsm_reader_ptr,
                     blk_meta,
                 ));
             }
         }
+        // Sort by field_id, min_ts and max_ts.
+        blk_metas.sort();
 
-        // If BlockMeta::count is less than max_datablock_values, we need to merge it with the
-        // next block
-        let mut merging_blks: Vec<CompactingBlock> = Vec::new();
-        // let mut merging_blk: Option<DataBlock> = None;
-        let mut merged_blk_time_range = (Timestamp::MAX, Timestamp::MIN);
-        // If BlockMeta::count reaches max_datablock_values, we don't decode the block.
-        let mut buf = vec![0_u8; 1024];
-        let mut is_first = true;
-        while let Some(cbm) = sorted_blk_metas.pop() {
-            // 1. Store DataBlocks in merging_blocks, merged_blk_time_range set by the first
-            //      BlockMeta
-            // 2. For each BlockMeta:
-            //   2.1. If it's time_range overlaps with merged_blk_time_range, read DataBlock and
-            //          push to merging_blocks, and update merged_blk_time_range
-            //   2.2. Else:
-            //     2.2.1. If merging_blks's length is 1 and it's a Raw, put to self::merged_blocks.
-            //     2.2.2. Else merge merging_blks into Vec<DataBlock>, push to back of
-            //              self::merged_blocks, and clean merging_blks.
-            //            The last one of the Vec<DataBlock> is special, if it's length is less than
-            //              self::max_datablock_values, do not push it.
-            //     2.2.3. If it's length reaches self::max_datablock_values, and there is no
-            //              tombstones, put Raw to merging_blks, otherwise put DataBlock
-            //              (used in 2.2.1).
-            // 3. Read DataBLock for the remaining BlockMeta, push to self::merged_blks.
-
-            // Exists merging DataBlock in past iteration
-            if is_first {
-                is_first = false;
-                merged_blk_time_range = (cbm.block_meta.min_ts(), cbm.block_meta.max_ts());
-                if cbm.block_meta.size() as usize > buf.len() {
-                    buf.resize(cbm.block_meta.size() as usize, 0);
-                }
-                if cbm.has_tombstone || self.decode_non_overlap_blocks {
-                    let data_block = self.tsm_readers[cbm.readers_idx]
-                        .get_data_block(&cbm.block_meta)
-                        .await
-                        .context(error::ReadTsmSnafu)?;
-                    merging_blks.push(CompactingBlock::DataBlock {
-                        priority: cbm.readers_idx + 1,
-                        field_id,
-                        data_block,
-                    });
-                } else {
-                    let size = self.tsm_readers[cbm.readers_idx]
-                        .get_raw_data(&cbm.block_meta, &mut buf)
-                        .await
-                        .context(error::ReadTsmSnafu)?;
-                    merging_blks.push(CompactingBlock::Raw {
-                        priority: cbm.readers_idx + 1,
-                        meta: cbm.block_meta,
-                        raw: buf[..size].to_vec(),
-                    });
-                }
-            } else if overlaps_tuples(
-                merged_blk_time_range,
-                (cbm.block_meta.min_ts(), cbm.block_meta.max_ts()),
-            ) {
-                // 2.1
-                let data_block = self.tsm_readers[cbm.readers_idx]
-                    .get_data_block(&cbm.block_meta)
-                    .await
-                    .context(error::ReadTsmSnafu)?;
-                merging_blks.push(CompactingBlock::DataBlock {
-                    priority: cbm.readers_idx + 1,
-                    field_id,
-                    data_block,
-                });
-
-                merged_blk_time_range.0 = merged_blk_time_range.0.min(cbm.block_meta.min_ts());
-                merged_blk_time_range.1 = merged_blk_time_range.0.max(cbm.block_meta.max_ts());
-            } else {
-                // 2.2
-                if !merging_blks.is_empty() {
-                    if merging_blks.len() == 1 {
-                        // 2.2.1
-                        if let Some(CompactingBlock::Raw { meta, .. }) = merging_blks.first() {
-                            if meta.count() == self.max_datablock_values {
-                                self.merged_blocks.push_back(merging_blks.remove(0));
-                            }
-                        }
-                    } else {
-                        // 2.2.2
-                        let merging_data_blks = CompactingBlock::rebuild_data_blocks(merging_blks)?;
-                        merging_blks = Vec::new();
-                        let merged_data_blks =
-                            DataBlock::merge_blocks(merging_data_blks, self.max_datablock_values);
-
-                        for (_i, data_block) in merged_data_blks.into_iter().enumerate() {
-                            if data_block.len() < self.max_datablock_values as usize {
-                                merging_blks.push(CompactingBlock::DataBlock {
-                                    priority: 0,
-                                    field_id,
-                                    data_block,
-                                });
-                                break;
-                            }
-                            self.merged_blocks.push_back(CompactingBlock::DataBlock {
-                                priority: 0,
-                                field_id,
-                                data_block,
-                            });
-                        }
-                    }
-
-                    // This DataBlock doesn't need to merge
-                    if cbm.block_meta.count() == self.max_datablock_values {
-                        // 2.2.3
-                        if cbm.block_meta.size() as usize > buf.len() {
-                            buf.resize(cbm.block_meta.size() as usize, 0);
-                        }
-                        merged_blk_time_range.0 =
-                            merged_blk_time_range.0.min(cbm.block_meta.min_ts());
-                        merged_blk_time_range.1 =
-                            merged_blk_time_range.0.max(cbm.block_meta.max_ts());
-                        if cbm.has_tombstone || self.decode_non_overlap_blocks {
-                            let data_block = self.tsm_readers[cbm.readers_idx]
-                                .get_data_block(&cbm.block_meta)
-                                .await
-                                .context(error::ReadTsmSnafu)?;
-                            merging_blks.push(CompactingBlock::DataBlock {
-                                priority: cbm.readers_idx + 1,
-                                field_id,
-                                data_block,
-                            });
-                        } else {
-                            let size = self.tsm_readers[cbm.readers_idx]
-                                .get_raw_data(&cbm.block_meta, &mut buf)
-                                .await
-                                .context(error::ReadTsmSnafu)?;
-                            merging_blks.push(CompactingBlock::Raw {
-                                priority: cbm.readers_idx + 1,
-                                meta: cbm.block_meta,
-                                raw: buf[..size].to_vec(),
-                            });
-                        }
-                    } else {
-                        // cbm.block_meta.count is less than max_datablock_values
-                        let data_block = self.tsm_readers[cbm.readers_idx]
-                            .get_data_block(&cbm.block_meta)
-                            .await
-                            .context(error::ReadTsmSnafu)?;
-                        merging_blks.push(CompactingBlock::DataBlock {
-                            priority: cbm.readers_idx + 1,
-                            field_id,
-                            data_block,
-                        });
-                    }
+        let mut blk_meta_groups: Vec<CompactingBlockMetaGroup> =
+            Vec::with_capacity(blk_metas.len());
+        for blk_meta in blk_metas {
+            blk_meta_groups.push(CompactingBlockMetaGroup::new(field_id, blk_meta));
+        }
+        // Compact blk_meta_groups.
+        let mut i = 0;
+        loop {
+            let mut head_idx = i;
+            // Find the first non-empty as head.
+            for (off, bmg) in blk_meta_groups[i..].iter().enumerate() {
+                if !bmg.is_empty() {
+                    head_idx += off;
+                    break;
                 }
             }
-        }
-
-        if !merging_blks.is_empty() {
-            let merging_data_blks = CompactingBlock::rebuild_data_blocks(merging_blks)?;
-            let merged_data_blks =
-                DataBlock::merge_blocks(merging_data_blks, self.max_datablock_values);
-
-            for (_i, data_block) in merged_data_blks.into_iter().enumerate() {
-                self.merged_blocks.push_back(CompactingBlock::DataBlock {
-                    priority: 0,
-                    field_id,
-                    data_block,
-                });
+            if head_idx >= blk_meta_groups.len() - 1 {
+                // There no other blk_meta_group to merge with the last one.
+                break;
             }
+            let mut head = blk_meta_groups[head_idx].clone();
+            i = head_idx + 1;
+            for bmg in blk_meta_groups[i..].iter_mut() {
+                if bmg.is_empty() {
+                    continue;
+                }
+                if head.overlaps(bmg) {
+                    head.append(bmg);
+                }
+            }
+            blk_meta_groups[head_idx] = head;
         }
+        let blk_meta_groups: VecDeque<CompactingBlockMetaGroup> = blk_meta_groups
+            .into_iter()
+            .filter(|l| !l.is_empty())
+            .collect();
+        trace!(
+            "selected merging meta groups: {}",
+            blk_meta_groups
+                .iter()
+                .map(|g| format!(
+                    "[{}]",
+                    g.blk_metas
+                        .iter()
+                        .map(|b| format!("{}", b))
+                        .collect::<Vec<String>>()
+                        .join(", ")
+                ))
+                .collect::<Vec<String>>()
+                .join(", ")
+        );
 
-        Ok(())
+        self.merging_blk_meta_groups = blk_meta_groups;
+
+        true
     }
 }
 
 impl CompactIterator {
-    pub(crate) async fn next(&mut self) -> Option<Result<CompactingBlock>> {
-        if let Some(blk) = self.merged_blocks.pop_front() {
-            return Some(Ok(blk));
-        }
-        loop {
-            trace!("------------------------------");
-
-            // For each tsm-file, get next index reader for current iteration field id
-            self.next_field_id();
-
-            trace!(
-                "selected blocks count: {} in iteration",
-                self.tmp_tsm_blks.len()
-            );
-            if self.tmp_tsm_blks.is_empty() {
-                trace!("iteration field_id {:?} is finished", self.curr_fid);
-                self.curr_fid = None;
-                break;
-            }
-
-            // Get all of block_metas of this field id, and merge these blocks
-            if let Err(e) = self.next_merging_blocks().await {
-                return Some(Err(e));
-            }
-
-            if self.finished_reader_cnt >= self.finished_readers.len() {
-                break;
-            }
+    pub(crate) async fn next(&mut self) -> Option<CompactingBlockMetaGroup> {
+        if let Some(g) = self.merging_blk_meta_groups.pop_front() {
+            return Some(g);
         }
 
-        if let Some(blk) = self.merged_blocks.pop_front() {
-            return Some(Ok(blk));
+        // For each tsm-file, get next index reader for current iteration field id
+        self.next_field_id();
+
+        trace!(
+            "selected {} blocks meta iterators",
+            self.tmp_tsm_blk_meta_iters.len()
+        );
+        if self.tmp_tsm_blk_meta_iters.is_empty() {
+            trace!("iteration field_id {:?} is finished", self.curr_fid);
+            self.curr_fid = None;
+            return None;
+        }
+
+        // Get all of block_metas of this field id, and merge these blocks
+        self.fetch_merging_block_meta_groups().await;
+
+        if let Some(g) = self.merging_blk_meta_groups.pop_front() {
+            return Some(g);
         }
         None
     }
@@ -517,22 +669,19 @@ pub async fn run_compaction_job(
         return Ok(None);
     }
 
-    let version = request.version;
-
     // Buffers all tsm-files and it's indexes for this compaction
-    let max_data_block_size = TseriesFamily::MAX_DATA_BLOCK_SIZE;
     let tsf_id = request.ts_family_id;
-    let storage_opt = request.storage_opt;
     let mut tsm_readers = Vec::new();
     for col_file in request.files.iter() {
         let tsm_file = col_file.file_path();
         // TODO Get tsm reader from lru cache.
-        let tsm_reader = version.get_tsm_reader(&tsm_file).await?;
+        let tsm_reader = request.version.get_tsm_reader(&tsm_file).await?;
         tsm_readers.push(tsm_reader);
     }
 
-    let mut iter = CompactIterator::new(tsm_readers, max_data_block_size, false);
-    let tsm_dir = storage_opt.tsm_dir(&request.database, tsf_id);
+    let max_block_size = TseriesFamily::MAX_DATA_BLOCK_SIZE as usize;
+    let mut iter = CompactIterator::new(tsm_readers, max_block_size, false);
+    let tsm_dir = request.storage_opt.tsm_dir(&request.database, tsf_id);
     let mut tsm_writer = tsm::new_tsm_writer(&tsm_dir, kernel.file_id_next(), false, 0).await?;
     info!(
         "Compaction: File: {} been created (level: {}).",
@@ -542,44 +691,23 @@ pub async fn run_compaction_job(
     let mut version_edit = VersionEdit::new(tsf_id);
     let mut file_metas: HashMap<ColumnFileId, Arc<BloomFilter>> = HashMap::new();
 
-    while let Some(block) = iter.next().await {
-        let blk = block?;
+    let mut previous_merged_block: Option<CompactingBlock> = None;
+    let mut fid = iter.curr_fid;
+    while let Some(blk_meta_group) = iter.next().await {
         trace!("===============================");
-        let write_ret = match blk {
-            CompactingBlock::DataBlock {
-                field_id: fid,
-                data_block: b,
-                ..
-            } => {
-                // TODO: let enc = b.encodings();
-                tsm_writer.write_block(fid, &b).await
-            }
-            CompactingBlock::Raw { meta, raw, .. } => tsm_writer.write_raw(&meta, &raw).await,
-        };
-        if let Err(e) = write_ret {
-            match e {
-                tsm::WriteTsmError::IO { source } => {
-                    // TODO handle this: stop compaction and report an error.
-                    error!("IO error when write tsm: {:?}", source);
-                }
-                tsm::WriteTsmError::Encode { source } => {
-                    // TODO handle this: stop compaction and report an error.
-                    error!("Encoding error when write tsm: {:?}", source);
-                }
-                tsm::WriteTsmError::MaxFileSizeExceed { .. } => {
-                    tsm_writer
-                        .write_index()
-                        .await
-                        .context(error::WriteTsmSnafu)?;
-                    tsm_writer.finish().await.context(error::WriteTsmSnafu)?;
-                    info!(
-                        "Compaction: File: {} write finished (level: {}, {} B).",
-                        tsm_writer.sequence(),
-                        request.out_level,
-                        tsm_writer.size()
-                    );
-                    let cm = new_compact_meta(&tsm_writer, request.ts_family_id, request.out_level);
-                    version_edit.add_file(cm, version.max_level_ts);
+        if fid.is_some() && fid != iter.curr_fid {
+            // Iteration of next field id, write previous merged block.
+            if let Some(blk) = previous_merged_block.take() {
+                // Write the small previous merged block.
+                if write_tsm(
+                    &mut tsm_writer,
+                    blk,
+                    &mut file_metas,
+                    &mut version_edit,
+                    &request,
+                )
+                .await?
+                {
                     tsm_writer =
                         tsm::new_tsm_writer(&tsm_dir, kernel.file_id_next(), false, 0).await?;
                     info!(
@@ -588,33 +716,66 @@ pub async fn run_compaction_job(
                         request.out_level
                     );
                 }
-                tsm::WriteTsmError::Finished { path } => {
-                    error!(
-                        "Trying to write by a finished tsm writer: {}",
-                        path.display()
-                    );
-                }
+            }
+        }
+
+        fid = iter.curr_fid;
+        let mut compacting_blks = blk_meta_group
+            .merge(previous_merged_block.take(), max_block_size)
+            .await?;
+        if compacting_blks.len() == 1 && compacting_blks[0].len() < max_block_size {
+            // The only one data block too small, try to extend the next compacting blocks.
+            previous_merged_block = Some(compacting_blks.remove(0));
+            continue;
+        }
+
+        let last_blk_idx = compacting_blks.len() - 1;
+        for (i, blk) in compacting_blks.into_iter().enumerate() {
+            if i == last_blk_idx && blk.len() < max_block_size {
+                // The last data block too small, try to extend to
+                // the next compacting blocks (current field id).
+                previous_merged_block = Some(blk);
+                break;
+            }
+            if write_tsm(
+                &mut tsm_writer,
+                blk,
+                &mut file_metas,
+                &mut version_edit,
+                &request,
+            )
+            .await?
+            {
+                tsm_writer = tsm::new_tsm_writer(&tsm_dir, kernel.file_id_next(), false, 0).await?;
+                info!(
+                    "Compaction: File: {} been created (level: {}).",
+                    tsm_writer.sequence(),
+                    request.out_level
+                );
             }
         }
     }
+    if let Some(blk) = previous_merged_block {
+        let _max_file_size_exceed = write_tsm(
+            &mut tsm_writer,
+            blk,
+            &mut file_metas,
+            &mut version_edit,
+            &request,
+        )
+        .await?;
+    }
+    if !tsm_writer.finished() {
+        finish_write_tsm(
+            &mut tsm_writer,
+            &mut file_metas,
+            &mut version_edit,
+            &request,
+            request.version.max_level_ts,
+        )
+        .await?;
+    }
 
-    tsm_writer
-        .write_index()
-        .await
-        .context(error::WriteTsmSnafu)?;
-    tsm_writer.finish().await.context(error::WriteTsmSnafu)?;
-    info!(
-        "Compaction: File: {} write finished (level: {}, {} B).",
-        tsm_writer.sequence(),
-        request.out_level,
-        tsm_writer.size()
-    );
-    let cm = new_compact_meta(&tsm_writer, request.ts_family_id, request.out_level);
-    version_edit.add_file(cm, version.max_level_ts);
-    file_metas.insert(
-        tsm_writer.sequence(),
-        Arc::new(tsm_writer.bloom_filter_cloned()),
-    );
     for file in request.files {
         version_edit.del_file(file.level(), file.file_id(), file.is_delta());
     }
@@ -623,8 +784,94 @@ pub async fn run_compaction_job(
         "Compaction: Compact finished, version edits: {:?}",
         version_edit
     );
-
     Ok(Some((version_edit, file_metas)))
+}
+
+async fn write_tsm(
+    tsm_writer: &mut TsmWriter,
+    blk: CompactingBlock,
+    file_metas: &mut HashMap<ColumnFileId, Arc<BloomFilter>>,
+    version_edit: &mut VersionEdit,
+    request: &CompactReq,
+) -> Result<bool> {
+    let write_ret = match blk {
+        CompactingBlock::Decoded {
+            field_id: fid,
+            data_block: b,
+            ..
+        } => tsm_writer.write_block(fid, &b).await,
+        CompactingBlock::Encoded {
+            field_id,
+            data_block,
+            ..
+        } => tsm_writer.write_encoded_block(field_id, &data_block).await,
+        CompactingBlock::Raw { meta, raw, .. } => tsm_writer.write_raw(&meta, &raw).await,
+    };
+    if let Err(e) = write_ret {
+        match e {
+            tsm::WriteTsmError::IO { source } => {
+                // TODO try re-run compaction on other time.
+                error!("Failed compaction: IO error when write tsm: {:?}", source);
+                return Err(Error::IO { source });
+            }
+            tsm::WriteTsmError::Encode { source } => {
+                // TODO try re-run compaction on other time.
+                error!(
+                    "Failed compaction: encoding error when write tsm: {:?}",
+                    source
+                );
+                return Err(Error::Encode { source });
+            }
+            tsm::WriteTsmError::MaxFileSizeExceed { .. } => {
+                finish_write_tsm(
+                    tsm_writer,
+                    file_metas,
+                    version_edit,
+                    request,
+                    request.version.max_level_ts,
+                )
+                .await?;
+                return Ok(true);
+            }
+            tsm::WriteTsmError::Finished { path } => {
+                error!(
+                    "Trying to write by a finished tsm writer: {}",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+async fn finish_write_tsm(
+    tsm_writer: &mut TsmWriter,
+    file_metas: &mut HashMap<ColumnFileId, Arc<BloomFilter>>,
+    version_edit: &mut VersionEdit,
+    request: &CompactReq,
+    max_level_ts: Timestamp,
+) -> Result<()> {
+    tsm_writer
+        .write_index()
+        .await
+        .context(error::WriteTsmSnafu)?;
+    tsm_writer.finish().await.context(error::WriteTsmSnafu)?;
+    file_metas.insert(
+        tsm_writer.sequence(),
+        Arc::new(tsm_writer.bloom_filter_cloned()),
+    );
+    info!(
+        "Compaction: File: {} write finished (level: {}, {} B).",
+        tsm_writer.sequence(),
+        request.out_level,
+        tsm_writer.size()
+    );
+
+    let cm = new_compact_meta(tsm_writer, request.ts_family_id, request.out_level);
+    version_edit.add_file(cm, max_level_ts);
+
+    Ok(())
 }
 
 fn new_compact_meta(
@@ -665,13 +912,11 @@ pub mod test {
     use crate::tseries_family::{ColumnFile, LevelInfo, Version};
     use crate::tsm::codec::DataBlockEncoding;
     use crate::tsm::{self, DataBlock, TsmReader, TsmTombstone};
-    use crate::{file_utils, TseriesFamilyId};
+    use crate::{file_utils, ColumnFileId};
 
     pub(crate) async fn write_data_blocks_to_column_file(
         dir: impl AsRef<Path>,
         data: Vec<HashMap<FieldId, Vec<DataBlock>>>,
-        _tsf_id: TseriesFamilyId,
-        _tsf_opt: Arc<Options>,
     ) -> (u64, Vec<Arc<ColumnFile>>) {
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
@@ -743,8 +988,11 @@ pub mod test {
         for (k, v) in expected_data.iter() {
             let data_blks = data.get(k).unwrap();
             if v.len() != data_blks.len() {
-                panic!("v.len() != data_blks.len()");
+                let v_str = format_data_blocks(v.as_slice());
+                let data_blks_str = format_data_blocks(data_blks.as_slice());
+                panic!("fid={k}, v.len != data_blks.len: v={v_str}, data_blks={data_blks_str}")
             }
+            assert_eq!(v.len(), data_blks.len());
             for (v_idx, v_blk) in v.iter().enumerate() {
                 assert_eq!(data_blks.get(v_idx).unwrap(), v_blk);
             }
@@ -787,6 +1035,17 @@ pub mod test {
         (compact_req, kernel)
     }
 
+    fn format_data_blocks(data_blocks: &[DataBlock]) -> String {
+        format!(
+            "[{}]",
+            data_blocks
+                .iter()
+                .map(|b| format!("{}", b))
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
+    }
+
     #[tokio::test]
     async fn test_compaction_fast() {
         #[rustfmt::skip]
@@ -819,8 +1078,7 @@ pub mod test {
         let opt = create_options(dir.to_string());
         let dir = opt.storage.tsm_dir(&database, 1);
 
-        let (next_file_id, files) =
-            write_data_blocks_to_column_file(&dir, data, 1, opt.clone()).await;
+        let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
             prepare_compact_req_and_kernel(database, opt, next_file_id, files);
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
@@ -862,8 +1120,7 @@ pub mod test {
         let opt = create_options(dir.to_string());
         let dir = opt.storage.tsm_dir(&database, 1);
 
-        let (next_file_id, files) =
-            write_data_blocks_to_column_file(&dir, data, 1, opt.clone()).await;
+        let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
             prepare_compact_req_and_kernel(database, opt, next_file_id, files);
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
@@ -890,7 +1147,7 @@ pub mod test {
             HashMap::from([
                 (1, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
                 (2, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default()}]),
+                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
             ]),
         ];
         #[rustfmt::skip]
@@ -906,8 +1163,7 @@ pub mod test {
         let opt = create_options(dir.to_string());
         let dir = opt.storage.tsm_dir(&database, 1);
 
-        let (next_file_id, files) =
-            write_data_blocks_to_column_file(&dir, data, 1, opt.clone()).await;
+        let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
             prepare_compact_req_and_kernel(database, opt, next_file_id, files);
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
@@ -1140,134 +1396,32 @@ pub mod test {
         check_column_file(dir, version_edit, expected_data).await;
     }
 
-    #[tokio::test]
-    async fn test_compaction_4() {
-        #[rustfmt::skip]
-        let data_desc = [
-            // [( tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)], vec![Option<(FieldId, MinTimestamp, MaxTimestamp)>] )]
-            (1_u64, vec![
-                // 1, 1~2500
-                (ValueType::Unsigned, 1_u64, 1_i64, 1000_i64),
-                (ValueType::Unsigned, 1, 1001, 2000),
-                (ValueType::Unsigned, 1, 2001, 2500),
-                // 2, 1~1500
-                (ValueType::Integer, 2, 1, 1000),
-                (ValueType::Integer, 2, 1001, 1500),
-                // 3, 1~1500
-                (ValueType::Boolean, 3, 1, 1000),
-                (ValueType::Boolean, 3, 1001, 1500),
-            ], vec![
-                Some((1_u64, 1_i64, 2_i64)),
-                None, None,
-                Some((2, 1001, 1002)),
-                None, None,
-                None, Some((3, 1499, 1500)), None
-            ]),
-            (2, vec![
-                // 1, 2001~4500
-                (ValueType::Unsigned, 1, 2001, 3000),
-                (ValueType::Unsigned, 1, 3001, 4000),
-                (ValueType::Unsigned, 1, 4001, 4500),
-                // 2, 1001~3000
-                (ValueType::Integer, 2, 1001, 2000),
-                (ValueType::Integer, 2, 2001, 3000),
-                // 3, 1001~2500
-                (ValueType::Boolean, 3, 1001, 2000),
-                (ValueType::Boolean, 3, 2001, 2500),
-                // 4, 1~1500
-                (ValueType::Float, 4, 1, 1000),
-                (ValueType::Float, 4, 1001, 1500),
-            ], vec![
-                Some((1, 2001, 2100)),
-                None, Some((1, 4500, 4501)),
-                Some((2, 2501, 2502)),
-                None, None,
-                None, None, None
-            ]),
-            (3, vec![
-                // 1, 4001~6500
-                (ValueType::Unsigned, 1, 4001, 5000),
-                (ValueType::Unsigned, 1, 5001, 6000),
-                (ValueType::Unsigned, 1, 6001, 6500),
-                // 2, 3001~5000
-                (ValueType::Integer, 2, 3001, 4000),
-                (ValueType::Integer, 2, 4001, 5000),
-                // 3, 2001~3500
-                (ValueType::Boolean, 3, 2001, 3000),
-                (ValueType::Boolean, 3, 3001, 3500),
-                // 4. 1001~2500
-                (ValueType::Float, 4, 1001, 2000),
-                (ValueType::Float, 4, 2001, 2500),
-            ], vec![
-                Some((1, 4500, 4501)),
-                None, None,
-                Some((2, 4001, 4002)),
-                None, None,
-                None, None, None
-            ]),
-        ];
-        #[rustfmt::skip]
-        let expected_data: HashMap<FieldId, Vec<DataBlock>> = HashMap::from(
-            [
-                // 1, 1~6500
-                (1, vec![
-                    generate_data_block(ValueType::Unsigned, vec![(3, 1002)]),
-                    generate_data_block(ValueType::Unsigned, vec![(1003, 2002)]),
-                    generate_data_block(ValueType::Unsigned, vec![(2003, 3002)]),
-                    generate_data_block(ValueType::Unsigned, vec![(3003, 4002)]),
-                    generate_data_block(ValueType::Unsigned, vec![(4003, 4499), (4502, 5004)]),
-                    generate_data_block(ValueType::Unsigned, vec![(5005, 6004)]),
-                    generate_data_block(ValueType::Unsigned, vec![(6005, 6500)]),
-                ]),
-                // 2, 1~5000
-                (2, vec![
-                    generate_data_block(ValueType::Integer, vec![(1, 1000)]),
-                    generate_data_block(ValueType::Integer, vec![(1001, 2000)]),
-                    generate_data_block(ValueType::Integer, vec![(2001, 2500), (2503, 3002)]),
-                    generate_data_block(ValueType::Integer, vec![(3003, 4000), (4003, 4004)]),
-                    generate_data_block(ValueType::Integer, vec![(4005, 5000)]),
-                ]),
-                // 3, 1~3500
-                (3, vec![
-                    generate_data_block(ValueType::Boolean, vec![(1, 1000)]),
-                    generate_data_block(ValueType::Boolean, vec![(1001, 2000)]),
-                    generate_data_block(ValueType::Boolean, vec![(2001, 3000)]),
-                    generate_data_block(ValueType::Boolean, vec![(3001, 3500)]),
-                ]),
-                // 4, 1~2500
-                (4, vec![
-                    generate_data_block(ValueType::Float, vec![(1, 1000)]),
-                    generate_data_block(ValueType::Float, vec![(1001, 2000)]),
-                    generate_data_block(ValueType::Float, vec![(2001, 2500)]),
-                ]),
-            ]
-        );
-
-        let dir = "/tmp/test/compaction/4";
-        let database = Arc::new("dba".to_string());
-        let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
-        if !file_manager::try_exists(&dir) {
-            std::fs::create_dir_all(&dir).unwrap();
-        }
-
+    #[allow(clippy::type_complexity)]
+    async fn write_data_block_desc(
+        dir: impl AsRef<Path>,
+        data_desc: &[(
+            ColumnFileId,
+            Vec<(ValueType, FieldId, Timestamp, Timestamp)>,
+            Vec<(FieldId, Timestamp, Timestamp)>,
+        )],
+    ) -> Vec<Arc<ColumnFile>> {
         let mut column_files = Vec::new();
         for (tsm_sequence, tsm_desc, tombstone_desc) in data_desc.iter() {
             let mut tsm_writer = tsm::new_tsm_writer(&dir, *tsm_sequence, false, 0)
                 .await
                 .unwrap();
-            for arg in tsm_desc.iter() {
+            for &(val_type, fid, min_ts, max_ts) in tsm_desc.iter() {
                 tsm_writer
-                    .write_block(arg.1, &generate_data_block(arg.0, vec![(arg.2, arg.3)]))
+                    .write_block(fid, &generate_data_block(val_type, vec![(min_ts, max_ts)]))
                     .await
                     .unwrap();
             }
             tsm_writer.write_index().await.unwrap();
             tsm_writer.finish().await.unwrap();
             let mut tsm_tombstone = TsmTombstone::open(&dir, *tsm_sequence).await.unwrap();
-            for t in tombstone_desc.iter().flatten() {
+            for (fid, min_ts, max_ts) in tombstone_desc.iter() {
                 tsm_tombstone
-                    .add_range(&[t.0][..], &TimeRange::new(t.1, t.2))
+                    .add_range(&[*fid][..], &TimeRange::new(*min_ts, *max_ts))
                     .await
                     .unwrap();
             }
@@ -1283,8 +1437,158 @@ pub mod test {
             )));
         }
 
-        let next_file_id = 4_u64;
+        column_files
+    }
 
+    #[tokio::test]
+    async fn test_compaction_4() {
+        #[rustfmt::skip]
+        let data_desc = [
+            // [( tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)], vec![Option<(FieldId, MinTimestamp, MaxTimestamp)>] )]
+            (1_u64, vec![
+                // 1, 1~2500
+                (ValueType::Unsigned, 1_u64, 1_i64, 1000_i64), (ValueType::Unsigned, 1, 1001, 2000), (ValueType::Unsigned, 1, 2001, 2500),
+            ], vec![(1_u64, 1_i64, 2_i64), (1, 2001, 2100)]),
+            (2, vec![
+                // 1, 2001~4500
+                // 2101~3100, 3101~4100, 4101~4499
+                (ValueType::Unsigned, 1, 2001, 3000), (ValueType::Unsigned, 1, 3001, 4000), (ValueType::Unsigned, 1, 4001, 4500),
+            ], vec![(1, 2001, 2100), (1, 4500, 4501)]),
+            (3, vec![
+                // 1, 4001~6500
+                // 4001~4499, 4502~5501, 5502~6500
+                (ValueType::Unsigned, 1, 4001, 5000), (ValueType::Unsigned, 1, 5001, 6000), (ValueType::Unsigned, 1, 6001, 6500),
+            ], vec![(1, 4500, 4501)]),
+        ];
+        #[rustfmt::skip]
+        let expected_data: HashMap<FieldId, Vec<DataBlock>> = HashMap::from(
+            [
+                // 1, 1~6500
+                (1, vec![
+                    generate_data_block(ValueType::Unsigned, vec![(3, 1002)]),
+                    generate_data_block(ValueType::Unsigned, vec![(1003, 2000), (2101, 2102)]),
+                    generate_data_block(ValueType::Unsigned, vec![(2103, 3102)]),
+                    generate_data_block(ValueType::Unsigned, vec![(3103, 4102)]),
+                    generate_data_block(ValueType::Unsigned, vec![(4103, 4499), (4502, 5104)]),
+                    generate_data_block(ValueType::Unsigned, vec![(5105, 6104)]),
+                    generate_data_block(ValueType::Unsigned, vec![(6105, 6500)]),
+                ]),
+            ]
+        );
+
+        let dir = "/tmp/test/compaction/4";
+        let database = Arc::new("dba".to_string());
+        let opt = create_options(dir.to_string());
+        let dir = opt.storage.tsm_dir(&database, 1);
+        if !file_manager::try_exists(&dir) {
+            std::fs::create_dir_all(&dir).unwrap();
+        }
+
+        let column_files = write_data_block_desc(&dir, &data_desc).await;
+        let next_file_id = 4_u64;
+        let (compact_req, kernel) =
+            prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
+
+        let (version_edit, _) = run_compaction_job(compact_req, kernel)
+            .await
+            .unwrap()
+            .unwrap();
+
+        check_column_file(dir, version_edit, expected_data).await;
+    }
+
+    #[tokio::test]
+    async fn test_compaction_5() {
+        #[rustfmt::skip]
+        let data_desc = [
+            // [( tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)], vec![Option<(FieldId, MinTimestamp, MaxTimestamp)>] )]
+            (1_u64, vec![
+                // 1, 1~2500
+                (ValueType::Unsigned, 1_u64, 1_i64, 1000_i64), (ValueType::Unsigned, 1, 1001, 2000),  (ValueType::Unsigned, 1, 2001, 2500),
+                // 2, 1~1500
+                (ValueType::Integer, 2, 1, 1000), (ValueType::Integer, 2, 1001, 1500),
+                // 3, 1~1500
+                (ValueType::Boolean, 3, 1, 1000), (ValueType::Boolean, 3, 1001, 1500),
+            ], vec![
+                (1_u64, 1_i64, 2_i64), (1, 2001, 2100),
+                (2, 1001, 1002),
+                (3, 1499, 1500),
+            ]),
+            (2, vec![
+                // 1, 2001~4500
+                (ValueType::Unsigned, 1, 2001, 3000), (ValueType::Unsigned, 1, 3001, 4000), (ValueType::Unsigned, 1, 4001, 4500),
+                // 2, 1001~3000
+                (ValueType::Integer, 2, 1001, 2000), (ValueType::Integer, 2, 2001, 3000),
+                // 3, 1001~2500
+                (ValueType::Boolean, 3, 1001, 2000), (ValueType::Boolean, 3, 2001, 2500),
+                // 4, 1~1500
+                (ValueType::Float, 4, 1, 1000), (ValueType::Float, 4, 1001, 1500),
+            ], vec![
+                (1, 2001, 2100), (1, 4500, 4501),
+                (2, 1001, 1002), (2, 2501, 2502),
+                (3, 1499, 1500),
+            ]),
+            (3, vec![
+                // 1, 4001~6500
+                (ValueType::Unsigned, 1, 4001, 5000), (ValueType::Unsigned, 1, 5001, 6000), (ValueType::Unsigned, 1, 6001, 6500),
+                // 2, 3001~5000
+                (ValueType::Integer, 2, 3001, 4000), (ValueType::Integer, 2, 4001, 5000),
+                // 3, 2001~3500
+                (ValueType::Boolean, 3, 2001, 3000), (ValueType::Boolean, 3, 3001, 3500),
+                // 4. 1001~2500
+                (ValueType::Float, 4, 1001, 2000), (ValueType::Float, 4, 2001, 2500),
+            ], vec![
+                (1, 4500, 4501),
+                (2, 4001, 4002),
+            ]),
+        ];
+        #[rustfmt::skip]
+        let expected_data: HashMap<FieldId, Vec<DataBlock>> = HashMap::from(
+            [
+                // 1, 1~6500
+                (1, vec![
+                    generate_data_block(ValueType::Unsigned, vec![(3, 1002)]),
+                    generate_data_block(ValueType::Unsigned, vec![(1003, 2000), (2101, 2102)]),
+                    generate_data_block(ValueType::Unsigned, vec![(2103, 3102)]),
+                    generate_data_block(ValueType::Unsigned, vec![(3103, 4102)]),
+                    generate_data_block(ValueType::Unsigned, vec![(4103, 4499), (4502, 5104)]),
+                    generate_data_block(ValueType::Unsigned, vec![(5105, 6104)]),
+                    generate_data_block(ValueType::Unsigned, vec![(6105, 6500)]),
+                ]),
+                // 2, 1~5000
+                (2, vec![
+                    generate_data_block(ValueType::Integer, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Integer, vec![(1003, 2002)]),
+                    generate_data_block(ValueType::Integer, vec![(2003, 2500), (2503, 3004)]),
+                    generate_data_block(ValueType::Integer, vec![(3005, 4000), (4003, 4006)]),
+                    generate_data_block(ValueType::Integer, vec![(4007, 5000)]),
+                ]),
+                // 3, 1~3500
+                (3, vec![
+                    generate_data_block(ValueType::Boolean, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Boolean, vec![(1001, 1498), (1501, 2002)]),
+                    generate_data_block(ValueType::Boolean, vec![(2003, 3002)]),
+                    generate_data_block(ValueType::Boolean, vec![(3003, 3500)]),
+                ]),
+                // 4, 1~2500
+                (4, vec![
+                    generate_data_block(ValueType::Float, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Float, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Float, vec![(2001, 2500)]),
+                ]),
+            ]
+        );
+
+        let dir = "/tmp/test/compaction/5";
+        let database = Arc::new("dba".to_string());
+        let opt = create_options(dir.to_string());
+        let dir = opt.storage.tsm_dir(&database, 1);
+        if !file_manager::try_exists(&dir) {
+            std::fs::create_dir_all(&dir).unwrap();
+        }
+
+        let column_files = write_data_block_desc(&dir, &data_desc).await;
+        let next_file_id = 4_u64;
         let (compact_req, kernel) =
             prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
 

--- a/tskv/src/compute/count.rs
+++ b/tskv/src/compute/count.rs
@@ -416,12 +416,7 @@ mod test {
                 .unwrap(),
         );
 
-        let (_, files) = runtime.block_on(write_data_blocks_to_column_file(
-            &dir,
-            data,
-            ts_family_id,
-            opt.clone(),
-        ));
+        let (_, files) = runtime.block_on(write_data_blocks_to_column_file(&dir, data));
         let version =
             build_version_by_column_files(opt.storage.clone(), database, ts_family_id, files);
         let pool: MemoryPoolRef = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
@@ -593,12 +588,7 @@ mod test {
                 .unwrap(),
         );
 
-        let (_, files) = runtime.block_on(write_data_blocks_to_column_file(
-            &dir,
-            data,
-            ts_family_id,
-            opt.clone(),
-        ));
+        let (_, files) = runtime.block_on(write_data_blocks_to_column_file(&dir, data));
         let version =
             build_version_by_column_files(opt.storage.clone(), database, ts_family_id, files);
         let test_helper = TestHelper {

--- a/tskv/src/error.rs
+++ b/tskv/src/error.rs
@@ -105,14 +105,24 @@ pub enum Error {
     #[snafu(display("Unexpected eof"))]
     Eof,
 
-    #[snafu(display("read record file block: {}", source))]
-    Encode {
+    #[snafu(display("Failed to encode record file block: {}", source))]
+    RecordFileEncode {
         source: bincode::Error,
     },
 
-    #[snafu(display("read record file block: {}", source))]
-    Decode {
+    #[snafu(display("Faield to decode record file block: {}", source))]
+    RecordFileDecode {
         source: bincode::Error,
+    },
+
+    #[snafu(display("Failed to do encode: {}", source))]
+    Encode {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("Faield to do decode: {}", source))]
+    Decode {
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
 
     #[snafu(display("Index: : {}", source))]

--- a/tskv/src/kv_option.rs
+++ b/tskv/src/kv_option.rs
@@ -52,7 +52,7 @@ pub struct StorageOptions {
 // database/data/ts_family_id/delta
 // database/data/ts_family_id/index
 impl StorageOptions {
-    pub fn level_file_size(&self, lvl: u32) -> u64 {
+    pub fn level_max_file_size(&self, lvl: u32) -> u64 {
         self.base_file_size * lvl as u64 * self.compact_trigger_file_num as u64
     }
 

--- a/tskv/src/kv_option.rs
+++ b/tskv/src/kv_option.rs
@@ -53,6 +53,7 @@ pub struct StorageOptions {
 // database/data/ts_family_id/index
 impl StorageOptions {
     pub fn level_max_file_size(&self, lvl: u32) -> u64 {
+        // TODO(zipper): size of lvl-0 is zero?
         self.base_file_size * lvl as u64 * self.compact_trigger_file_num as u64
     }
 

--- a/tskv/src/summary.rs
+++ b/tskv/src/summary.rs
@@ -217,17 +217,18 @@ impl VersionEdit {
     }
 
     pub fn encode(&self) -> Result<Vec<u8>> {
-        bincode::serialize(self).map_err(|e| Error::Encode { source: (e) })
+        bincode::serialize(self).map_err(|e| Error::RecordFileEncode { source: (e) })
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self> {
-        bincode::deserialize(buf).map_err(|e| Error::Decode { source: (e) })
+        bincode::deserialize(buf).map_err(|e| Error::RecordFileDecode { source: (e) })
     }
 
     pub fn encode_vec(data: &[Self]) -> Result<Vec<u8>> {
         let mut buf: Vec<u8> = Vec::with_capacity(data.len() * 32);
         for ve in data {
-            let ve_buf = bincode::serialize(ve).map_err(|e| Error::Encode { source: (e) })?;
+            let ve_buf =
+                bincode::serialize(ve).map_err(|e| Error::RecordFileEncode { source: (e) })?;
             let pos = buf.len();
             buf.resize(pos + 4 + ve_buf.len(), 0_u8);
             buf[pos..pos + 4].copy_from_slice((ve_buf.len() as u32).to_be_bytes().as_slice());

--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -204,7 +204,7 @@ impl LevelInfo {
         tsf_id: u32,
         storage_opt: Arc<StorageOptions>,
     ) -> Self {
-        let max_size = storage_opt.level_file_size(level);
+        let max_size = storage_opt.level_max_file_size(level);
         Self {
             files: Vec::new(),
             database,


### PR DESCRIPTION
# Which issue does this PR close?

Related #.

# Rationale for this change

The past compaction costs too much RAM because it decodes all data blocks that going to merge together and then starts merge. Now compaction decodes them and merge one by one in a loop. 

# What changes are included in this PR?

## 1. Disable `checksum group <group> `

The new style of compaction changed it's API so checksum statement won't work. I'm now working to re-enable checksum.

## 2. Improve compaction pick

- Level-4 has less possibility to be picked.
- Stop picking if total size of picked files exceed configured `max_compact_size`.
- Keep the last file picked even if picked files exceed the configurated `max_compact_size` after picked the last file.
- Reset the weight to calculate a score.
- Delete some code that not used in `picker.rs`.

## 3. Improve compact

### Handle 1 data block at a time, instead of decoding all data blocks

- Add `CompactingBlockMetaGroup` to group data block meta data that should be merged. It has method `merge` to load and merge data blocks from tsm files in a loop, return chunked `Vec<CompactingBlock>` to write to tsm.
- Enum `CompactingBlock` now has three variants:
  - `Decoded` - decoded data block.
  - `Encoded` - still encoded data block, costs lower memory than `Decoded`.
  - `Raw` - raw data, costs the lowest memory of the three variants.

## 4. Methods in `DataBlock`

- Add `decode()`, to create a `DataBlock` by encoded timestamps and values.
- Add `extend()`, to extend timestamps and values from an other `DataBlock` to self.
- Add `merge()`, to create a `DataBlock` by 2 `DataBlock`s.

## 5. Add `EncodedDataBlock`

To store encoded `DataBlock` data temporarily.

## 6. `TsmWriter` changes.

- Return `WriteTsmError::MaxFileSizeExceed` if file size exceed the max size after a write.
- Able to write `EncodedDataBlock`.

## 7. Enum `tskv::Error` changes.

### Rename

- `Encode` -> `RecordFileEncode`
- `Decode` -> `RecordFileDecode`

### Add

- `Encode` - Wrapping errors from `tsm::codec`
- `Decode` - Wrapping errors from `tsm::codec`

# Are there any user-facing changes?

Disabled statement  `checksum group <group> `.