### PR TITLE
feat(compaction): add delta compaction

### DIFF
--- a/meta/singleton.sh
+++ b/meta/singleton.sh
@@ -72,7 +72,7 @@ kill() {
   if [ "$(uname)" = "Darwin" ]; then
     SERVICE='cnosdb-meta'
     if pgrep -xq -- "${SERVICE}"; then
-      pkill -f "${SERVICE}"
+      pkill -9 -f "${SERVICE}"
     fi
   else
     set +e # killall will error if finds no process to kill

--- a/tskv/src/compaction/compact.rs
+++ b/tskv/src/compaction/compact.rs
@@ -1,5 +1,6 @@
 use std::collections::{BinaryHeap, HashMap, VecDeque};
 use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -17,7 +18,7 @@ use crate::summary::{CompactMeta, VersionEdit};
 use crate::tseries_family::TseriesFamily;
 use crate::tsm::{
     self, BlockMeta, BlockMetaIterator, DataBlock, EncodedDataBlock, IndexIterator, IndexMeta,
-    TsmReader, TsmWriter,
+    TsmReader, TsmWriter, WriteTsmError, WriteTsmResult,
 };
 use crate::{ColumnFileId, Error, LevelId, TseriesFamilyId};
 
@@ -418,13 +419,14 @@ pub(crate) struct CompactIterator {
     compacting_files: BinaryHeap<Pin<Box<CompactingFile>>>,
     /// Maximum values in generated CompactingBlock
     max_data_block_size: usize,
-    // /// The time range of data to be merged of level-0 data blocks.
-    // /// The level-0 data that out of the thime range will write back to level-0.
-    // level_time_range: TimeRange,
     /// Decode a data block even though it doesn't need to merge with others,
     /// return CompactingBlock::DataBlock rather than CompactingBlock::Raw .
     decode_non_overlap_blocks: bool,
-
+    // /// Whether to enable `out_level_time_range`.
+    // delta_compaction: bool,
+    // /// The time range of data to be merged of level-0 data blocks.
+    // /// The level-0 data that after the time range will write back to level-0.
+    // out_level_time_range: TimeRange,
     tmp_tsm_blk_meta_iters: Vec<BlockMetaIterator>,
     /// Index to mark `Peekable<BlockMetaIterator>` in witch `TsmReader`,
     /// tmp_tsm_blks[i] is in self.tsm_readers[ tmp_tsm_blk_tsm_reader_idx[i] ]
@@ -673,7 +675,6 @@ pub async fn run_compaction_job(
     }
 
     // Buffers all tsm-files and it's indexes for this compaction
-    let tsf_id = request.ts_family_id;
     let mut tsm_readers = Vec::new();
     for col_file in request.files.iter() {
         let tsm_reader = request.version.get_tsm_reader(col_file.file_path()).await?;
@@ -682,15 +683,7 @@ pub async fn run_compaction_job(
 
     let max_block_size = TseriesFamily::MAX_DATA_BLOCK_SIZE as usize;
     let mut iter = CompactIterator::new(tsm_readers, max_block_size, false);
-    let tsm_dir = request.storage_opt.tsm_dir(&request.database, tsf_id);
-    let mut tsm_writer = tsm::new_tsm_writer(&tsm_dir, kernel.file_id_next(), false, 0).await?;
-    info!(
-        "Compaction: File: {} been created (level: {}).",
-        tsm_writer.sequence(),
-        request.out_level
-    );
-    let mut version_edit = VersionEdit::new(tsf_id);
-    let mut file_metas: HashMap<ColumnFileId, Arc<BloomFilter>> = HashMap::new();
+    let mut writer_wrapper = WriterWrapper::new(&request, kernel.clone());
 
     let mut previous_merged_block: Option<CompactingBlock> = None;
     let mut fid = iter.curr_fid;
@@ -700,23 +693,7 @@ pub async fn run_compaction_job(
             // Iteration of next field id, write previous merged block.
             if let Some(blk) = previous_merged_block.take() {
                 // Write the small previous merged block.
-                if write_tsm(
-                    &mut tsm_writer,
-                    blk,
-                    &mut file_metas,
-                    &mut version_edit,
-                    &request,
-                )
-                .await?
-                {
-                    tsm_writer =
-                        tsm::new_tsm_writer(&tsm_dir, kernel.file_id_next(), false, 0).await?;
-                    info!(
-                        "Compaction: File: {} been created (level: {}).",
-                        tsm_writer.sequence(),
-                        request.out_level
-                    );
-                }
+                writer_wrapper.write(blk).await?;
             }
         }
 
@@ -738,45 +715,14 @@ pub async fn run_compaction_job(
                 previous_merged_block = Some(blk);
                 break;
             }
-            if write_tsm(
-                &mut tsm_writer,
-                blk,
-                &mut file_metas,
-                &mut version_edit,
-                &request,
-            )
-            .await?
-            {
-                tsm_writer = tsm::new_tsm_writer(&tsm_dir, kernel.file_id_next(), false, 0).await?;
-                info!(
-                    "Compaction: File: {} been created (level: {}).",
-                    tsm_writer.sequence(),
-                    request.out_level
-                );
-            }
+            writer_wrapper.write(blk).await?;
         }
     }
     if let Some(blk) = previous_merged_block {
-        let _max_file_size_exceed = write_tsm(
-            &mut tsm_writer,
-            blk,
-            &mut file_metas,
-            &mut version_edit,
-            &request,
-        )
-        .await?;
-    }
-    if !tsm_writer.finished() {
-        finish_write_tsm(
-            &mut tsm_writer,
-            &mut file_metas,
-            &mut version_edit,
-            &request,
-            request.version.max_level_ts,
-        )
-        .await?;
+        writer_wrapper.write(blk).await?;
     }
 
+    let (mut version_edit, file_metas) = writer_wrapper.close().await?;
     for file in request.files {
         version_edit.del_file(file.level(), file.file_id(), file.is_delta());
     }
@@ -788,91 +734,459 @@ pub async fn run_compaction_job(
     Ok(Some((version_edit, file_metas)))
 }
 
-async fn write_tsm(
-    tsm_writer: &mut TsmWriter,
-    blk: CompactingBlock,
-    file_metas: &mut HashMap<ColumnFileId, Arc<BloomFilter>>,
-    version_edit: &mut VersionEdit,
-    request: &CompactReq,
-) -> Result<bool> {
-    let write_ret = match blk {
-        CompactingBlock::Decoded {
-            field_id: fid,
-            data_block: b,
-            ..
-        } => tsm_writer.write_block(fid, &b).await,
-        CompactingBlock::Encoded {
-            field_id,
-            data_block,
-            ..
-        } => tsm_writer.write_encoded_block(field_id, &data_block).await,
-        CompactingBlock::Raw { meta, raw, .. } => tsm_writer.write_raw(&meta, &raw).await,
-    };
-    if let Err(e) = write_ret {
-        match e {
-            tsm::WriteTsmError::IO { source } => {
+pub(crate) struct WriterWrapper {
+    // Init values.
+    delta_compaction: bool,
+    ts_family_id: TseriesFamilyId,
+    out_level: LevelId,
+    out_level_max_ts: Timestamp,
+    max_level_ts: Timestamp,
+    max_file_size: u64,
+    tsm_dir: PathBuf,
+    delta_dir: PathBuf,
+    context: Arc<GlobalContext>,
+
+    // Temporary values.
+    tsm_writer_full: bool,
+    tsm_writer: Option<TsmWriter>,
+    delta_writer_full: bool,
+    delta_writer: Option<TsmWriter>,
+
+    // Result values.
+    version_edit: VersionEdit,
+    file_metas: HashMap<ColumnFileId, Arc<BloomFilter>>,
+}
+
+impl WriterWrapper {
+    pub fn new(request: &CompactReq, context: Arc<GlobalContext>) -> Self {
+        Self {
+            delta_compaction: request.in_level == 0,
+            ts_family_id: request.ts_family_id,
+            out_level: request.out_level,
+            out_level_max_ts: request.time_range.max_ts,
+            max_level_ts: request.version.max_level_ts,
+            max_file_size: request
+                .version
+                .storage_opt
+                .level_max_file_size(request.out_level),
+            tsm_dir: request
+                .storage_opt
+                .tsm_dir(&request.database, request.ts_family_id),
+            delta_dir: request
+                .storage_opt
+                .delta_dir(&request.database, request.ts_family_id),
+            context,
+
+            tsm_writer_full: false,
+            tsm_writer: None,
+            delta_writer_full: false,
+            delta_writer: None,
+
+            version_edit: VersionEdit::new(request.ts_family_id),
+            file_metas: HashMap::new(),
+        }
+    }
+
+    pub async fn close(mut self) -> Result<(VersionEdit, HashMap<ColumnFileId, Arc<BloomFilter>>)> {
+        if let Some(ref mut w) = self.delta_writer {
+            Self::close_writer(
+                w,
+                &mut self.file_metas,
+                &mut self.version_edit,
+                0,
+                self.ts_family_id,
+                self.max_level_ts,
+            )
+            .await?;
+        }
+        if let Some(ref mut w) = self.tsm_writer {
+            Self::close_writer(
+                w,
+                &mut self.file_metas,
+                &mut self.version_edit,
+                self.out_level,
+                self.ts_family_id,
+                self.max_level_ts,
+            )
+            .await?;
+        }
+
+        Ok((self.version_edit, self.file_metas))
+    }
+
+    /// Write CompactingBlock to TsmWriter, fill file_metas and version_edit.
+    pub async fn write(&mut self, blk: CompactingBlock) -> Result<()> {
+        match blk {
+            CompactingBlock::Decoded {
+                priority: _priority,
+                field_id,
+                data_block,
+            } => {
+                if self.delta_compaction {
+                    if let Some(tr) = data_block.time_range() {
+                        if tr.0 < self.out_level_max_ts && tr.1 > self.out_level_max_ts {
+                            // Split block.
+                            let (tsm_blk, delta_blk) = data_block.split(self.out_level_max_ts);
+                            if !tsm_blk.is_empty() {
+                                self.write_tsm_data_block(field_id, &tsm_blk).await?;
+                            }
+                            if !delta_blk.is_empty() {
+                                self.write_delta_data_block(field_id, &delta_blk).await?;
+                            }
+                        } else if tr.0 > self.out_level_max_ts {
+                            self.write_delta_data_block(field_id, &data_block).await?;
+                        } else {
+                            self.write_tsm_data_block(field_id, &data_block).await?;
+                        }
+                    }
+                } else {
+                    self.write_tsm_data_block(field_id, &data_block).await?;
+                }
+            }
+            CompactingBlock::Encoded {
+                priority,
+                field_id,
+                data_block,
+            } => {
+                if self.delta_compaction {
+                    if let Some(tr) = data_block.time_range {
+                        if tr.min_ts < self.out_level_max_ts && tr.max_ts > self.out_level_max_ts {
+                            // Split block.
+                            let decoded_blk =
+                                CompactingBlock::encoded(priority, field_id, data_block)
+                                    .decode()?;
+                            let (tsm_blk, delta_blk) = decoded_blk.split(self.out_level_max_ts);
+                            if !tsm_blk.is_empty() {
+                                self.write_tsm_data_block(field_id, &tsm_blk).await?;
+                            }
+                            if !delta_blk.is_empty() {
+                                self.write_delta_data_block(field_id, &delta_blk).await?;
+                            }
+                        } else if tr.min_ts > self.out_level_max_ts {
+                            self.write_delta_encoded_data_block(field_id, &data_block)
+                                .await?;
+                        } else {
+                            self.write_tsm_encoded_data_block(field_id, &data_block)
+                                .await?;
+                        }
+                    }
+                } else {
+                    self.write_tsm_encoded_data_block(field_id, &data_block)
+                        .await?;
+                }
+            }
+            CompactingBlock::Raw {
+                priority,
+                meta,
+                raw,
+            } => {
+                if self.delta_compaction {
+                    let tr = meta.time_range();
+                    if tr.min_ts < self.out_level_max_ts && tr.max_ts > self.out_level_max_ts {
+                        // Split block.
+                        let field_id = meta.field_id();
+                        let decoded_blk = CompactingBlock::raw(priority, meta, raw).decode()?;
+                        let (tsm_blk, delta_blk) = decoded_blk.split(self.out_level_max_ts);
+                        if !tsm_blk.is_empty() {
+                            self.write_tsm_data_block(field_id, &tsm_blk).await?;
+                        }
+                        if !delta_blk.is_empty() {
+                            self.write_delta_data_block(field_id, &delta_blk).await?;
+                        }
+                    } else if tr.min_ts > self.out_level_max_ts {
+                        self.write_delta_raw_data_block(&meta, &raw).await?;
+                    } else {
+                        self.write_tsm_raw_data_block(&meta, &raw).await?;
+                    }
+                } else {
+                    self.write_tsm_raw_data_block(&meta, &raw).await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn write_delta_data_block(
+        &mut self,
+        field_id: FieldId,
+        data_block: &DataBlock,
+    ) -> Result<usize> {
+        self.write_block_inner(field_id, data_block, true).await
+    }
+
+    pub async fn write_tsm_data_block(
+        &mut self,
+        field_id: FieldId,
+        data_block: &DataBlock,
+    ) -> Result<usize> {
+        self.write_block_inner(field_id, data_block, false).await
+    }
+
+    async fn write_block_inner(
+        &mut self,
+        field_id: FieldId,
+        data_block: &DataBlock,
+        is_delta: bool,
+    ) -> Result<usize> {
+        let write_ret = if is_delta {
+            let write_ret = self
+                .delta_writer_mut()
+                .await?
+                .write_block(field_id, data_block)
+                .await;
+            if let Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) = write_ret {
+                self.delta_writer_full = true;
+                return Ok(write_size);
+            }
+            write_ret
+        } else {
+            let write_ret = self
+                .tsm_writer_mut()
+                .await?
+                .write_block(field_id, data_block)
+                .await;
+            if let Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) = write_ret {
+                self.tsm_writer_full = true;
+                return Ok(write_size);
+            }
+            write_ret
+        };
+        Self::warp_write_tsm_result(write_ret)
+    }
+
+    pub async fn write_delta_encoded_data_block(
+        &mut self,
+        field_id: FieldId,
+        data_block: &EncodedDataBlock,
+    ) -> Result<usize> {
+        self.write_encoded_block_inner(field_id, data_block, true)
+            .await
+    }
+
+    pub async fn write_tsm_encoded_data_block(
+        &mut self,
+        field_id: FieldId,
+        data_block: &EncodedDataBlock,
+    ) -> Result<usize> {
+        self.write_encoded_block_inner(field_id, data_block, false)
+            .await
+    }
+
+    async fn write_encoded_block_inner(
+        &mut self,
+        field_id: FieldId,
+        data_block: &EncodedDataBlock,
+        is_delta: bool,
+    ) -> Result<usize> {
+        let write_ret = if is_delta {
+            let write_ret = self
+                .delta_writer_mut()
+                .await?
+                .write_encoded_block(field_id, data_block)
+                .await;
+            if let Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) = write_ret {
+                self.delta_writer_full = true;
+                return Ok(write_size);
+            }
+            write_ret
+        } else {
+            let write_ret = self
+                .tsm_writer_mut()
+                .await?
+                .write_encoded_block(field_id, data_block)
+                .await;
+            if let Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) = write_ret {
+                self.tsm_writer_full = true;
+                return Ok(write_size);
+            }
+            write_ret
+        };
+        Self::warp_write_tsm_result(write_ret)
+    }
+
+    pub async fn write_delta_raw_data_block(
+        &mut self,
+        block_meta: &BlockMeta,
+        data_block: &[u8],
+    ) -> Result<usize> {
+        self.write_raw_inner(block_meta, data_block, true).await
+    }
+
+    pub async fn write_tsm_raw_data_block(
+        &mut self,
+        block_meta: &BlockMeta,
+        data_block: &[u8],
+    ) -> Result<usize> {
+        self.write_raw_inner(block_meta, data_block, false).await
+    }
+
+    async fn write_raw_inner(
+        &mut self,
+        block_meta: &BlockMeta,
+        data_block: &[u8],
+        is_delta: bool,
+    ) -> Result<usize> {
+        let write_ret = if is_delta {
+            let write_ret = self
+                .delta_writer_mut()
+                .await?
+                .write_raw(block_meta, data_block)
+                .await;
+            if let Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) = write_ret {
+                self.delta_writer_full = true;
+                return Ok(write_size);
+            }
+            write_ret
+        } else {
+            let write_ret = self
+                .tsm_writer_mut()
+                .await?
+                .write_raw(block_meta, data_block)
+                .await;
+            if let Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) = write_ret {
+                self.tsm_writer_full = true;
+                return Ok(write_size);
+            }
+            write_ret
+        };
+        Self::warp_write_tsm_result(write_ret)
+    }
+
+    async fn tsm_writer_mut(&mut self) -> Result<&mut TsmWriter> {
+        if self.tsm_writer_full {
+            if let Some(ref mut w) = self.tsm_writer {
+                Self::close_writer(
+                    w,
+                    &mut self.file_metas,
+                    &mut self.version_edit,
+                    self.out_level,
+                    self.ts_family_id,
+                    self.out_level_max_ts,
+                )
+                .await?;
+            }
+            self.new_writer(false).await
+        } else {
+            match self.tsm_writer {
+                Some(ref mut w) => Ok(w),
+                None => self.new_writer(false).await,
+            }
+        }
+    }
+
+    async fn delta_writer_mut(&mut self) -> Result<&mut TsmWriter> {
+        if self.delta_writer_full {
+            if let Some(ref mut w) = self.tsm_writer {
+                Self::close_writer(
+                    w,
+                    &mut self.file_metas,
+                    &mut self.version_edit,
+                    0,
+                    self.ts_family_id,
+                    self.out_level_max_ts,
+                )
+                .await?;
+            }
+            self.new_writer(true).await
+        } else {
+            match self.delta_writer {
+                Some(ref mut w) => Ok(w),
+                None => self.new_writer(true).await,
+            }
+        }
+    }
+
+    async fn new_writer(&mut self, is_delta: bool) -> Result<&mut TsmWriter> {
+        let writer_path = if is_delta {
+            &self.delta_dir
+        } else {
+            &self.tsm_dir
+        };
+        let writer = tsm::new_tsm_writer(
+            writer_path,
+            self.context.file_id_next(),
+            is_delta,
+            self.max_file_size,
+        )
+        .await?;
+        info!(
+            "Compaction: File: {} been created (level: {}).",
+            writer.sequence(),
+            if is_delta { 0 } else { self.out_level }
+        );
+
+        if is_delta {
+            self.delta_writer_full = false;
+            Ok(self.delta_writer.insert(writer))
+        } else {
+            self.tsm_writer_full = false;
+            Ok(self.tsm_writer.insert(writer))
+        }
+    }
+
+    async fn close_writer(
+        tsm_writer: &mut TsmWriter,
+        file_metas: &mut HashMap<ColumnFileId, Arc<BloomFilter>>,
+        version_edit: &mut VersionEdit,
+        out_level: LevelId,
+        ts_family_id: TseriesFamilyId,
+        max_level_ts: Timestamp,
+    ) -> Result<()> {
+        tsm_writer
+            .write_index()
+            .await
+            .context(error::WriteTsmSnafu)?;
+        tsm_writer.finish().await.context(error::WriteTsmSnafu)?;
+        file_metas.insert(
+            tsm_writer.sequence(),
+            Arc::new(tsm_writer.bloom_filter_cloned()),
+        );
+        info!(
+            "Compaction: File: {} write finished (level: {}, {} B).",
+            tsm_writer.sequence(),
+            out_level,
+            tsm_writer.size()
+        );
+
+        let cm = new_compact_meta(tsm_writer, ts_family_id, out_level);
+        version_edit.add_file(cm, max_level_ts);
+
+        Ok(())
+    }
+
+    fn warp_write_tsm_result<T: Default>(write_result: WriteTsmResult<T>) -> Result<T> {
+        match write_result {
+            Ok(size) => Ok(size),
+            Err(tsm::WriteTsmError::IO { source }) => {
                 // TODO try re-run compaction on other time.
                 error!("Failed compaction: IO error when write tsm: {:?}", source);
-                return Err(Error::IO { source });
+                Err(Error::IO { source })
             }
-            tsm::WriteTsmError::Encode { source } => {
+            Err(tsm::WriteTsmError::Encode { source }) => {
                 // TODO try re-run compaction on other time.
                 error!(
                     "Failed compaction: encoding error when write tsm: {:?}",
                     source
                 );
-                return Err(Error::Encode { source });
+                Err(Error::Encode { source })
             }
-            tsm::WriteTsmError::MaxFileSizeExceed { .. } => {
-                finish_write_tsm(
-                    tsm_writer,
-                    file_metas,
-                    version_edit,
-                    request,
-                    request.version.max_level_ts,
-                )
-                .await?;
-                return Ok(true);
-            }
-            tsm::WriteTsmError::Finished { path } => {
+            Err(tsm::WriteTsmError::Finished { path }) => {
                 error!(
-                    "Trying to write by a finished tsm writer: {}",
+                    "Failed compaction: Trying write already finished tsm file: '{}'",
                     path.display()
                 );
+                Err(Error::WriteTsm {
+                    source: tsm::WriteTsmError::Finished { path },
+                })
+            }
+            Err(tsm::WriteTsmError::MaxFileSizeExceed { .. }) => {
+                // This error should be already handled before, ignore.
+                error!("WriteTsmError::MaxFileSizeExceed should be handled before.");
+                Ok(T::default())
             }
         }
     }
-
-    Ok(false)
-}
-
-async fn finish_write_tsm(
-    tsm_writer: &mut TsmWriter,
-    file_metas: &mut HashMap<ColumnFileId, Arc<BloomFilter>>,
-    version_edit: &mut VersionEdit,
-    request: &CompactReq,
-    max_level_ts: Timestamp,
-) -> Result<()> {
-    tsm_writer
-        .write_index()
-        .await
-        .context(error::WriteTsmSnafu)?;
-    tsm_writer.finish().await.context(error::WriteTsmSnafu)?;
-    file_metas.insert(
-        tsm_writer.sequence(),
-        Arc::new(tsm_writer.bloom_filter_cloned()),
-    );
-    info!(
-        "Compaction: File: {} write finished (level: {}, {} B).",
-        tsm_writer.sequence(),
-        request.out_level,
-        tsm_writer.size()
-    );
-
-    let cm = new_compact_meta(tsm_writer, request.ts_family_id, request.out_level);
-    version_edit.add_file(cm, max_level_ts);
-
-    Ok(())
 }
 
 fn new_compact_meta(
@@ -913,7 +1227,7 @@ pub mod test {
     use crate::tseries_family::{ColumnFile, LevelInfo, Version};
     use crate::tsm::codec::DataBlockEncoding;
     use crate::tsm::{self, DataBlock, TsmReader, TsmTombstone};
-    use crate::{file_utils, ColumnFileId};
+    use crate::{file_utils, ColumnFileId, LevelId};
 
     pub(crate) async fn write_data_blocks_to_column_file(
         dir: impl AsRef<Path>,
@@ -963,13 +1277,26 @@ pub mod test {
         data
     }
 
-    fn get_result_file_path(dir: impl AsRef<Path>, version_edit: VersionEdit) -> PathBuf {
+    fn get_result_file_path(
+        dir: impl AsRef<Path>,
+        version_edit: VersionEdit,
+        level: LevelId,
+    ) -> PathBuf {
         if version_edit.has_file_id && !version_edit.add_files.is_empty() {
-            let file_id = version_edit.add_files.first().unwrap().file_id;
-            return file_utils::make_tsm_file_name(dir, file_id);
+            if let Some(f) = version_edit
+                .add_files
+                .into_iter()
+                .find(|f| f.level == level)
+            {
+                if level == 0 {
+                    return file_utils::make_delta_file_name(dir, f.file_id);
+                } else {
+                    return file_utils::make_tsm_file_name(dir, f.file_id);
+                }
+            }
+            panic!("VersionEdit::add_files doesn't contain any file matches level-{level}.");
         }
-
-        panic!("VersionEdit doesn't contain any add_files.");
+        panic!("VersionEdit::add_files is empty, no file to read.");
     }
 
     /// Compare DataBlocks in path with the expected_Data using assert_eq.
@@ -977,8 +1304,9 @@ pub mod test {
         dir: impl AsRef<Path>,
         version_edit: VersionEdit,
         expected_data: HashMap<FieldId, Vec<DataBlock>>,
+        expected_data_level: LevelId,
     ) {
-        let path = get_result_file_path(dir, version_edit);
+        let path = get_result_file_path(dir, version_edit, expected_data_level);
         let data = read_data_blocks_from_column_file(path).await;
         let mut data_field_ids = data.keys().copied().collect::<Vec<_>>();
         data_field_ids.sort_unstable();
@@ -1002,16 +1330,17 @@ pub mod test {
 
     pub(crate) fn create_options(base_dir: String) -> Arc<Options> {
         let mut config = config::get_config_for_test();
-        config.storage.path = base_dir;
-        let opt = Options::from(&config);
-        Arc::new(opt)
+        config.storage.path = base_dir.clone();
+        config.log.path = base_dir;
+        Arc::new(Options::from(&config))
     }
 
-    fn prepare_compact_req_and_kernel(
+    fn prepare_compaction(
         database: Arc<String>,
         opt: Arc<Options>,
-        next_file_id: u64,
+        next_file_id: ColumnFileId,
         files: Vec<Arc<ColumnFile>>,
+        max_level_ts: Timestamp,
     ) -> (CompactReq, Arc<GlobalContext>) {
         let version = Arc::new(Version::new(
             1,
@@ -1019,7 +1348,7 @@ pub mod test {
             opt.storage.clone(),
             1,
             LevelInfo::init_levels(database.clone(), 0, opt.storage.clone()),
-            1000,
+            max_level_ts,
             Arc::new(ShardedCache::with_capacity(1)),
         ));
         let compact_req = CompactReq {
@@ -1028,12 +1357,14 @@ pub mod test {
             storage_opt: opt.storage.clone(),
             files,
             version,
+            in_level: 1,
             out_level: 2,
+            time_range: TimeRange::all(),
         };
-        let kernel = Arc::new(GlobalContext::new());
-        kernel.set_file_id(next_file_id);
+        let context = Arc::new(GlobalContext::new());
+        context.set_file_id(next_file_id);
 
-        (compact_req, kernel)
+        (compact_req, context)
     }
 
     fn format_data_blocks(data_blocks: &[DataBlock]) -> String {
@@ -1047,6 +1378,7 @@ pub mod test {
         )
     }
 
+    /// Test compaction with ordered data.
     #[tokio::test]
     async fn test_compaction_fast() {
         #[rustfmt::skip]
@@ -1074,21 +1406,25 @@ pub mod test {
             (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
         ]);
 
-        let dir = "/tmp/test/compaction";
+        let dir = "/tmp/test/compaction/0";
+        let _ = std::fs::remove_dir_all(dir);
         let database = Arc::new("dba".to_string());
         let opt = create_options(dir.to_string());
         let dir = opt.storage.tsm_dir(&database, 1);
+        let max_level_ts = 9;
 
         let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, files);
+            prepare_compaction(database, opt, next_file_id, files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
+    /// Test compact with disordered files.
     #[tokio::test]
     async fn test_compaction_1() {
         #[rustfmt::skip]
@@ -1117,20 +1453,24 @@ pub mod test {
         ]);
 
         let dir = "/tmp/test/compaction/1";
+        let _ = std::fs::remove_dir_all(dir);
         let database = Arc::new("dba".to_string());
         let opt = create_options(dir.to_string());
         let dir = opt.storage.tsm_dir(&database, 1);
+        let max_level_ts = 9;
 
         let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, files);
+            prepare_compaction(database, opt, next_file_id, files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
+    /// Test compact with duplicate timestamp.
     #[tokio::test]
     async fn test_compaction_2() {
         #[rustfmt::skip]
@@ -1160,18 +1500,21 @@ pub mod test {
         ]);
 
         let dir = "/tmp/test/compaction/2";
+        let _ = std::fs::remove_dir_all(dir);
         let database = Arc::new("dba".to_string());
         let opt = create_options(dir.to_string());
         let dir = opt.storage.tsm_dir(&database, 1);
+        let max_level_ts = 9;
 
         let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, files);
+            prepare_compaction(database, opt, next_file_id, files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
     /// Returns a generated `DataBlock` with default value and specified size, `DataBlock::ts`
@@ -1268,10 +1611,57 @@ pub mod test {
         }
     }
 
+    type DataDesc = (
+        ColumnFileId,
+        Vec<(ValueType, FieldId, Timestamp, Timestamp)>,
+        Vec<(FieldId, Timestamp, Timestamp)>,
+    );
+
+    #[allow(clippy::type_complexity)]
+    async fn write_data_block_desc(
+        dir: impl AsRef<Path>,
+        data_desc: &[DataDesc],
+    ) -> Vec<Arc<ColumnFile>> {
+        let mut column_files = Vec::new();
+        for (tsm_sequence, tsm_desc, tombstone_desc) in data_desc.iter() {
+            let mut tsm_writer = tsm::new_tsm_writer(&dir, *tsm_sequence, false, 0)
+                .await
+                .unwrap();
+            for &(val_type, fid, min_ts, max_ts) in tsm_desc.iter() {
+                tsm_writer
+                    .write_block(fid, &generate_data_block(val_type, vec![(min_ts, max_ts)]))
+                    .await
+                    .unwrap();
+            }
+            tsm_writer.write_index().await.unwrap();
+            tsm_writer.finish().await.unwrap();
+            let mut tsm_tombstone = TsmTombstone::open(&dir, *tsm_sequence).await.unwrap();
+            for (fid, min_ts, max_ts) in tombstone_desc.iter() {
+                tsm_tombstone
+                    .add_range(&[*fid][..], &TimeRange::new(*min_ts, *max_ts))
+                    .await
+                    .unwrap();
+            }
+
+            tsm_tombstone.flush().await.unwrap();
+            column_files.push(Arc::new(ColumnFile::new(
+                *tsm_sequence,
+                2,
+                TimeRange::new(tsm_writer.min_ts(), tsm_writer.max_ts()),
+                tsm_writer.size(),
+                false,
+                tsm_writer.path(),
+            )));
+        }
+
+        column_files
+    }
+
+    /// Test compaction without tombstones.
     #[tokio::test]
     async fn test_compaction_3() {
         #[rustfmt::skip]
-        let data_desc = [
+        let data_desc: [DataDesc; 3] = [
             // [( tsm_sequence, vec![ (ValueType, FieldId, Timestamp_Begin, Timestamp_end) ] )]
             (1_u64, vec![
                 // 1, 1~2500
@@ -1284,7 +1674,7 @@ pub mod test {
                 // 3, 1~1500
                 (ValueType::Boolean, 3, 1, 1000),
                 (ValueType::Boolean, 3, 1001, 1500),
-            ]),
+            ], vec![]),
             (2, vec![
                 // 1, 2001~4500
                 (ValueType::Unsigned, 1, 2001, 3000),
@@ -1299,7 +1689,7 @@ pub mod test {
                 // 4, 1~1500
                 (ValueType::Float, 4, 1, 1000),
                 (ValueType::Float, 4, 1001, 1500),
-            ]),
+            ], vec![]),
             (3, vec![
                 // 1, 4001~6500
                 (ValueType::Unsigned, 1, 4001, 5000),
@@ -1314,7 +1704,7 @@ pub mod test {
                 // 4. 1001~2500
                 (ValueType::Float, 4, 1001, 2000),
                 (ValueType::Float, 4, 2001, 2500),
-            ]),
+            ], vec![]),
         ];
         #[rustfmt::skip]
         let expected_data: HashMap<FieldId, Vec<DataBlock>> = HashMap::from(
@@ -1354,102 +1744,41 @@ pub mod test {
         );
 
         let dir = "/tmp/test/compaction/3";
+        let _ = std::fs::remove_dir_all(dir);
         let database = Arc::new("dba".to_string());
         let opt = create_options(dir.to_string());
         let dir = opt.storage.tsm_dir(&database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
+        let max_level_ts = 6500;
 
-        let mut column_files = Vec::new();
-        for (tsm_sequence, args) in data_desc.iter() {
-            let mut tsm_writer = tsm::new_tsm_writer(&dir, *tsm_sequence, false, 0)
-                .await
-                .unwrap();
-            for arg in args.iter() {
-                tsm_writer
-                    .write_block(arg.1, &generate_data_block(arg.0, vec![(arg.2, arg.3)]))
-                    .await
-                    .unwrap();
-            }
-            tsm_writer.write_index().await.unwrap();
-            tsm_writer.finish().await.unwrap();
-            column_files.push(Arc::new(ColumnFile::new(
-                *tsm_sequence,
-                2,
-                TimeRange::new(tsm_writer.min_ts(), tsm_writer.max_ts()),
-                tsm_writer.size(),
-                false,
-                tsm_writer.path(),
-            )));
-        }
-
+        let column_files = write_data_block_desc(&dir, &data_desc).await;
         let next_file_id = 4_u64;
 
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
-
+            prepare_compaction(database, opt, next_file_id, column_files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
 
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
-    #[allow(clippy::type_complexity)]
-    async fn write_data_block_desc(
-        dir: impl AsRef<Path>,
-        data_desc: &[(
-            ColumnFileId,
-            Vec<(ValueType, FieldId, Timestamp, Timestamp)>,
-            Vec<(FieldId, Timestamp, Timestamp)>,
-        )],
-    ) -> Vec<Arc<ColumnFile>> {
-        let mut column_files = Vec::new();
-        for (tsm_sequence, tsm_desc, tombstone_desc) in data_desc.iter() {
-            let mut tsm_writer = tsm::new_tsm_writer(&dir, *tsm_sequence, false, 0)
-                .await
-                .unwrap();
-            for &(val_type, fid, min_ts, max_ts) in tsm_desc.iter() {
-                tsm_writer
-                    .write_block(fid, &generate_data_block(val_type, vec![(min_ts, max_ts)]))
-                    .await
-                    .unwrap();
-            }
-            tsm_writer.write_index().await.unwrap();
-            tsm_writer.finish().await.unwrap();
-            let mut tsm_tombstone = TsmTombstone::open(&dir, *tsm_sequence).await.unwrap();
-            for (fid, min_ts, max_ts) in tombstone_desc.iter() {
-                tsm_tombstone
-                    .add_range(&[*fid][..], &TimeRange::new(*min_ts, *max_ts))
-                    .await
-                    .unwrap();
-            }
-
-            tsm_tombstone.flush().await.unwrap();
-            column_files.push(Arc::new(ColumnFile::new(
-                *tsm_sequence,
-                2,
-                TimeRange::new(tsm_writer.min_ts(), tsm_writer.max_ts()),
-                tsm_writer.size(),
-                false,
-                tsm_writer.path(),
-            )));
-        }
-
-        column_files
-    }
-
+    /// Test compaction with tombstones
     #[tokio::test]
     async fn test_compaction_4() {
         #[rustfmt::skip]
-        let data_desc = [
-            // [( tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)], vec![Option<(FieldId, MinTimestamp, MaxTimestamp)>] )]
-            (1_u64, vec![
+        let data_desc: [DataDesc; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
                 // 1, 1~2500
-                (ValueType::Unsigned, 1_u64, 1_i64, 1000_i64), (ValueType::Unsigned, 1, 1001, 2000), (ValueType::Unsigned, 1, 2001, 2500),
-            ], vec![(1_u64, 1_i64, 2_i64), (1, 2001, 2100)]),
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000), (ValueType::Unsigned, 1, 2001, 2500),
+            ], vec![(1, 1, 2), (1, 2001, 2100)]),
             (2, vec![
                 // 1, 2001~4500
                 // 2101~3100, 3101~4100, 4101~4499
@@ -1478,40 +1807,45 @@ pub mod test {
         );
 
         let dir = "/tmp/test/compaction/4";
+        let _ = std::fs::remove_dir_all(dir);
         let database = Arc::new("dba".to_string());
         let opt = create_options(dir.to_string());
         let dir = opt.storage.tsm_dir(&database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
+        let max_level_ts = 6500;
 
         let column_files = write_data_block_desc(&dir, &data_desc).await;
         let next_file_id = 4_u64;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
-
+            prepare_compaction(database, opt, next_file_id, column_files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
 
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
+    /// Test compaction with multi-field and tombstones.
     #[tokio::test]
     async fn test_compaction_5() {
         #[rustfmt::skip]
-        let data_desc = [
-            // [( tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)], vec![Option<(FieldId, MinTimestamp, MaxTimestamp)>] )]
-            (1_u64, vec![
+        let data_desc: [DataDesc; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
                 // 1, 1~2500
-                (ValueType::Unsigned, 1_u64, 1_i64, 1000_i64), (ValueType::Unsigned, 1, 1001, 2000),  (ValueType::Unsigned, 1, 2001, 2500),
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000),  (ValueType::Unsigned, 1, 2001, 2500),
                 // 2, 1~1500
                 (ValueType::Integer, 2, 1, 1000), (ValueType::Integer, 2, 1001, 1500),
                 // 3, 1~1500
                 (ValueType::Boolean, 3, 1, 1000), (ValueType::Boolean, 3, 1001, 1500),
             ], vec![
-                (1_u64, 1_i64, 2_i64), (1, 2001, 2100),
+                (1, 1, 2), (1, 2001, 2100),
                 (2, 1001, 1002),
                 (3, 1499, 1500),
             ]),
@@ -1587,17 +1921,142 @@ pub mod test {
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
+        let max_level_ts = 6500;
 
         let column_files = write_data_block_desc(&dir, &data_desc).await;
         let next_file_id = 4_u64;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
+            prepare_compaction(database, opt, next_file_id, column_files, max_level_ts);
+        let out_level = compact_req.out_level;
+        let (version_edit, _) = run_compaction_job(compact_req, kernel)
+            .await
+            .unwrap()
+            .unwrap();
+
+        check_column_file(dir, version_edit, expected_data, out_level).await;
+    }
+
+    /// Test compaction on level-0 (delta compaction) with multi-field.
+    #[tokio::test]
+    async fn test_compaction_6() {
+        #[rustfmt::skip]
+        let data_desc: [DataDesc; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
+                // 1, 1~2500
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000),  (ValueType::Unsigned, 1, 2001, 2500),
+                // 2, 1~1500
+                (ValueType::Integer, 2, 1, 1000), (ValueType::Integer, 2, 1001, 1500),
+                // 3, 1~1500
+                (ValueType::Boolean, 3, 1, 1000), (ValueType::Boolean, 3, 1001, 1500),
+            ], vec![]),
+            (2, vec![
+                // 1, 2001~4500
+                (ValueType::Unsigned, 1, 2001, 3000), (ValueType::Unsigned, 1, 3001, 4000), (ValueType::Unsigned, 1, 4001, 4500),
+                // 2, 1001~3000
+                (ValueType::Integer, 2, 1001, 2000), (ValueType::Integer, 2, 2001, 3000),
+                // 3, 1001~2500
+                (ValueType::Boolean, 3, 1001, 2000), (ValueType::Boolean, 3, 2001, 2500),
+                // 4, 1~1500
+                (ValueType::Float, 4, 1, 1000), (ValueType::Float, 4, 1001, 1500),
+            ], vec![]),
+            (3, vec![
+                // 1, 4001~6500
+                (ValueType::Unsigned, 1, 4001, 5000), (ValueType::Unsigned, 1, 5001, 6000), (ValueType::Unsigned, 1, 6001, 6500),
+                // 2, 3001~5000
+                (ValueType::Integer, 2, 3001, 4000), (ValueType::Integer, 2, 4001, 5000),
+                // 3, 2001~3500
+                (ValueType::Boolean, 3, 2001, 3000), (ValueType::Boolean, 3, 3001, 3500),
+                // 4. 1001~2500
+                (ValueType::Float, 4, 1001, 2000), (ValueType::Float, 4, 2001, 2500),
+            ], vec![]),
+        ];
+        #[rustfmt::skip]
+        let expected_data_target_level: HashMap<FieldId, Vec<DataBlock>> = HashMap::from(
+            [
+                // 1, 1~6500
+                (1, vec![
+                    generate_data_block(ValueType::Unsigned, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(2001, 3000)]),
+                ]),
+                // 2, 1~5000
+                (2, vec![
+                    generate_data_block(ValueType::Integer, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Integer, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Integer, vec![(2001, 3000)]),
+                ]),
+                // 3, 1~3500
+                (3, vec![
+                    generate_data_block(ValueType::Boolean, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Boolean, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Boolean, vec![(2001, 3000)]),
+                ]),
+                // 4, 1~2500
+                (4, vec![
+                    generate_data_block(ValueType::Float, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Float, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Float, vec![(2001, 2500)]),
+                ]),
+            ]
+        );
+        #[rustfmt::skip]
+        let expected_data_delta_level: HashMap<FieldId, Vec<DataBlock>> = HashMap::from(
+            [
+                // 1, 1~6500
+                (1, vec![
+                    generate_data_block(ValueType::Unsigned, vec![(3001, 4000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(4001, 5000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(5001, 6000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(6001, 6500)]),
+                ]),
+                // 2, 1~5000
+                (2, vec![
+                    generate_data_block(ValueType::Integer, vec![(3001, 4000)]),
+                    generate_data_block(ValueType::Integer, vec![(4001, 5000)]),
+                ]),
+                // 3, 1~3500
+                (3, vec![
+                    generate_data_block(ValueType::Boolean, vec![(3001, 3500)]),
+                ]),
+            ]
+        );
+
+        let dir = "/tmp/test/compaction/6";
+        let database = Arc::new("dba".to_string());
+        let opt = create_options(dir.to_string());
+        let tsm_dir = opt.storage.tsm_dir(&database, 1);
+        if !file_manager::try_exists(&tsm_dir) {
+            std::fs::create_dir_all(&tsm_dir).unwrap();
+        }
+        let delta_dir = opt.storage.delta_dir(&database, 1);
+        if !file_manager::try_exists(&delta_dir) {
+            std::fs::create_dir_all(&delta_dir).unwrap();
+        }
+        let max_level_ts = 9000;
+
+        let column_files = write_data_block_desc(&delta_dir, &data_desc).await;
+        let next_file_id = 4_u64;
+        let (mut compact_req, kernel) =
+            prepare_compaction(database, opt, next_file_id, column_files, max_level_ts);
+        compact_req.in_level = 0;
+        compact_req.out_level = 2;
+        compact_req.time_range = TimeRange::new(1, 3000);
 
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
 
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(
+            &delta_dir,
+            version_edit.clone(),
+            expected_data_delta_level,
+            0,
+        )
+        .await;
+        check_column_file(tsm_dir, version_edit, expected_data_target_level, 2).await;
     }
 }

--- a/tskv/src/compaction/flush.rs
+++ b/tskv/src/compaction/flush.rs
@@ -234,7 +234,7 @@ pub async fn run_flush_memtable_job(
         tsf.read().await.update_last_modified().await;
 
         if let Some(sender) = compact_task_sender.as_ref() {
-            let _ = sender.send(CompactTask::Vnode(req.ts_family_id)).await;
+            let _ = sender.send(CompactTask::Normal(req.ts_family_id)).await;
         }
     }
 

--- a/tskv/src/compaction/job.rs
+++ b/tskv/src/compaction/job.rs
@@ -5,9 +5,10 @@ use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::{oneshot, RwLock, Semaphore};
+use tokio_util::sync::CancellationToken;
 use trace::{error, info};
 
-use crate::compaction::{flush, CompactTask, LevelCompactionPicker, Picker};
+use crate::compaction::{flush, CompactTask, DeltaCompactionPicker, LevelCompactionPicker, Picker};
 use crate::context::{GlobalContext, GlobalSequenceContext};
 use crate::kv_option::StorageOptions;
 use crate::summary::SummaryTask;
@@ -17,18 +18,21 @@ use crate::TseriesFamilyId;
 const COMPACT_BATCH_CHECKING_SECONDS: u64 = 1;
 
 struct CompactProcessor {
-    vnode_ids: HashMap<TseriesFamilyId, bool>,
+    vnode_ids: HashMap<TseriesFamilyId, CompactStrategy>,
 }
 
 impl CompactProcessor {
-    fn insert(&mut self, vnode_id: TseriesFamilyId, should_flush: bool) {
-        let old_should_flush = self.vnode_ids.entry(vnode_id).or_insert(should_flush);
-        if should_flush && !*old_should_flush {
-            *old_should_flush = should_flush
+    fn insert(&mut self, vnode_id: TseriesFamilyId, strategy: CompactStrategy) {
+        let old_strategy = self.vnode_ids.entry(vnode_id).or_default();
+        if strategy.flush_vnode {
+            old_strategy.flush_vnode = true;
+        }
+        if strategy.delta_compaction {
+            old_strategy.delta_compaction = true;
         }
     }
 
-    fn take(&mut self) -> HashMap<TseriesFamilyId, bool> {
+    fn take(&mut self) -> HashMap<TseriesFamilyId, CompactStrategy> {
         std::mem::replace(&mut self.vnode_ids, HashMap::with_capacity(32))
     }
 }
@@ -37,6 +41,21 @@ impl Default for CompactProcessor {
     fn default() -> Self {
         Self {
             vnode_ids: HashMap::with_capacity(32),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct CompactStrategy {
+    flush_vnode: bool,
+    delta_compaction: bool,
+}
+
+impl CompactStrategy {
+    fn new(flush_vnode: bool, delta_compaction: bool) -> Self {
+        Self {
+            flush_vnode,
+            delta_compaction,
         }
     }
 }
@@ -53,6 +72,8 @@ pub fn run(
     let runtime_inner = runtime.clone();
     let compact_processor = Arc::new(RwLock::new(CompactProcessor::default()));
     let compact_batch_processor = compact_processor.clone();
+    let close_sig_tx = CancellationToken::new();
+    let close_sig_rx = close_sig_tx.clone();
     runtime.spawn(async move {
         // TODO: Concurrent compactions should not over argument $cpu.
         let compaction_limit = Arc::new(Semaphore::new(
@@ -62,6 +83,9 @@ pub fn run(
             tokio::time::interval(Duration::from_secs(COMPACT_BATCH_CHECKING_SECONDS));
 
         loop {
+            if close_sig_rx.is_cancelled() {
+                break;
+            }
             check_interval.tick().await;
             let processor = compact_batch_processor.read().await;
             if processor.vnode_ids.is_empty() {
@@ -72,7 +96,18 @@ pub fn run(
             let vnode_ids_for_debug = vnode_ids.clone();
             let now = Instant::now();
             info!("Compacting on vnode(job start): {:?}", &vnode_ids_for_debug);
-            for (vnode_id, flush_vnode) in vnode_ids {
+            for (
+                vnode_id,
+                CompactStrategy {
+                    flush_vnode,
+                    delta_compaction,
+                },
+            ) in vnode_ids
+            {
+                if close_sig_rx.is_cancelled() {
+                    break;
+                }
+
                 let ts_family = version_set
                     .read()
                     .await
@@ -85,7 +120,12 @@ pub fn run(
                         info!("forbidden compaction on moving vnode {}", vnode_id);
                         return;
                     }
-                    let picker = LevelCompactionPicker::new(storage_opt.clone());
+                    // TODO(zipper): logical here is something clutter.
+                    let picker: Box<dyn Picker> = if delta_compaction {
+                        Box::new(DeltaCompactionPicker::new())
+                    } else {
+                        Box::new(LevelCompactionPicker::new())
+                    };
                     let version = tsf.read().await.version();
                     let compact_req = picker.pick_compaction(version);
                     if let Some(req) = compact_req {
@@ -166,43 +206,69 @@ pub fn run(
 
     runtime.spawn(async move {
         while let Some(compact_task) = receiver.recv().await {
-            // Vnode id to compact & whether vnode be flushed before compact
-            let (vnode_id, flush_vnode) = match compact_task {
-                CompactTask::Vnode(id) => (id, false),
-                CompactTask::ColdVnode(id) => (id, true),
-            };
-            compact_processor
-                .write()
-                .await
-                .insert(vnode_id, flush_vnode);
+            let mut compact_processor_wlock = compact_processor.write().await;
+            match compact_task {
+                CompactTask::Normal(id) => compact_processor_wlock.insert(
+                    id,
+                    CompactStrategy {
+                        flush_vnode: false,
+                        delta_compaction: false,
+                    },
+                ),
+                CompactTask::Cold(id) => compact_processor_wlock.insert(
+                    id,
+                    CompactStrategy {
+                        flush_vnode: true,
+                        delta_compaction: false,
+                    },
+                ),
+                CompactTask::Delta(id) => compact_processor_wlock.insert(
+                    id,
+                    CompactStrategy {
+                        flush_vnode: false,
+                        delta_compaction: true,
+                    },
+                ),
+            }
         }
+        close_sig_tx.cancel();
     });
 }
 
 #[cfg(test)]
 mod test {
-    use crate::compaction::job::CompactProcessor;
+    use crate::compaction::job::{CompactProcessor, CompactStrategy};
     use crate::TseriesFamilyId;
 
     #[test]
     fn test_build_compact_batch() {
         let mut compact_batch_builder = CompactProcessor::default();
-        compact_batch_builder.insert(1, false);
-        compact_batch_builder.insert(2, false);
-        compact_batch_builder.insert(1, true);
-        compact_batch_builder.insert(3, true);
+        compact_batch_builder.insert(1, CompactStrategy::new(false, false));
+        compact_batch_builder.insert(2, CompactStrategy::new(false, false));
+        compact_batch_builder.insert(1, CompactStrategy::new(true, true));
+        compact_batch_builder.insert(3, CompactStrategy::new(true, false));
+        compact_batch_builder.insert(1, CompactStrategy::new(false, false));
         assert_eq!(compact_batch_builder.vnode_ids.len(), 3);
         let mut keys: Vec<TseriesFamilyId> =
             compact_batch_builder.vnode_ids.keys().cloned().collect();
         keys.sort();
         assert_eq!(keys, vec![1, 2, 3]);
-        assert_eq!(compact_batch_builder.vnode_ids.get(&1), Some(&true));
-        assert_eq!(compact_batch_builder.vnode_ids.get(&2), Some(&false));
-        assert_eq!(compact_batch_builder.vnode_ids.get(&3), Some(&true));
+        assert_eq!(
+            compact_batch_builder.vnode_ids.get(&1),
+            Some(&CompactStrategy::new(true, true))
+        );
+        assert_eq!(
+            compact_batch_builder.vnode_ids.get(&2),
+            Some(&CompactStrategy::new(false, false))
+        );
+        assert_eq!(
+            compact_batch_builder.vnode_ids.get(&3),
+            Some(&CompactStrategy::new(true, false))
+        );
         let vnode_ids = compact_batch_builder.take();
         assert_eq!(vnode_ids.len(), 3);
-        assert_eq!(vnode_ids.get(&1), Some(&true));
-        assert_eq!(vnode_ids.get(&2), Some(&false));
-        assert_eq!(vnode_ids.get(&3), Some(&true));
+        assert_eq!(vnode_ids.get(&1), Some(&CompactStrategy::new(true, true)));
+        assert_eq!(vnode_ids.get(&2), Some(&CompactStrategy::new(false, false)));
+        assert_eq!(vnode_ids.get(&3), Some(&CompactStrategy::new(true, false)));
     }
 }

--- a/tskv/src/compaction/mod.rs
+++ b/tskv/src/compaction/mod.rs
@@ -7,34 +7,64 @@ mod picker;
 
 use std::sync::Arc;
 
+use chrono::Utc;
 pub use compact::*;
 pub use flush::*;
+use models::predicate::domain::TimeRange;
 use parking_lot::RwLock;
 pub use picker::*;
 
 use crate::kv_option::StorageOptions;
 use crate::memcache::MemCache;
-use crate::tseries_family::{ColumnFile, Version};
+use crate::tseries_family::{ColumnFile, LevelInfo, Version};
 use crate::{LevelId, TseriesFamilyId};
 
 pub enum CompactTask {
-    Vnode(TseriesFamilyId),
-    ColdVnode(TseriesFamilyId),
+    Normal(TseriesFamilyId),
+    Cold(TseriesFamilyId),
+    Delta(TseriesFamilyId),
 }
 
+#[derive(Debug, Clone)]
 pub struct CompactReq {
-    pub ts_family_id: TseriesFamilyId,
-    pub database: Arc<String>,
+    ts_family_id: TseriesFamilyId,
+    database: Arc<String>,
     storage_opt: Arc<StorageOptions>,
 
     files: Vec<Arc<ColumnFile>>,
     version: Arc<Version>,
-    pub out_level: LevelId,
+    in_level: LevelId,
+    out_level: LevelId,
+    time_range: TimeRange,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FlushReq {
     pub ts_family_id: TseriesFamilyId,
     pub mems: Vec<Arc<RwLock<MemCache>>>,
     pub force_flush: bool,
+}
+
+fn format_level_infos(levels: &[LevelInfo]) -> String {
+    levels
+        .iter()
+        .map(|l| format!("{l}"))
+        .collect::<Vec<String>>()
+        .join(", ")
+}
+
+fn format_column_files(files: &[Arc<ColumnFile>]) -> String {
+    files
+        .iter()
+        .map(|f| format!("{f}"))
+        .collect::<Vec<String>>()
+        .join(", ")
+}
+
+const PICKER_CONTEXT_DATETIME_FORMAT: &str = "%d%m%Y_%H%M%S_%3f";
+
+fn context_datetime() -> String {
+    Utc::now()
+        .format(PICKER_CONTEXT_DATETIME_FORMAT)
+        .to_string()
 }

--- a/tskv/src/compaction/picker.rs
+++ b/tskv/src/compaction/picker.rs
@@ -1,12 +1,9 @@
 use std::fmt::Debug;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use models::predicate::domain::TimeRange;
 use trace::{debug, info};
 
-use crate::compaction::CompactReq;
-use crate::kv_option::StorageOptions;
+use crate::compaction::{context_datetime, format_column_files, format_level_infos, CompactReq};
 use crate::tseries_family::{ColumnFile, LevelInfo, Version};
 use crate::LevelId;
 
@@ -14,11 +11,16 @@ pub trait Picker: Send + Sync + Debug {
     fn pick_compaction(&self, version: Arc<Version>) -> Option<CompactReq>;
 }
 
-/// Compaction picker for picking files in level
+const LEVEL_WEIGHT_FILE_NUM: [f64; 5] = [1.0, 1.0, 1.0, 1.0, 1.0];
+const LEVEL_WEIGHT_REMAINING_SIZE: [f64; 5] = [1.0, 1.0, 1.0, 1.0, 1.0];
+
+/// Compaction picker for picking a level from level-1 to level-4, and then
+/// pick inner files of the level.
 #[derive(Debug)]
 pub struct LevelCompactionPicker {
-    picking: AtomicBool,
-    storage: Arc<StorageOptions>,
+    /// Datetime when this picker created.
+    strategy: String,
+    datetime: String,
 }
 
 impl Picker for LevelCompactionPicker {
@@ -28,49 +30,25 @@ impl Picker for LevelCompactionPicker {
         //! 3. Get files(`Vec<Arc<ColumnFile>>`) from the picked level, sorted by min_ts(ascending)
         //!    and size(ascending), pick ColumnFile until picking_files_size reaches
         //!    max_compact_size, remove away the last picked files with overlapped time_range.
-        //! 4. Get files(`Vec<Arc<ColumnFile>>`) from level-0, sorted by min_ts(ascending)
-        //!    and size(ascending), pick ColumnFile until picking_files_size reaches
-        //!    max_compact_size.
+        //! 4. (Deprecated and skipped): Pick files from level-0.
         //! 5. Build CompactReq using **version**, picked level and picked files.
 
         debug!(
-            "Picker: Version info: [ {} ]",
-            version
-                .levels_info()
-                .iter()
-                .enumerate()
-                .map(|(i, lvl)| {
-                    format!(
-                        "Level-{}: files: [ {} ]",
-                        i,
-                        lvl.files
-                            .iter()
-                            .map(|f| format!(
-                                "{}(C:{}, {}-{}, {} B)",
-                                f.file_id(),
-                                if f.is_compacting() { "Y" } else { "N" },
-                                f.time_range().min_ts,
-                                f.time_range().max_ts,
-                                f.size()
-                            ))
-                            .collect::<Vec<String>>()
-                            .join(", ")
-                    )
-                })
-                .collect::<Vec<String>>()
-                .join(", ")
+            "Picker: strategy: {}, version: [ {} ]",
+            self.strategy,
+            format_level_infos(&version.levels_info)
         );
 
         let storage_opt = version.storage_opt();
         let level_infos = version.levels_info();
 
-        // Pick a level to compact with level 0
+        // Pick a level to compact
         let level_start: &LevelInfo;
+        let in_level;
         let out_level;
-
         if let Some((start_lvl, out_lvl)) = self.pick_level(level_infos) {
-            info!("Picker: picked level: {} to {}", start_lvl, out_lvl);
             level_start = &level_infos[start_lvl as usize];
+            in_level = start_lvl;
             out_level = out_lvl;
 
             // If start_lvl is L1, compare the number of L1 files
@@ -80,111 +58,72 @@ impl Picker for LevelCompactionPicker {
                 && (level_infos[1].files.len() as u32) < storage_opt.compact_trigger_file_num
             {
                 info!(
-                    "Picker: picked L1 files({}) does not reach trigger({}), return None",
+                    "Picker: strategy: {}, picked L1 files({}) does not reach trigger({}), return None",
+                    self.strategy,
                     level_infos[1].files.len(),
                     storage_opt.compact_trigger_file_num
                 );
                 return None;
             }
         } else {
-            info!("Picker: picked no level");
+            info!("Picker: strategy: {}, picked no level", self.strategy);
             return None;
         }
 
         // Pick selected level files.
-        let mut picking_files: Vec<Arc<ColumnFile>> = Vec::new();
-        let (mut picking_files_size, picking_time_range) = if level_start.files.is_empty() {
-            info!("Picker: picked no files from level {}", level_start.level);
+        if level_start.files.is_empty() {
             return None;
-        } else {
-            let mut files = level_start.files.clone();
-            files.sort_by(Self::compare_column_file);
-            Self::pick_files(files, storage_opt.max_compact_size, &mut picking_files)
-        };
-
-        // Pick level 0 files.
-        let mut files = level_infos[0].files.clone();
-        files.sort_by(Self::compare_column_file);
-        for file in files.iter() {
-            if file.time_range().min_ts > picking_time_range.max_ts {
-                break;
-            }
-            if file.is_compacting() || !file.time_range().overlaps(&picking_time_range) {
-                continue;
-            }
-            if !file.mark_compacting() {
-                // If file already compacting, continue to next file.
-                continue;
-            }
-            picking_files.push(file.clone());
-            picking_files_size += file.size();
-
-            if picking_files_size > storage_opt.max_compact_size {
-                // Picked file size >= max_compact_size, try break picking files.
-                break;
-            }
         }
 
-        // Even if picked only 1 file, send it to the next level.
-
+        let mut files = level_start.files.clone();
+        files.sort_by(Self::compare_column_file);
+        let picking_files: Vec<Arc<ColumnFile>> =
+            Self::pick_files(files, storage_opt.max_compact_size);
         info!(
-            "Picker: Picked files: [ {} ]",
-            picking_files
-                .iter()
-                .map(|f| {
-                    format!(
-                        "{{ Level-{}, file_id: {}, time_range: {}-{} }}",
-                        f.level(),
-                        f.file_id(),
-                        f.time_range().min_ts,
-                        f.time_range().max_ts
-                    )
-                })
-                .collect::<Vec<String>>()
-                .join(", ")
+            "Picker: strategy: {}, Picked files: [ {} ]",
+            self.strategy,
+            format_column_files(&picking_files)
         );
+        if picking_files.is_empty() {
+            return None;
+        }
 
+        // Run compaction and send them to the next level, even if picked only 1 file,.
         Some(CompactReq {
             ts_family_id: version.ts_family_id,
             database: version.database.clone(),
             storage_opt: version.storage_opt.clone(),
             files: picking_files,
             version: version.clone(),
+            in_level,
             out_level,
+            time_range: level_infos[out_level as usize].time_range,
         })
     }
 }
 
 impl LevelCompactionPicker {
-    pub fn new(storage_opt: Arc<StorageOptions>) -> LevelCompactionPicker {
+    pub fn new() -> LevelCompactionPicker {
         Self {
-            picking: AtomicBool::new(false),
-            storage: storage_opt,
+            strategy: "normal".to_string(),
+            datetime: context_datetime(),
         }
     }
 
     /// Weight of file number of a level to be picked.
     fn level_weight_file_num(level: LevelId) -> f64 {
-        match level {
-            0 => 1.0,
-            1 => 0.8,
-            2 => 0.4,
-            3 => 0.2,
-            4 => 0.1,
-            _ => 0.0,
+        if level as usize >= LEVEL_WEIGHT_FILE_NUM.len() {
+            return 0.0;
         }
+        LEVEL_WEIGHT_FILE_NUM[level as usize]
     }
 
     /// Weight of the ramaining size of a level to be picked.
     fn level_weight_remaining_size(level: LevelId) -> f64 {
-        match level {
-            0 => 1.0,
-            1 => 1.0,
-            2 => 1.0,
-            3 => 1.0,
-            4 => 1.0,
-            _ => 0.0,
+        if level as usize >= LEVEL_WEIGHT_REMAINING_SIZE.len() {
+            return 0.0;
         }
+        LEVEL_WEIGHT_REMAINING_SIZE[level as usize]
     }
 
     fn compare_column_file(a: &Arc<ColumnFile>, b: &Arc<ColumnFile>) -> std::cmp::Ordering {
@@ -247,8 +186,9 @@ impl LevelCompactionPicker {
             score_a.partial_cmp(score_b).expect("a NaN score").reverse()
         });
 
-        info!(
-            "Picker: Calculate level scores: [ {} ]",
+        debug!(
+            "Picker: strategy: {}, level scores: [ {} ]",
+            self.strategy,
             level_scores
                 .iter()
                 .map(|lc| format!("{{ Level-{}: {} }}", lc.0, lc.4))
@@ -265,30 +205,147 @@ impl LevelCompactionPicker {
         })
     }
 
-    fn pick_files(
-        src_files: Vec<Arc<ColumnFile>>,
-        max_compact_size: u64,
-        dst_files: &mut Vec<Arc<ColumnFile>>,
-    ) -> (u64, TimeRange) {
+    fn pick_files(src_files: Vec<Arc<ColumnFile>>, max_compact_size: u64) -> Vec<Arc<ColumnFile>> {
+        let mut dst_files = Vec::with_capacity(src_files.len());
+
         let mut picking_file_size = 0_u64;
-        let mut picking_time_range = TimeRange::none();
         for file in src_files.iter() {
             if file.is_compacting() || !file.mark_compacting() {
                 // If file already compacting, continue to next file.
                 continue;
             }
             picking_file_size += file.size();
-            picking_time_range.merge(file.time_range());
             dst_files.push(file.clone());
 
             if picking_file_size >= max_compact_size {
                 // Picked file size >= max_compact_size, try break picking files.
-                picking_file_size -= file.size();
                 break;
             }
         }
 
-        (picking_file_size, picking_time_range)
+        dst_files
+    }
+}
+
+/// Compaction picker for picking files in level-0 (delta files)
+#[derive(Debug)]
+pub struct DeltaCompactionPicker {
+    strategy: String,
+    /// Datetime when this picker created.
+    datetime: String,
+}
+
+impl Picker for DeltaCompactionPicker {
+    fn pick_compaction(&self, version: Arc<Version>) -> Option<CompactReq> {
+        debug!(
+            "Picker: strategy: {}, version: [ {} ]",
+            self.strategy,
+            format_level_infos(&version.levels_info)
+        );
+
+        let levels = version.levels_info();
+        if levels[0].files.is_empty() {
+            return None;
+        }
+
+        let mut level_overlaped_files: [Vec<Arc<ColumnFile>>; 5] =
+            [vec![], Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+        let mut file_picked: bool;
+        let mut level_picking: usize;
+        for file in levels[0].files.iter() {
+            if file.is_compacting() {
+                continue;
+            }
+            file_picked = false;
+            level_picking = 4;
+            // Form level-4 to level-1, put the overlapped files.
+            for level in levels.iter().skip(1).rev() {
+                if file.time_range().min_ts < level.time_range.max_ts {
+                    level_overlaped_files[level_picking].push(file.clone());
+                    file_picked = true;
+                    break;
+                }
+                level_picking -= 1;
+            }
+            // If time_range of a file is too old than level-4, put to level-4 files.
+            if !file_picked {
+                level_overlaped_files[4].push(file.clone());
+            }
+        }
+        debug!(
+            "Picker: strategy: {}, level overlaped files: [ {} ]",
+            self.strategy,
+            level_overlaped_files
+                .iter()
+                .enumerate()
+                .map(|(i, files)| format!("{{ Level-{}: {} }}", i, files.len()))
+                .collect::<Vec<String>>()
+                .join(", ")
+        );
+
+        // Find the level with maximum overlaped level-0 files.
+        let mut out_level = 0;
+        let mut max_files = 0_usize;
+        for (i, files) in level_overlaped_files.iter().enumerate() {
+            if files.len() > max_files {
+                out_level = i;
+                max_files = files.len();
+            }
+        }
+        if out_level == 0 || max_files == 0 {
+            info!(
+                "Picker: strategy: {}, picked out-level is 0 or picked no files",
+                self.strategy
+            );
+            return None;
+        }
+
+        // Pick files from level-0 files overlapped with that level.
+        let max_compact_size = version.storage_opt.max_compact_size;
+        let mut picking_files = Vec::with_capacity(level_overlaped_files.len());
+        let mut picking_file_size = 0_u64;
+        for file in level_overlaped_files[out_level].iter() {
+            if file.is_compacting() || !file.mark_compacting() {
+                // If file already compacting, continue to next file.
+                continue;
+            }
+            picking_file_size += file.size();
+            picking_files.push(file.clone());
+
+            if picking_file_size >= max_compact_size {
+                // Picked file size >= max_compact_size
+                break;
+            }
+        }
+        info!(
+            "Picker: strategy: {}, Picked files: [ {} ]",
+            self.strategy,
+            format_column_files(&picking_files)
+        );
+        if picking_files.is_empty() {
+            return None;
+        }
+
+        // Run compaction and send them to the target level, even if picked only 1 file,.
+        Some(CompactReq {
+            ts_family_id: version.ts_family_id,
+            database: version.database.clone(),
+            storage_opt: version.storage_opt.clone(),
+            files: picking_files,
+            version: version.clone(),
+            in_level: 0,
+            out_level: out_level as u32,
+            time_range: levels[out_level].time_range,
+        })
+    }
+}
+
+impl DeltaCompactionPicker {
+    pub fn new() -> Self {
+        Self {
+            strategy: "delta".to_string(),
+            datetime: context_datetime(),
+        }
     }
 }
 
@@ -303,7 +360,7 @@ mod test {
     use tokio::sync::mpsc;
 
     use crate::compaction::test::create_options;
-    use crate::compaction::{LevelCompactionPicker, Picker};
+    use crate::compaction::{DeltaCompactionPicker, LevelCompactionPicker, Picker};
     use crate::file_utils::make_tsm_file_name;
     use crate::kv_option::Options;
     use crate::kvcore::COMPACT_REQ_CHANNEL_CAP;
@@ -393,11 +450,11 @@ mod test {
     }
 
     #[test]
-    fn test_pick_1() {
+    fn test_pick_level_files_1() {
         //! There are Level 0-4, and Level 1 is now in compaction.
         //! In this case, Level 2, and serial files in Level 0 will be picked,
         //! and compact to Level 3.
-        let dir = "/tmp/test/pick/1";
+        let dir = "/tmp/test/pick/level_files_1";
         let opt = create_options(dir.to_string());
 
         #[rustfmt::skip]
@@ -427,11 +484,58 @@ mod test {
             ]), // 0.00001
         ];
 
-        let storage_opt = opt.storage.clone();
         let tsf = create_tseries_family(Arc::new("dba".to_string()), opt, levels_sketch);
-        let picker = LevelCompactionPicker::new(storage_opt);
+        let picker = LevelCompactionPicker::new();
         let compact_req = picker.pick_compaction(tsf.version()).unwrap();
         assert_eq!(compact_req.out_level, 2);
         assert_eq!(compact_req.files.len(), 2);
+    }
+
+    #[test]
+    fn test_pick_delta_files_1() {
+        //! There are Level 0-4, and Level 0 is now in compaction.
+        //! In this case, Level 2, and serial files in Level 0 will be picked,
+        //! and compact to Level 3.
+        let dir = "/tmp/test/pick/delta_files_1";
+        let opt = create_options(dir.to_string());
+
+        #[rustfmt::skip]
+        let levels_sketch: LevelsSketch = vec![
+            // vec![( level, Timestamp_Begin, Timestamp_end, vec![(file_id, Timestamp_Begin, Timestamp_end, size, being_compact)] )]
+            (0_u32, 1_i64, 370_i64, vec![
+                (11_u64, 1_i64, 5_i64, 10_u64, false), // 4
+                (12, 10, 20, 10, true),                // 4
+                (12, 30, 40, 10, false),               // 4
+                (12, 110, 120, 10, false),             // 4
+                (12, 230, 240, 10, false),             // 3
+                (12, 300, 350, 10, false),             // 3
+                (12, 340, 350, 10, false),             // 2
+                (12, 360, 370, 10, false),             // 1
+            ]),
+            (1, 341, 380, vec![
+                (7, 341, 350, 1000, false),
+                (8, 351, 360, 1000, false),
+                (9, 361, 370, 1000, true),
+                (10, 371, 380, 1000, true),
+            ]), // 1
+            (2, 301, 340, vec![
+                (5, 301, 320, 2000, false),
+                (6, 321, 340, 2000, false),
+            ]), // 1
+            (3, 201, 300, vec![
+                (3, 201, 250, 5000, false),
+                (4, 251, 300, 5000, false),
+            ]), // 2
+            (4, 1, 200, vec![
+                (1, 10, 100, 10000, false),
+                (2, 101, 200, 10000, false),
+            ]), // 3
+        ];
+
+        let tsf = create_tseries_family(Arc::new("dba".to_string()), opt, levels_sketch);
+        let picker = DeltaCompactionPicker::new();
+        let compact_req = picker.pick_compaction(tsf.version()).unwrap();
+        assert_eq!(compact_req.out_level, 4);
+        assert_eq!(compact_req.files.len(), 3);
     }
 }

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -27,7 +27,7 @@ use crate::kv_option::{Options, INDEX_PATH};
 use crate::memcache::{MemCache, RowData, RowGroup};
 use crate::schema::schemas::DBschemas;
 use crate::summary::{SummaryTask, VersionEdit};
-use crate::tseries_family::{LevelInfo, TseriesFamily, Version};
+use crate::tseries_family::{schedule_vnode_compaction, LevelInfo, TseriesFamily, Version};
 use crate::version_set::VersionSet;
 use crate::Error::{self, InvalidPoint};
 use crate::{file_utils, ColumnFileId, TseriesFamilyId};
@@ -47,6 +47,17 @@ pub struct Database {
     runtime: Arc<Runtime>,
     memory_pool: MemoryPoolRef,
     metrics_register: Arc<MetricsRegister>,
+}
+
+impl Drop for Database {
+    fn drop(&mut self) {
+        let vnodes: Vec<Arc<RwLock<TseriesFamily>>> = self.ts_families.values().cloned().collect();
+        self.runtime.spawn(async move {
+            for vnode in vnodes {
+                vnode.write().await.close();
+            }
+        });
+    }
 }
 
 impl Database {
@@ -78,7 +89,7 @@ impl Database {
         flush_task_sender: Sender<FlushReq>,
         compact_task_sender: Sender<CompactTask>,
     ) {
-        let tf = TseriesFamily::new(
+        let vnode = TseriesFamily::new(
             ver.tf_id(),
             ver.database(),
             MemCache::new(
@@ -95,10 +106,10 @@ impl Database {
             self.memory_pool.clone(),
             &self.metrics_register,
         );
-        tf.schedule_compaction(self.runtime.clone());
+        let vnode_ref = Arc::new(RwLock::new(vnode));
+        schedule_vnode_compaction(self.runtime.clone(), vnode_ref.clone());
 
-        self.ts_families
-            .insert(ver.tf_id(), Arc::new(RwLock::new(tf)));
+        self.ts_families.insert(ver.tf_id(), vnode_ref);
     }
 
     // todo: Maybe TseriesFamily::new() should be refactored.

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -987,7 +987,7 @@ impl Engine for TsKv {
                     }
                 }
 
-                let picker = LevelCompactionPicker::new(self.options.storage.clone());
+                let picker = LevelCompactionPicker::new();
                 let version = ts_family.read().await.version();
                 if let Some(req) = picker.pick_compaction(version) {
                     match compaction::run_compaction_job(req, self.global_ctx.clone()).await {

--- a/tskv/src/summary.rs
+++ b/tskv/src/summary.rs
@@ -818,17 +818,18 @@ impl SummaryScheduler {
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
-    use std::fs;
     use std::sync::Arc;
 
+    use config::Config;
     use memory_pool::GreedyMemoryPool;
     use meta::model::meta_manager::RemoteMetaManager;
-    use meta::model::MetaRef;
+    use meta::model::MetaManager;
     use metrics::metric_register::MetricsRegister;
     use models::schema::{make_owner, DatabaseSchema, TenantOptions};
     use tokio::runtime::Runtime;
     use tokio::sync::mpsc;
     use tokio::sync::mpsc::Sender;
+    use tokio::task::JoinHandle;
     use utils::BloomFilter;
 
     use crate::compaction::{CompactTask, FlushReq};
@@ -866,419 +867,415 @@ mod test {
         assert_eq!(ves, ves_2);
     }
 
-    #[test]
-    fn test_summary() {
-        let mut config = config::get_config_for_test();
+    struct SummaryTestHelper {
+        test_case_name: String,
+        base_dir: String,
+        config: Config,
+        options: Arc<Options>,
+        runtime: Arc<Runtime>,
+        summary_task_sender: Sender<SummaryTask>,
+        summary_job: JoinHandle<()>,
+        flush_task_sender: Sender<FlushReq>,
+        flush_job: JoinHandle<()>,
+        global_seq_task_sender: Sender<GlobalSequenceTask>,
+        global_seq_job: JoinHandle<()>,
+        compact_task_sender: Sender<CompactTask>,
+        compact_job: JoinHandle<()>,
+    }
 
-        let runtime = Arc::new(
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .worker_threads(4)
-                .build()
-                .unwrap(),
-        );
-
-        // NOTICE: Make sure these channel senders are dropped before test_summary() finished.
-        let (summary_task_sender, mut summary_task_receiver) =
-            mpsc::channel::<SummaryTask>(SUMMARY_REQ_CHANNEL_CAP);
-        let summary_job_mock = runtime.spawn(async move {
-            println!("Mock summary job started (test_summary).");
-            while let Some(t) = summary_task_receiver.recv().await {
-                // Do nothing
-                let _ = t.request.call_back.send(Ok(()));
-            }
-            println!("Mock summary job finished (test_summary).");
-        });
-        let (flush_task_sender, mut flush_task_receiver) =
-            mpsc::channel::<FlushReq>(config.storage.flush_req_channel_cap);
-        let flush_job_mock = runtime.spawn(async move {
-            println!("Mock flush job started (test_summary).");
-            while flush_task_receiver.recv().await.is_some() {
-                // Do nothing
-            }
-            println!("Mock flush job finished (test_summary).");
-        });
-        let (global_seq_task_sender, mut global_seq_task_receiver) =
-            mpsc::channel::<GlobalSequenceTask>(GLOBAL_TASK_REQ_CHANNEL_CAP);
-        let _global_seq_job_mock = runtime.spawn(async move {
-            println!("Mock global sequence job started (test_summary).");
-            while let Some(_t) = global_seq_task_receiver.recv().await {
-                // Do nothing
-            }
-            println!("Mock global sequence job finished (test_summary).");
-        });
-        let (compact_task_sender, mut compact_task_receiver) =
-            mpsc::channel::<CompactTask>(COMPACT_REQ_CHANNEL_CAP);
-        let compact_job_mock = runtime.spawn(async move {
-            println!("Mock compact job started (test_summary).");
-            while compact_task_receiver.recv().await.is_some() {
-                // Do nothing
-            }
-            println!("Mock compact job finished (test_summary).");
-        });
-
-        let runtime_ref = runtime.clone();
-        runtime.block_on(async move {
-            println!("Running test: test_summary_recover");
-            let base_dir = "/tmp/test/summary/test_summary_recover".to_string();
-            let _ = fs::remove_dir_all(&base_dir);
+    impl SummaryTestHelper {
+        fn new(mut config: Config, base_dir: String, test_case_name: String) -> Self {
             config.storage.path = base_dir.clone();
-            test_summary_recover(
-                config.clone(),
-                runtime_ref.clone(),
-                flush_task_sender.clone(),
-                global_seq_task_sender.clone(),
-                compact_task_sender.clone(),
-            )
-            .await;
+            config.log.path = base_dir.clone();
+            let options = Arc::new(Options::from(&config));
 
-            println!("Running test: test_tsf_num_recover");
-            let base_dir = "/tmp/test/summary/test_tsf_num_recover".to_string();
-            let _ = fs::remove_dir_all(&base_dir);
-            config.storage.path = base_dir.clone();
-            test_tsf_num_recover(
-                config.clone(),
-                runtime_ref.clone(),
-                flush_task_sender.clone(),
-                global_seq_task_sender.clone(),
-                compact_task_sender.clone(),
-            )
-            .await;
+            let runtime = Arc::new(
+                tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .worker_threads(4)
+                    .build()
+                    .unwrap(),
+            );
 
-            println!("Running test: test_recover_summary_with_roll_0");
-            let base_dir = "/tmp/test/summary/test_recover_summary_with_roll_0".to_string();
-            let _ = fs::remove_dir_all(&base_dir);
-            config.storage.path = base_dir.clone();
-            test_recover_summary_with_roll_0(
-                config.clone(),
-                runtime_ref.clone(),
-                summary_task_sender.clone(),
-                flush_task_sender.clone(),
-                global_seq_task_sender.clone(),
-                compact_task_sender.clone(),
-            )
-            .await;
+            // NOTICE: Make sure these channel senders are dropped before test_summary() finished.
+            let (summary_task_sender, mut summary_task_receiver) =
+                mpsc::channel::<SummaryTask>(SUMMARY_REQ_CHANNEL_CAP);
+            let test_case_name_clone = test_case_name.clone();
+            let summary_job = runtime.spawn(async move {
+                println!("Mock summary job started ({test_case_name_clone}).");
+                while let Some(t) = summary_task_receiver.recv().await {
+                    // Do nothing
+                    let _ = t.request.call_back.send(Ok(()));
+                }
+                println!("Mock summary job finished ({test_case_name_clone}).");
+            });
+            let (flush_task_sender, mut flush_task_receiver) =
+                mpsc::channel::<FlushReq>(config.storage.flush_req_channel_cap);
+            let test_case_name_clone = test_case_name.clone();
+            let flush_job = runtime.spawn(async move {
+                println!("Mock flush job started ({test_case_name_clone}).");
+                while flush_task_receiver.recv().await.is_some() {
+                    // Do nothing
+                }
+                println!("Mock flush job finished ({test_case_name_clone}).");
+            });
+            let (global_seq_task_sender, mut global_seq_task_receiver) =
+                mpsc::channel::<GlobalSequenceTask>(GLOBAL_TASK_REQ_CHANNEL_CAP);
+            let test_case_name_clone = test_case_name.clone();
+            let global_seq_job = runtime.spawn(async move {
+                println!("Mock global sequence job started ({test_case_name_clone}).");
+                while let Some(_t) = global_seq_task_receiver.recv().await {
+                    // Do nothing
+                }
+                println!("Mock global sequence job finished ({test_case_name_clone}).");
+            });
+            let (compact_task_sender, mut compact_task_receiver) =
+                mpsc::channel::<CompactTask>(COMPACT_REQ_CHANNEL_CAP);
+            let test_case_name_clone = test_case_name.clone();
+            let compact_job = runtime.spawn(async move {
+                println!("Mock compact job started ({test_case_name_clone}).");
+                while compact_task_receiver.recv().await.is_some() {
+                    // Do nothing
+                }
+                println!("Mock compact job finished ({test_case_name_clone}).");
+            });
 
-            println!("Running test: test_recover_summary_with_roll_1");
-            let base_dir = "/tmp/test/summary/test_recover_summary_with_roll_1".to_string();
-            let _ = fs::remove_dir_all(&base_dir);
-            config.storage.path = base_dir.clone();
-            test_recover_summary_with_roll_1(
-                config.clone(),
-                runtime_ref.clone(),
+            Self {
+                test_case_name,
+                base_dir,
+                config,
+                options,
+                runtime,
                 summary_task_sender,
+                summary_job,
+                flush_task_sender,
+                flush_job,
+                global_seq_task_sender,
+                global_seq_job,
+                compact_task_sender,
+                compact_job,
+            }
+        }
+
+        fn with_default_config(base_dir: String, test_case_name: String) -> Self {
+            let config = config::get_config_for_test();
+            Self::new(config, base_dir, test_case_name)
+        }
+
+        fn init(&self) -> (Arc<dyn MetaManager>, Arc<GreedyMemoryPool>, Summary) {
+            self.runtime.block_on(async {
+                let meta_manager: Arc<dyn MetaManager> =
+                    RemoteMetaManager::new(self.config.clone(), self.base_dir.clone()).await;
+                meta_manager
+                    .admin_meta()
+                    .add_data_node()
+                    .await
+                    .map_err(|e| format!("[{}] {e}", &self.test_case_name))
+                    .unwrap();
+                // TODO(zipper): `create_tenant()` add ignore existed tenant option.
+                let _ = meta_manager
+                    .tenant_manager()
+                    .create_tenant("cnosdb".to_string(), TenantOptions::default())
+                    .await;
+                let summary_dir = self.options.storage.summary_dir();
+                if !file_manager::try_exists(&summary_dir) {
+                    std::fs::create_dir_all(&summary_dir)
+                        .map_err(|e| format!("[{}] {e}", &self.test_case_name))
+                        .unwrap();
+                }
+                let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
+                let summary = Summary::new(
+                    self.options.clone(),
+                    self.runtime.clone(),
+                    memory_pool.clone(),
+                    self.global_seq_task_sender.clone(),
+                    Arc::new(MetricsRegister::default()),
+                )
+                .await
+                .map_err(|e| format!("[{}] {e}", &self.test_case_name))
+                .unwrap();
+                (meta_manager, memory_pool, summary)
+            })
+        }
+
+        fn join(self) {
+            let SummaryTestHelper {
+                summary_task_sender,
+                summary_job,
+                flush_task_sender,
+                flush_job,
+                global_seq_task_sender,
+                global_seq_job,
+                compact_task_sender,
+                compact_job,
+                ..
+            } = self;
+            drop(summary_task_sender);
+            drop(flush_task_sender);
+            drop(global_seq_task_sender);
+            drop(compact_task_sender);
+            let _ = self.runtime.block_on(async {
+                tokio::join!(summary_job, flush_job, global_seq_job, compact_job,)
+            });
+        }
+    }
+
+    #[test]
+    fn test_summary_recover() {
+        let base_dir = "/tmp/test/summary/test_summary_recover";
+        let _ = std::fs::remove_dir_all(base_dir);
+        let test_helper = SummaryTestHelper::with_default_config(
+            base_dir.to_string(),
+            "test_summary_recover".to_string(),
+        );
+        let runtime = test_helper.runtime.clone();
+        let options = test_helper.options.clone();
+
+        let (meta_manager, memory_pool, mut summary_1) = test_helper.init();
+        #[rustfmt::skip]
+        runtime.block_on(summary_1.apply_version_edit(
+            vec![VersionEdit::new_add_vnode(100, "cnosdb.hello".to_string(), 0,)],
+            HashMap::new(),
+            HashMap::new(),
+        )).unwrap();
+
+        let summary_2 = runtime
+            .block_on(Summary::recover(
+                meta_manager,
+                options,
+                runtime.clone(),
+                memory_pool,
+                test_helper.flush_task_sender.clone(),
+                test_helper.global_seq_task_sender.clone(),
+                test_helper.compact_task_sender.clone(),
+                false,
+                Arc::new(MetricsRegister::default()),
+            ))
+            .unwrap();
+
+        // TODO(zipper): compare summary_1 and summary_2
+        drop(summary_1);
+        drop(summary_2);
+        test_helper.join();
+    }
+
+    #[test]
+    fn test_tsf_num_recover() {
+        let base_dir = "/tmp/test/summary/test_tsf_num_recover";
+        let _ = std::fs::remove_dir_all(base_dir);
+        let test_helper = SummaryTestHelper::with_default_config(
+            base_dir.to_string(),
+            "test_tsf_num_recover".to_string(),
+        );
+        let runtime = test_helper.runtime.clone();
+        let runtime_inner = runtime.clone();
+        let options = test_helper.options.clone();
+        let flush_task_sender = test_helper.flush_task_sender.clone();
+        let global_seq_task_sender = test_helper.global_seq_task_sender.clone();
+        let compact_task_sender = test_helper.compact_task_sender.clone();
+
+        let (meta_manager, memory_pool, mut summary_1) = test_helper.init();
+        #[rustfmt::skip]
+        runtime.block_on(summary_1.apply_version_edit(
+            vec![VersionEdit::new_add_vnode(100, "cnosdb.test_tsf_num_recover".to_string(), 0,)],
+            HashMap::new(),
+            HashMap::new(),
+        )).unwrap();
+        drop(summary_1);
+
+        runtime.block_on(async move {
+            let mut summary = Summary::recover(
+                meta_manager.clone(),
+                options.clone(),
+                runtime_inner.clone(),
+                memory_pool.clone(),
+                flush_task_sender.clone(),
+                global_seq_task_sender.clone(),
+                compact_task_sender.clone(),
+                false,
+                Arc::new(MetricsRegister::default()),
+            )
+            .await
+            .unwrap();
+            assert_eq!(summary.version_set.read().await.tsf_num().await, 1);
+            summary
+                .apply_version_edit(
+                    vec![VersionEdit::new_del_vnode(100)],
+                    HashMap::new(),
+                    HashMap::new(),
+                )
+                .await
+                .unwrap();
+            drop(summary);
+
+            let summary = Summary::recover(
+                meta_manager,
+                options,
+                runtime_inner,
+                memory_pool,
                 flush_task_sender,
                 global_seq_task_sender,
                 compact_task_sender,
+                false,
+                Arc::new(MetricsRegister::default()),
             )
-            .await;
-
-            let _ = tokio::join!(summary_job_mock, flush_job_mock, compact_job_mock);
+            .await
+            .unwrap();
+            assert_eq!(summary.version_set.read().await.tsf_num().await, 0);
         });
+
+        test_helper.join();
     }
 
-    async fn test_summary_recover(
-        config: config::Config,
-        runtime: Arc<Runtime>,
-        flush_task_sender: Sender<FlushReq>,
-        global_seq_task_sender: Sender<GlobalSequenceTask>,
-        compact_task_sender: Sender<CompactTask>,
-    ) {
-        let opt = Arc::new(Options::from(&config));
-        let empty_path = "";
-        let meta_manager: MetaRef =
-            RemoteMetaManager::new(config.clone(), empty_path.to_string()).await;
+    #[test]
+    fn test_recover_summary_with_roll_0() {
+        let base_dir = "/tmp/test/summary/test_recover_summary_with_roll_0";
+        let _ = std::fs::remove_dir_all(base_dir);
+        let database = "test_recover_summary_with_roll_0";
+        let owned_database = make_owner("cnosdb", database);
+        let global_ctx = Arc::new(GlobalContext::new());
+        let mut config = config::get_config_for_test();
+        config.storage.max_summary_size = 512;
+        let test_helper = SummaryTestHelper::new(
+            config,
+            base_dir.to_string(),
+            "test_recover_summary_with_roll_0".to_string(),
+        );
+        let runtime = test_helper.runtime.clone();
+        let runtime_inner = runtime.clone();
+        let options = test_helper.options.clone();
+        let summary_task_sender = test_helper.summary_task_sender.clone();
+        let flush_task_sender = test_helper.flush_task_sender.clone();
+        let global_seq_task_sender = test_helper.global_seq_task_sender.clone();
+        let compact_task_sender = test_helper.compact_task_sender.clone();
 
-        meta_manager.admin_meta().add_data_node().await.unwrap();
+        let (meta_manager, memory_pool, mut summary_1) = test_helper.init();
 
-        let _ = meta_manager
-            .tenant_manager()
-            .create_tenant("cnosdb".to_string(), TenantOptions::default())
-            .await;
-        let summary_dir = opt.storage.summary_dir();
-        if !file_manager::try_exists(&summary_dir) {
-            std::fs::create_dir_all(&summary_dir).unwrap();
-        }
-        let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
-        let mut summary = Summary::new(
-            opt.clone(),
-            runtime.clone(),
-            memory_pool.clone(),
-            global_seq_task_sender.clone(),
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-        let edit = VersionEdit::new_add_vnode(100, "cnosdb.hello".to_string(), 0);
-        summary
-            .apply_version_edit(vec![edit], HashMap::new(), HashMap::new())
-            .await
-            .unwrap();
-        let _summary = Summary::recover(
-            meta_manager,
-            opt.clone(),
-            runtime.clone(),
-            memory_pool,
-            flush_task_sender,
-            global_seq_task_sender,
-            compact_task_sender,
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-    }
-
-    async fn test_tsf_num_recover(
-        config: config::Config,
-        runtime: Arc<Runtime>,
-        flush_task_sender: Sender<FlushReq>,
-        global_seq_task_sender: Sender<GlobalSequenceTask>,
-        compact_task_sender: Sender<CompactTask>,
-    ) {
-        let opt = Arc::new(Options::from(&config));
-        let empty_path = "";
-        let meta_manager: MetaRef =
-            RemoteMetaManager::new(config.clone(), empty_path.to_string()).await;
-
-        meta_manager.admin_meta().add_data_node().await.unwrap();
-
-        let _ = meta_manager
-            .tenant_manager()
-            .create_tenant("cnosdb".to_string(), TenantOptions::default())
-            .await;
-        let summary_dir = opt.storage.summary_dir();
-        if !file_manager::try_exists(&summary_dir) {
-            std::fs::create_dir_all(&summary_dir).unwrap();
-        }
-        let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
-        let mut summary = Summary::new(
-            opt.clone(),
-            runtime.clone(),
-            memory_pool.clone(),
-            global_seq_task_sender.clone(),
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-
-        let edit = VersionEdit::new_add_vnode(100, "cnosdb.hello".to_string(), 0);
-        summary
-            .apply_version_edit(vec![edit], HashMap::new(), HashMap::new())
-            .await
-            .unwrap();
-        let mut summary = Summary::recover(
-            meta_manager.clone(),
-            opt.clone(),
-            runtime.clone(),
-            memory_pool.clone(),
-            flush_task_sender.clone(),
-            global_seq_task_sender.clone(),
-            compact_task_sender.clone(),
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-        assert_eq!(summary.version_set.read().await.tsf_num().await, 1);
-        let edit = VersionEdit::new_del_vnode(100);
-        summary
-            .apply_version_edit(vec![edit], HashMap::new(), HashMap::new())
-            .await
-            .unwrap();
-        let summary = Summary::recover(
-            meta_manager,
-            opt.clone(),
-            runtime,
-            memory_pool.clone(),
-            flush_task_sender,
-            global_seq_task_sender,
-            compact_task_sender,
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-        assert_eq!(summary.version_set.read().await.tsf_num().await, 0);
-    }
-
-    // tips : we can use a small max_summary_size
-    #[allow(clippy::too_many_arguments)]
-    async fn test_recover_summary_with_roll_0(
-        config: config::Config,
-        runtime: Arc<Runtime>,
-        summary_task_sender: Sender<SummaryTask>,
-        flush_task_sender: Sender<FlushReq>,
-        global_seq_task_sender: Sender<GlobalSequenceTask>,
-        compact_task_sender: Sender<CompactTask>,
-    ) {
-        let opt = Arc::new(Options::from(&config));
-        let empty_path = "";
-        let meta_manager: MetaRef =
-            RemoteMetaManager::new(config.clone(), empty_path.to_string()).await;
-
-        meta_manager.admin_meta().add_data_node().await.unwrap();
-        let _ = meta_manager
-            .tenant_manager()
-            .create_tenant("cnosdb".to_string(), TenantOptions::default())
-            .await;
-        let database = "test".to_string();
-        let summary_dir = opt.storage.summary_dir();
-        if !file_manager::try_exists(&summary_dir) {
-            std::fs::create_dir_all(&summary_dir).unwrap();
-        }
-        let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
-        let global = Arc::new(GlobalContext::new());
-        let mut summary = Summary::new(
-            opt.clone(),
-            runtime.clone(),
-            memory_pool.clone(),
-            global_seq_task_sender.clone(),
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-
-        let mut edits = vec![];
-        let db = summary
-            .version_set
-            .write()
-            .await
-            .create_db(
-                DatabaseSchema::new("cnosdb", &database),
-                meta_manager.clone(),
-                memory_pool.clone(),
-            )
-            .await
-            .unwrap();
-        for i in 0..40 {
-            db.write()
-                .await
-                .add_tsfamily(
+        #[rustfmt::skip]
+        runtime.block_on(async {
+            let mut edits = vec![];
+            #[rustfmt::skip]
+            let db = summary_1.version_set.write().await.create_db(
+                DatabaseSchema::new("cnosdb", database), meta_manager.clone(), memory_pool.clone(),
+            ).await.unwrap();
+            // Add 20 vnodes
+            for i in 0..20 {
+                #[rustfmt::skip]
+                db.write().await.add_tsfamily(
                     i,
                     0,
                     None,
                     summary_task_sender.clone(),
                     flush_task_sender.clone(),
                     compact_task_sender.clone(),
-                    global.clone(),
-                )
-                .await
-                .expect("add tsfamily successfully");
-            let edit = VersionEdit::new_add_vnode(i, make_owner("cnosdb", &database), 0);
-            edits.push(edit.clone());
-        }
-
-        for _ in 0..100 {
-            for i in 0..20 {
-                db.write()
-                    .await
-                    .del_tsfamily(i, summary_task_sender.clone())
-                    .await;
-                edits.push(VersionEdit::new_del_vnode(i));
+                    global_ctx.clone(),
+                ).await.expect("add tsfamily successfully");
+                let edit = VersionEdit::new_add_vnode(i, owned_database.to_string(), 0);
+                edits.push(edit.clone());
             }
-        }
-        summary
-            .apply_version_edit(edits, HashMap::new(), HashMap::new())
-            .await
-            .unwrap();
+            summary_1
+                .apply_version_edit(edits.drain(..).collect(), HashMap::new(), HashMap::new())
+                .await
+                .unwrap();
+            // Do delete vnode for 10 times.
+            for _ in 0..10 {
+                edits.truncate(0);
+                // Delete 10 vnodes
+                for i in 0..10 {
+                    #[rustfmt::skip]
+                    db.write().await.del_tsfamily(i, summary_task_sender.clone()).await;
+                    edits.push(VersionEdit::new_del_vnode(i));
+                }
+                summary_1
+                    .apply_version_edit(edits.drain(..).collect(), HashMap::new(), HashMap::new())
+                    .await
+                    .unwrap();
+            }
+        });
 
-        let summary = Summary::recover(
-            meta_manager.clone(),
-            opt.clone(),
-            runtime,
-            memory_pool.clone(),
-            flush_task_sender.clone(),
-            global_seq_task_sender.clone(),
-            compact_task_sender,
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(summary.version_set.read().await.tsf_num().await, 20);
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn test_recover_summary_with_roll_1(
-        config: config::Config,
-        runtime: Arc<Runtime>,
-        summary_task_sender: Sender<SummaryTask>,
-        flush_task_sender: Sender<FlushReq>,
-        global_seq_task_sender: Sender<GlobalSequenceTask>,
-        compact_task_sender: Sender<CompactTask>,
-    ) {
-        let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
-
-        let opt = Arc::new(Options::from(&config));
-        let empty_path = "";
-        let meta_manager: MetaRef =
-            RemoteMetaManager::new(config.clone(), empty_path.to_string()).await;
-
-        meta_manager.admin_meta().add_data_node().await.unwrap();
-
-        let _ = meta_manager
-            .tenant_manager()
-            .create_tenant("cnosdb".to_string(), TenantOptions::default())
-            .await;
-        let database = "test".to_string();
-        let summary_dir = opt.storage.summary_dir();
-        if !file_manager::try_exists(&summary_dir) {
-            std::fs::create_dir_all(&summary_dir).unwrap();
-        }
-        let mut summary = Summary::new(
-            opt.clone(),
-            runtime.clone(),
-            memory_pool.clone(),
-            global_seq_task_sender.clone(),
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-
-        let db = summary
-            .version_set
-            .write()
-            .await
-            .create_db(
-                DatabaseSchema::new("cnosdb", &database),
-                meta_manager.clone(),
-                memory_pool.clone(),
+        runtime.block_on(async move {
+            let summary = Summary::recover(
+                meta_manager,
+                options,
+                runtime_inner,
+                memory_pool,
+                flush_task_sender,
+                global_seq_task_sender,
+                compact_task_sender,
+                false,
+                Arc::new(MetricsRegister::default()),
             )
             .await
             .unwrap();
-        let cxt = Arc::new(GlobalContext::new());
-        db.write()
-            .await
-            .add_tsfamily(
-                10,
+            assert_eq!(summary.version_set.read().await.tsf_num().await, 10);
+        });
+
+        drop(summary_task_sender);
+        drop(summary_1);
+        test_helper.join();
+    }
+
+    #[test]
+    fn test_recover_summary_with_roll_1() {
+        let base_dir = "/tmp/test/summary/test_recover_summary_with_roll_1";
+        let _ = std::fs::remove_dir_all(base_dir);
+        let database = "test_recover_summary_with_roll_1";
+        let owned_database = make_owner("cnosdb", database);
+        let vnode_id = 10;
+        let global_ctx = Arc::new(GlobalContext::new());
+        let mut config = config::get_config_for_test();
+        config.storage.max_summary_size = 256;
+        let test_helper = SummaryTestHelper::new(
+            config,
+            base_dir.to_string(),
+            "test_recover_summary_with_roll_1".to_string(),
+        );
+        let runtime = test_helper.runtime.clone();
+        let runtime_inner = runtime.clone();
+        let options = test_helper.options.clone();
+        let summary_task_sender = test_helper.summary_task_sender.clone();
+        let flush_task_sender = test_helper.flush_task_sender.clone();
+        let global_seq_task_sender = test_helper.global_seq_task_sender.clone();
+        let compact_task_sender = test_helper.compact_task_sender.clone();
+
+        let (meta_manager, memory_pool, mut summary_1) = test_helper.init();
+
+        // Add vnode[10], delete vnode[0]
+        let mut edits = runtime.block_on(async {
+            #[rustfmt::skip]
+            let db = summary_1.version_set.write().await.create_db(
+                DatabaseSchema::new("cnosdb", database), meta_manager.clone(), memory_pool.clone(),
+            ).await.unwrap();
+            #[rustfmt::skip]
+            db.write().await.add_tsfamily(
+                vnode_id,
                 0,
                 None,
                 summary_task_sender.clone(),
                 flush_task_sender.clone(),
                 compact_task_sender.clone(),
-                cxt.clone(),
-            )
-            .await
-            .expect("add tsfamily failed");
+                global_ctx.clone(),
+            ).await.expect("add tsfamily failed");
+            #[rustfmt::skip]
+            let mut edits = vec![VersionEdit::new_add_vnode(vnode_id, owned_database.to_string(), 0)];
+            for _ in 0..10 {
+                db.write()
+                    .await
+                    .del_tsfamily(0, summary_task_sender.clone())
+                    .await;
+                let edit = VersionEdit::new_del_vnode(0);
+                edits.push(edit);
+            }
 
-        let mut edits = vec![];
-        let edit = VersionEdit::new_add_vnode(10, "cnosdb.hello".to_string(), 0);
-        edits.push(edit);
+            edits
+        });
 
-        for _ in 0..100 {
-            db.write()
-                .await
-                .del_tsfamily(0, summary_task_sender.clone())
-                .await;
-            let edit = VersionEdit::new_del_vnode(0);
-            edits.push(edit);
-        }
-
-        {
-            let vs = summary.version_set.write().await;
-            let tsf = vs.get_tsfamily_by_tf_id(10).await.unwrap();
+        // Add some files to vnode[10]
+        runtime.block_on(async move {
+            let tsf = {
+                let vs = summary_1.version_set.read().await;
+                vs.get_tsfamily_by_tf_id(vnode_id).await.unwrap()
+            };
             let mut version = tsf.read().await.version().copy_apply_version_edits(
                 edits.clone(),
                 &mut HashMap::new(),
@@ -1286,8 +1283,8 @@ mod test {
             );
             let tsm_reader_cache = Arc::downgrade(&version.tsm_reader_cache);
 
-            summary.ctx.set_last_seq(1);
-            let mut edit = VersionEdit::new(10);
+            summary_1.ctx.set_last_seq(1);
+            let mut edit = VersionEdit::new(vnode_id);
             let meta = CompactMeta {
                 file_id: 15,
                 is_delta: false,
@@ -1295,7 +1292,7 @@ mod test {
                 level: 1,
                 min_ts: 1,
                 max_ts: 1,
-                tsf_id: 10,
+                tsf_id: vnode_id,
                 high_seq: 1,
                 ..Default::default()
             };
@@ -1307,40 +1304,45 @@ mod test {
             tsf.write().await.new_version(version, None);
             edit.add_file(meta, 1);
             edits.push(edit);
-        }
 
-        summary
-            .apply_version_edit(edits, HashMap::new(), HashMap::new())
+            summary_1
+                .apply_version_edit(edits, HashMap::new(), HashMap::new())
+                .await
+                .unwrap();
+        });
+
+        runtime.block_on(async move {
+            let summary = Summary::recover(
+                meta_manager,
+                options,
+                runtime_inner,
+                memory_pool,
+                flush_task_sender,
+                global_seq_task_sender,
+                compact_task_sender,
+                false,
+                Arc::new(MetricsRegister::default()),
+            )
             .await
             .unwrap();
 
-        let summary = Summary::recover(
-            meta_manager,
-            opt,
-            runtime,
-            memory_pool.clone(),
-            flush_task_sender,
-            global_seq_task_sender,
-            compact_task_sender,
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
+            let vs = summary.version_set.read().await;
+            let tsf = vs.get_tsfamily_by_tf_id(vnode_id).await.unwrap();
+            assert_eq!(tsf.read().await.version().last_seq, 1);
+            assert_eq!(tsf.read().await.version().levels_info[1].tsf_id, vnode_id);
+            assert!(!tsf.read().await.version().levels_info[1].files[0].is_delta());
+            assert_eq!(
+                tsf.read().await.version().levels_info[1].files[0].file_id(),
+                15
+            );
+            assert_eq!(
+                tsf.read().await.version().levels_info[1].files[0].size(),
+                100
+            );
+            assert_eq!(summary.ctx.file_id(), 16);
+        });
 
-        let vs = summary.version_set.read().await;
-        let tsf = vs.get_tsfamily_by_tf_id(10).await.unwrap();
-        assert_eq!(tsf.read().await.version().last_seq, 1);
-        assert_eq!(tsf.read().await.version().levels_info[1].tsf_id, 10);
-        assert!(!tsf.read().await.version().levels_info[1].files[0].is_delta());
-        assert_eq!(
-            tsf.read().await.version().levels_info[1].files[0].file_id(),
-            15
-        );
-        assert_eq!(
-            tsf.read().await.version().levels_info[1].files[0].size(),
-            100
-        );
-        assert_eq!(summary.ctx.file_id(), 16);
+        drop(summary_task_sender);
+        test_helper.join();
     }
 }

--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
@@ -15,6 +16,7 @@ use models::{FieldId, SchemaId, SeriesId, Timestamp};
 use parking_lot::RwLock;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::RwLock as AsyncRwLock;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use trace::{debug, error, info, warn};
@@ -163,6 +165,21 @@ impl Drop for ColumnFile {
             }
             info!("Removed file {} at '{}", self.file_id, path.display());
         }
+    }
+}
+
+impl Display for ColumnFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{ L:{}, ID:{}, C:{}, T:{}-{}, S:{} }}",
+            self.level,
+            self.file_id,
+            if self.is_compacting() { "T" } else { "F" },
+            self.time_range.min_ts,
+            self.time_range.max_ts,
+            self.size,
+        )
     }
 }
 
@@ -338,6 +355,19 @@ impl LevelInfo {
 
     pub fn level(&self) -> u32 {
         self.level
+    }
+}
+
+impl Display for LevelInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{ L:{}, files: [ ", self.level)?;
+        for (i, file) in self.files.iter().enumerate() {
+            write!(f, "{}", file.as_ref())?;
+            if i < self.files.len() - 1 {
+                write!(f, ", ")?;
+            }
+        }
+        write!(f, "] }}")
     }
 }
 
@@ -880,37 +910,6 @@ impl TseriesFamily {
         }
     }
 
-    pub fn schedule_compaction(&self, runtime: Arc<Runtime>) {
-        let tsf_id = self.tf_id;
-        let compact_trigger_cold_duration = self.storage_opt.compact_trigger_cold_duration;
-        let last_modified = self.last_modified.clone();
-        let compact_task_sender = self.compact_task_sender.clone();
-        let cancellation_token = self.cancellation_token.clone();
-        let _jh = runtime.spawn(async move {
-            if compact_trigger_cold_duration == Duration::ZERO {} else {
-                let mut cold_check_interval = tokio::time::interval(Duration::from_secs(10));
-                cold_check_interval.tick().await;
-                loop {
-                    tokio::select! {
-                        _ = cold_check_interval.tick() => {
-                            let last_modified = last_modified.read().await;
-                            if let Some(t) = *last_modified {
-                                if t.elapsed() >= compact_trigger_cold_duration {
-                                    if let Err(e) = compact_task_sender.send(CompactTask::ColdVnode(tsf_id)).await {
-                                        warn!("failed to send compact task({}), {}", tsf_id, e);
-                                    }
-                                }
-                            }
-                        }
-                        _ = cancellation_token.cancelled() => {
-                            break;
-                        }
-                    }
-                }
-            }
-        });
-    }
-
     pub fn close(&self) {
         self.cancellation_token.cancel();
     }
@@ -1002,8 +1001,64 @@ impl TseriesFamily {
 
 impl Drop for TseriesFamily {
     fn drop(&mut self) {
-        self.cancellation_token.cancel();
+        if !self.cancellation_token.is_cancelled() {
+            self.cancellation_token.cancel();
+        }
     }
+}
+
+pub fn schedule_vnode_compaction(runtime: Arc<Runtime>, vnode: Arc<AsyncRwLock<TseriesFamily>>) {
+    let _jh = runtime.spawn(async move {
+        let vnode_rlock = vnode.read().await;
+        let tsf_id = vnode_rlock.tf_id;
+        let compact_trigger_cold_duration = vnode_rlock.storage_opt.compact_trigger_cold_duration;
+        let last_modified = vnode_rlock.last_modified.clone();
+        let compact_trigger_file_num = vnode_rlock.storage_opt.compact_trigger_file_num as usize;
+        let compact_task_sender = vnode_rlock.compact_task_sender.clone();
+        let cancellation_token = vnode_rlock.cancellation_token.clone();
+        drop(vnode_rlock);
+
+        if compact_trigger_cold_duration == Duration::ZERO {} else {
+            let mut check_interval = tokio::time::interval(Duration::from_secs(10));
+            check_interval.tick().await;
+
+            loop {
+                tokio::select! {
+                    _ = check_interval.tick() => {
+                        // Check if vnode is cold.
+                        let ts_rlock = last_modified.read().await;
+                        if let Some(t) = *ts_rlock {
+                            if t.elapsed() >= compact_trigger_cold_duration {
+                                drop(ts_rlock);
+                                let mut ts_wlock = last_modified.write().await;
+                                *ts_wlock = Some(Instant::now());
+                                if let Err(e) = compact_task_sender.send(CompactTask::Cold(tsf_id)).await {
+                                    warn!("failed to send compact task({}), {}", tsf_id, e);
+                                }
+                            }
+                        }
+
+                        // Check if level-0 files is more than DEFAULT_COMPACT_TRIGGER_DETLA_FILE_NUM
+                        let version = vnode.read().await.super_version().version.clone();
+                        let mut level0_files = 0_usize;
+                        for file in version.levels_info()[0].files.iter() {
+                            if !file.is_compacting() {
+                                level0_files += 1;
+                            }
+                        }
+                        if level0_files >= compact_trigger_file_num {
+                            if let Err(e) = compact_task_sender.send(CompactTask::Delta(tsf_id)).await {
+                                warn!("failed to send compact task({}), {}", tsf_id, e);
+                            }
+                        }
+                    }
+                    _ = cancellation_token.cancelled() => {
+                        break;
+                    }
+                }
+            }
+        }
+    });
 }
 
 #[cfg(test)]

--- a/tskv/src/tsm/block.rs
+++ b/tskv/src/tsm/block.rs
@@ -428,6 +428,106 @@ impl DataBlock {
         blk
     }
 
+    pub fn split(self, timestamp: Timestamp) -> (DataBlock, DataBlock) {
+        match &self {
+            DataBlock::U64 { ts, val, .. } => {
+                let i = ts.binary_search(&timestamp).unwrap_or_else(|i| i);
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, ValueType::Unsigned))
+                } else {
+                    (
+                        DataBlock::U64 {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::U64 {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+            DataBlock::I64 { ts, val, .. } => {
+                let i = ts.binary_search(&timestamp).unwrap_or_else(|i| i);
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, ValueType::Integer))
+                } else {
+                    (
+                        DataBlock::I64 {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::I64 {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+            DataBlock::Str { ts, val, .. } => {
+                let i = ts.binary_search(&timestamp).unwrap_or_else(|i| i);
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, ValueType::String))
+                } else {
+                    (
+                        DataBlock::Str {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::Str {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+            DataBlock::F64 { ts, val, .. } => {
+                let i = ts.binary_search(&timestamp).unwrap_or_else(|i| i);
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, ValueType::Float))
+                } else {
+                    (
+                        DataBlock::F64 {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::F64 {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+            DataBlock::Bool { ts, val, .. } => {
+                let i = ts.binary_search(&timestamp).unwrap_or_else(|i| i);
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, ValueType::Boolean))
+                } else {
+                    (
+                        DataBlock::Bool {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::Bool {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+        }
+    }
+
     /// Merges one or many `DataBlock`s into some `DataBlock` with fixed length,
     /// sorted by timestamp, if many (timestamp, value) conflict with the same
     /// timestamp, use the last value.


### PR DESCRIPTION
# Which issue does this PR close?

Related #.

# Rationale for this change

Reduce amount of level-0 files early.

# What changes are included in this PR?

## Changes on compaction

- Add `DeltaCompactionPicker`, group level-0 files with the other 4-level (from level-4 to level-1), if it's minimum timestamp < maximum timestamp of the other level, then group this level-0 file to that level.
- Change `LevelCompactionPicker` logic, it only pick files in one level now.
- Now `schedule_compaction()` not only check if a vnode cold, but also check level-0 files (config `compact_trigger_file_num`) (This change makes unite tests in `summary.rs` won't stop, so I also edited test code in `summary.rs`.
- Now if a compact is for level-0 files, it merge data in level-0 files to the destination level, and put back data that timestamp > maximum timestamp of the destination level. 

## Other changes
- Add `Display` trait to `ColumnFile` and `LevelInfo`.
- Make unit tests in `summary.rs` can run in parallel.

# Are there any user-facing changes?

