### PR TITLE
fix(fs): normalize file manager API: distinguishing read,write,create

### DIFF
--- a/tskv/benches/snafu_bench.rs
+++ b/tskv/benches/snafu_bench.rs
@@ -1,0 +1,97 @@
+use std::io;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use snafu::{ResultExt, Snafu};
+
+#[derive(Snafu, Debug)]
+pub enum Error {
+    #[snafu(display("This an error with it's base: {source}"))]
+    WithSource { source: std::io::Error },
+
+    #[snafu(display("This an error with external'{external}': {source}"))]
+    WithExternal {
+        external: String,
+        source: std::io::Error,
+    },
+}
+
+fn foo(i: usize) -> Result<(), io::Error> {
+    if i == 0 {
+        Ok(())
+    } else {
+        Err(match i {
+            1 => io::ErrorKind::Other.into(),
+            2 => io::ErrorKind::Other.into(),
+            _ => io::ErrorKind::Other.into(),
+        })
+    }
+}
+
+fn bench_with_source(c: &mut Criterion) {
+    let len = 10;
+    let mut numbers = Vec::with_capacity(len);
+    for _ in 0..numbers.len() {
+        numbers.push(rand::random::<usize>() % 3);
+    }
+
+    let mut idx = 0_usize;
+    c.bench_function("bench_snafu_with_source", |b| {
+        b.iter(|| {
+            let i = unsafe { numbers.get_unchecked(idx % len) };
+            idx += 1;
+
+            let r = foo(*i).context(WithSourceSnafu);
+            drop(r);
+        });
+    });
+
+    idx = 0;
+    c.bench_function("bench_map_err_with_source", |b| {
+        b.iter(|| {
+            let i = unsafe { numbers.get_unchecked(idx % len) };
+            idx += 1;
+
+            let r = foo(*i).map_err(|e| Error::WithSource { source: e });
+            drop(r);
+        });
+    });
+}
+
+fn bench_with_external(c: &mut Criterion) {
+    let len = 100;
+    let mut numbers = Vec::with_capacity(len);
+    for _ in 0..len {
+        numbers.push(rand::random::<usize>() % 3);
+    }
+    let base_err_message = "Failed to get file_metadata".to_string();
+
+    let mut idx = 0_usize;
+    c.bench_function("bench_snafu_with_external", |b| {
+        b.iter(|| {
+            let i = unsafe { numbers.get_unchecked(idx % len) };
+            idx += 1;
+
+            let r = foo(*i).context(WithExternalSnafu {
+                external: format!("Failed to run foo: {}", &base_err_message),
+            });
+            drop(r);
+        });
+    });
+
+    idx = 0;
+    c.bench_function("bench_map_err_with_external", |b| {
+        b.iter(|| {
+            let i = unsafe { numbers.get_unchecked(idx % len) };
+            idx += 1;
+
+            let r = foo(*i).map_err(|e| Error::WithExternal {
+                external: format!("Failed to run foo: {}", &base_err_message),
+                source: e,
+            });
+            drop(r);
+        });
+    });
+}
+
+criterion_group!(benches, bench_with_source, bench_with_external);
+criterion_main!(benches);

