### PR TITLE
fix(test): clippy warnings & get_disk_info on windows11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,7 +3770,7 @@ dependencies = [
  "trace",
  "utils",
  "uuid",
- "winapi",
+ "windows",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ uuid = "1.1"
 walkdir = "2.3.2"
 warp = "0.3.4"
 winapi = "0.3.9"
+windows = { version = "0.48.0" }
 zstd = "0.11.2"
 sqllogictest = "0.13.2"
 duration-str = "0.5.0"

--- a/common/models/Cargo.toml
+++ b/common/models/Cargo.toml
@@ -35,7 +35,7 @@ tokio-util = { workspace = true }
 uuid = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { workspace = true }
+windows = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 
 [features]
 default = []

--- a/common/models/src/meta_data.rs
+++ b/common/models/src/meta_data.rs
@@ -317,11 +317,11 @@ pub fn allocation_replication_set(
 pub fn get_disk_info(path: &str) -> std::io::Result<u64> {
     use std::mem::MaybeUninit;
 
-    use crate::errors::check_err;
-
     #[cfg(unix)]
     {
         use std::ffi::CString;
+
+        use crate::errors::check_err;
 
         let mut statfs = MaybeUninit::<libc::statfs>::zeroed();
         let c_storage_path = CString::new(path).unwrap();
@@ -337,50 +337,20 @@ pub fn get_disk_info(path: &str) -> std::io::Result<u64> {
     #[cfg(windows)]
     {
         use std::ffi::OsStr;
-        use std::os::windows::prelude::OsStrExt;
 
-        use winapi::um::winnt::{LPCWSTR, PULARGE_INTEGER, ULARGE_INTEGER, WCHAR};
+        use windows::core::HSTRING;
+        use windows::Win32::Storage::FileSystem::{
+            GetDiskSpaceInformationW, DISK_SPACE_INFORMATION,
+        };
 
-        // A directory on the disk.
-        // If this parameter is NULL, the function uses the root of the current disk.
-        // If this parameter is a UNC name, it must include a trailing backslash, for example, "\\MyServer\MyShare\".
-        // This parameter does not have to specify the root directory on a disk. The function accepts any directory on a disk.
-        // The calling application must have FILE_LIST_DIRECTORY access rights for this directory.
-        let dirctory_name: Vec<WCHAR> = OsStr::new(path).encode_wide().collect();
-
-        // A pointer to a variable that receives the total number of free bytes on a disk that are available to the user who is associated with the calling thread.
-        let mut free_bytes_available_to_caller = MaybeUninit::<ULARGE_INTEGER>::zeroed();
-
-        // A pointer to a variable that receives the total number of bytes on a disk that are available to the user who is associated with the calling thread.
-        let mut _total_number_of_bytes = MaybeUninit::<ULARGE_INTEGER>::zeroed();
-        // A pointer to a variable that receives the total number of bytes on a disk that are available to the user who is associated with the calling thread.
-        let mut _total_number_of_free_bytes = MaybeUninit::<ULARGE_INTEGER>::zeroed();
-        unsafe {
-            // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdiskfreespaceexw
-            // If the function succeeds, the return value is nonzero.
-            // If the function fails, the return value is zero (0). To get extended error information, call GetLastError.
-            check_err(winapi::um::fileapi::GetDiskFreeSpaceExW(
-                dirctory_name.as_ptr() as LPCWSTR,
-                free_bytes_available_to_caller.as_mut_ptr() as PULARGE_INTEGER,
-                _total_number_of_bytes.as_mut_ptr() as PULARGE_INTEGER,
-                _total_number_of_free_bytes.as_mut_ptr() as PULARGE_INTEGER,
-            ))?;
-        }
-
-        #[cfg(target_pointer_width = "64")]
-        {
-            Ok(unsafe { *free_bytes_available_to_caller.assume_init().QuadPart() })
-        }
-
-        #[cfg(target_pointer_width = "32")]
-        {
-            let u = unsafe {
-                let free_bytes_available_to_caller = free_bytes_available_to_caller.assume_init();
-                free_bytes_available_to_caller.u()
-            };
-            let mut free_bytes = u.LowPart as u64;
-            free_bytes |= (u.HighPart as u64) << 32;
-            Ok(free_bytes)
-        }
+        let hdir = HSTRING::from(OsStr::new(path));
+        let mut disk_space_info = MaybeUninit::<DISK_SPACE_INFORMATION>::zeroed();
+        let disk_space_info = unsafe {
+            GetDiskSpaceInformationW(&hdir, disk_space_info.as_mut_ptr())
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+            disk_space_info.assume_init()
+        };
+        Ok(disk_space_info.ActualAvailableAllocationUnits
+            * (disk_space_info.SectorsPerAllocationUnit * disk_space_info.BytesPerSector) as u64)
     }
 }

--- a/meta/src/model/meta_admin.rs
+++ b/meta/src/model/meta_admin.rs
@@ -195,7 +195,7 @@ impl AdminMeta for RemoteAdminMeta {
         let disk_free = match get_disk_info(&self.path) {
             Ok(size) => size,
             Err(e) => {
-                error!("Failed to get disk info:{}", e);
+                error!("Failed to get disk info '{}': {}", self.path, e);
                 0
             }
         };

--- a/query_server/sqllogicaltests/src/os/mod.rs
+++ b/query_server/sqllogicaltests/src/os/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(not(target_family = "windows"))]
+mod unix;
+#[cfg(not(target_family = "windows"))]
+pub use unix::*;
+
+#[cfg(target_family = "windows")]
+mod windows;
+#[cfg(target_family = "windows")]
+pub use windows::*;

--- a/query_server/sqllogicaltests/src/os/unix.rs
+++ b/query_server/sqllogicaltests/src/os/unix.rs
@@ -1,0 +1,39 @@
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+use sqllogictest::{default_column_validator, default_validator};
+use trace::info;
+
+use crate::instance::{CnosDBClient, SqlClientOptions};
+
+pub async fn run_test_file(
+    path: &Path,
+    relative_path: PathBuf,
+    options: SqlClientOptions,
+) -> Result<(), Box<dyn Error>> {
+    info!("Running with DataFusion runner: {}", path.display());
+    let client = CnosDBClient::new(relative_path, options);
+    let mut runner = sqllogictest::Runner::new(client);
+    runner.run_file_async(path).await?;
+    Ok(())
+}
+
+pub async fn run_complete_file(
+    path: &Path,
+    relative_path: PathBuf,
+    options: SqlClientOptions,
+) -> Result<(), Box<dyn Error>> {
+    info!("Using complete mode to complete: {}", path.display());
+
+    let client = CnosDBClient::new(relative_path, options);
+    let mut runner = sqllogictest::Runner::new(client);
+    let col_separator = " ";
+    let validator = default_validator;
+    let column_validator = default_column_validator;
+    runner
+        .update_test_file(path, col_separator, validator, column_validator)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
+}

--- a/query_server/sqllogicaltests/src/os/windows.rs
+++ b/query_server/sqllogicaltests/src/os/windows.rs
@@ -1,0 +1,28 @@
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+use trace::info;
+
+use crate::instance::{CnosDBClient, SqlClientOptions};
+
+pub async fn run_test_file(
+    path: &Path,
+    relative_path: PathBuf,
+    options: SqlClientOptions,
+) -> Result<(), Box<dyn Error>> {
+    info!("Running with DataFusion runner: {}", path.display());
+
+    let _client = CnosDBClient::new(relative_path, options);
+    Ok(())
+}
+
+pub async fn run_complete_file(
+    path: &Path,
+    relative_path: PathBuf,
+    options: SqlClientOptions,
+) -> Result<(), Box<dyn Error>> {
+    info!("Running with DataFusion runner: {}", path.display());
+
+    let _client = CnosDBClient::new(relative_path, options);
+    Ok(())
+}


### PR DESCRIPTION
# Which issue does this PR close?

Related #.

# Rationale for this change

A lot of errors in crate `sqllogicaltest` when I run `make clippy_test` on windows11. 

Get disk_info by path returns `The system cannot find the path specified. (os error 3)`.

# What changes are included in this PR?

- Add module `os::unix` and `os::windows`.
- Add code for windows platform to avoid **unused** warnings.
- Use crate `windows` persented by microsoft to get disk_info;

# Are there any user-facing changes?
