### PR TITLE
fix: being polled after read stream exception

### DIFF
--- a/common/models/src/arrow/stream.rs
+++ b/common/models/src/arrow/stream.rs
@@ -34,10 +34,14 @@ where
             let sender = sender.clone();
             let task = async move {
                 while let Some(item) = stream.next().await {
+                    let exit = item.is_err();
                     // If send fails, stream being torn down,
                     // there is no place to send the error.
                     if sender.send(item).await.is_err() {
                         warn!("Stopping execution: output is gone, ParallelMergeStream cancelling");
+                        return;
+                    }
+                    if exit {
                         return;
                     }
                 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related #1303  .

this maybe fix `async fn` resumed after completion

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