--- a/tskv/src/compaction/check.rs
+++ b/tskv/src/compaction/check.rs
@@ -966,7 +966,7 @@ mod test {
         let wal_dir = "/tmp/test/repair/1/wal".to_string();
         let log_dir = "/tmp/test/repair/1/log".to_string();
         // trace::init_default_global_tracing(&log_dir, "test.log", "debug");
-        let _ = std::fs::remove_dir(&base_dir);
+        let _ = std::fs::remove_dir_all(&base_dir);
         let tenant_name = "cnosdb".to_string();
         let database_name = "test_get_vnode_hash_tree".to_string();
         let vnode_id: TseriesFamilyId = 1;

--- a/tskv/src/error.rs
+++ b/tskv/src/error.rs
@@ -73,6 +73,12 @@ pub enum Error {
         source: std::io::Error,
     },
 
+    #[snafu(display("Unable to create file '{}': {}", path.display(), source))]
+    CreateFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
     #[snafu(display("Error with read file '{}': {}", path.display(), source))]
     ReadFile {
         path: PathBuf,

--- a/tskv/src/index/binlog.rs
+++ b/tskv/src/index/binlog.rs
@@ -142,8 +142,7 @@ impl BinlogWriter {
         // Get file and check if new file
         let mut new_file = false;
         let file = if file_manager::try_exists(path) {
-            let f = file_manager::get_file_manager()
-                .open_file(path)
+            let f = file_manager::open_create_file(path)
                 .await
                 .map_err(|e| IndexError::FileErrors { msg: e.to_string() })?;
             if f.is_empty() {
@@ -152,8 +151,7 @@ impl BinlogWriter {
             f
         } else {
             new_file = true;
-            file_manager::get_file_manager()
-                .create_file(path)
+            file_manager::create_file(path)
                 .await
                 .map_err(|e| IndexError::FileErrors { msg: e.to_string() })?
         };

--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -1055,7 +1055,7 @@ pub mod test_tseries_family {
         //! - Lv.3: [ ]
         //! - Lv.4: [ ]
         let dir = "/tmp/test/ts_family/1";
-        let _ = std::fs::remove_dir(dir);
+        let _ = std::fs::remove_dir_all(dir);
         std::fs::create_dir_all(dir).unwrap();
         let mut global_config = config::get_config_for_test();
         global_config.storage.path = dir.to_string();
@@ -1150,7 +1150,7 @@ pub mod test_tseries_family {
         //! - Lv.3: [ (6, 1~2000) ]
         //! - Lv.4: [ ]
         let dir = "/tmp/test/ts_family/2";
-        let _ = std::fs::remove_dir(dir);
+        let _ = std::fs::remove_dir_all(dir);
         std::fs::create_dir_all(dir).unwrap();
         let mut global_config = config::get_config_for_test();
         global_config.storage.path = dir.to_string();
@@ -1291,7 +1291,7 @@ pub mod test_tseries_family {
     #[tokio::test]
     pub async fn test_tsf_delete() {
         let dir = "/tmp/test/ts_family/tsf_delete";
-        let _ = std::fs::remove_dir(dir);
+        let _ = std::fs::remove_dir_all(dir);
         std::fs::create_dir_all(dir).unwrap();
         let mut global_config = config::get_config_for_test();
         global_config.storage.path = dir.to_string();
@@ -1440,7 +1440,7 @@ pub mod test_tseries_family {
         };
 
         let dir = "/tmp/test/ts_family/read_with_tomb";
-        let _ = std::fs::remove_dir(dir);
+        let _ = std::fs::remove_dir_all(dir);
         std::fs::create_dir_all(dir).unwrap();
         let mut global_config = config::get_config_for_test();
         global_config.storage.path = dir.to_string();

--- a/tskv/src/tsm/tombstone.rs
+++ b/tskv/src/tsm/tombstone.rs
@@ -216,7 +216,7 @@ mod test {
     #[tokio::test]
     async fn test_write_read_1() {
         let dir = PathBuf::from("/tmp/test/tombstone/1".to_string());
-        let _ = std::fs::remove_dir(&dir);
+        let _ = std::fs::remove_dir_all(&dir);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
@@ -242,7 +242,7 @@ mod test {
     #[tokio::test]
     async fn test_write_read_2() {
         let dir = PathBuf::from("/tmp/test/tombstone/2".to_string());
-        let _ = std::fs::remove_dir(&dir);
+        let _ = std::fs::remove_dir_all(&dir);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
@@ -283,7 +283,7 @@ mod test {
     #[tokio::test]
     async fn test_write_read_3() {
         let dir = PathBuf::from("/tmp/test/tombstone/3".to_string());
-        let _ = std::fs::remove_dir(&dir);
+        let _ = std::fs::remove_dir_all(&dir);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }


### PR DESCRIPTION
# Which issue does this PR close?

Related #.

# Rationale for this change

I thought methods in `FileManager` has something wrong.

- `open_file` also create the file if not exists.
- Some `Error` instanced too early.

# What changes are included in this PR?

1. Methods in file manager has it's own function:
   - `open_file`: Open a file to read.
   - `create_file`: Open or create a file to read & write, overwrite if exists.
   - `open_create_file`: Open or create a file to read & write, append if exists.
2. Some unit test doesn't clean it's directory since last run.
   - change `remote_dir()` to `remove_dir_all()`.
# Are there any user-facing changes?
