### PR TITLE
Fix: add-tsfamily uses config max_cached_readers

### DIFF
--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -164,7 +164,9 @@ impl Database {
             seq_no,
             LevelInfo::init_levels(self.owner.clone(), tsf_id, self.opt.storage.clone()),
             i64::MIN,
-            Arc::new(ShardedCache::default()),
+            Arc::new(ShardedCache::with_capacity(
+                self.opt.storage.max_cached_readers,
+            )),
         ));
         let tf = TseriesFamily::new(
             tsf_id,


### PR DESCRIPTION
# Which issue does this PR close?

Related #.

# Rationale for this change

And when insert an existing key to LRU cache, subtract old entry entry-charge and add the new charge

# What changes are included in this PR?

# Are there any user-facing changes?
