### PR TITLE
fix(query): fix row_iterator finished too early

### DIFF
--- a/query_server/test/cases/ddl/cli_precision.result
+++ b/query_server/test/cases/ddl/cli_precision.result
@@ -58,7 +58,7 @@ time,ta,tb,value
 2022-11-03T06:20:11.000001000,a1,b1,1.0
 
 -- WRITE OPEN TSDB JSON --
-select * from nice;
+select * from nice order by host;
 -- OPEN TSDB JSON END --
 200 OK
 time,dc,host,value
@@ -129,7 +129,7 @@ time,ta,tb,value
 2022-11-03T06:20:11.000000000,a1,b1,1.0
 
 -- WRITE OPEN TSDB JSON --
-select * from nice;
+select * from nice order by host;
 -- OPEN TSDB JSON END --
 200 OK
 time,dc,host,value

--- a/query_server/test/cases/ddl/cli_precision.sql
+++ b/query_server/test/cases/ddl/cli_precision.sql
@@ -39,7 +39,7 @@ select * from test1;
 
 select * from test2;
 
-select * from nice;
+select * from nice order by host;
 
 drop database cli_precision;
 
@@ -80,4 +80,4 @@ select * from test1;
 
 select * from test2;
 
-select * from nice;
+select * from nice order by host;


### PR DESCRIPTION
# Which issue does this PR close?

Related #1274 .

# Rationale for this change

1. `RowIterator` set wrong parallel task number.
2. `RowIterator` finished too early, some data not loaded.

# What changes are included in this PR?

1. `series_group_num` is the minimum value of `cpu_num` and  `series_len`
2. Swap variable name of `series_group_num` and `series_group_size`.
3. When reset `FIeldFIleLocation::intersected_time_ranges`, also reset `FIeldFIleLocation::self.intersected_time_ranges_i`.

## Other changes in `tskv/../iterator.rs`

1. Add some comments.
4. Rename some variables.

# Are there any user-facing changes?
