### PR TITLE
improve: implement flight sql do_put_prepared_statement_update

### DIFF
--- a/common/trace/src/lib.rs
+++ b/common/trace/src/lib.rs
@@ -58,7 +58,7 @@ pub fn targets_filter(level: LevelFilter, defined_tokio_trace: bool) -> filter::
             ("http_protocol", level),
             ("limiter_bucket", level),
             ("lru_cache", level),
-            ("main", level),
+            ("cnosdb", level),
             ("memory_pool", level),
             ("meta", level),
             ("metrics", level),

--- a/main/src/flight_sql/flight_sql_server.rs
+++ b/main/src/flight_sql/flight_sql_server.rs
@@ -921,22 +921,19 @@ where
     /// because ad-hoc statement of flight jdbc needs to call this interface, so it is simple to implement
     async fn do_put_prepared_statement_update(
         &self,
-        _query: CommandPreparedStatementUpdate,
-        _request: Request<Streaming<FlightData>>,
+        query: CommandPreparedStatementUpdate,
+        request: Request<Streaming<FlightData>>,
     ) -> Result<i64, Status> {
-        // debug!(
-        //     "do_put_prepared_statement_update: query: {:?}, request: {:?}",
-        //     query, request
-        // );
-        //
-        // let prepared_statement_handle = query.prepared_statement_handle.to_byte_slice();
-        //
-        // let rows_count = self.fetch_affected_rows_count(prepared_statement_handle)?;
-        //
-        // Ok(rows_count)
-        Err(Status::unimplemented(
-            "do_put_prepared_statement_update not implemented",
-        ))
+        let prepared_statement_ident = query.prepared_statement_handle.to_byte_slice();
+        debug!(
+            "do_put_prepared_statement_update query: {:?}",
+            prepared_statement_ident
+        );
+        let _ = get_span_recorder(
+            request.extensions(),
+            "flight sql do_put_prepared_statement_update",
+        );
+        Ok(-1)
     }
 
     /// Prepared statement is not supported,


### PR DESCRIPTION
# Rationale for this change
Because the `do_put_prepared_statement_update` of the `flight sql server` was not implemented before, the sql cannot be executed when using arrow-fligh-jdbc.


 
