### PR TITLE
[Feature] Recovering WAL records will not add schema to tskv; stores `drop_table` & `remove_tsfamily` in WAL

### DIFF
--- a/common/protos/src/models_helper.rs
+++ b/common/protos/src/models_helper.rs
@@ -380,9 +380,11 @@ mod test {
 
     pub fn create_random_points_include_delta<'a>(
         fbb: &mut flatbuffers::FlatBufferBuilder<'a>,
+        database: &str,
+        table: &str,
         num: usize,
     ) -> WIPOffset<Points<'a>> {
-        let db = fbb.create_vector("db".as_bytes());
+        let db = fbb.create_vector(database.as_bytes());
         let mut tags_names: HashMap<&str, usize> = HashMap::new();
         tags_names.insert("ta", 0);
         tags_names.insert("tb", 1);
@@ -464,7 +466,7 @@ mod test {
         let fb_schema = build_fb_schema_offset(fbb, &schema);
 
         let point = fbb.create_vector(&points);
-        let tab = fbb.create_vector("table".as_bytes());
+        let tab = fbb.create_vector(table.as_bytes());
 
         let mut table_builder = TableBuilder::new(fbb);
 
@@ -487,6 +489,7 @@ mod test {
 
     pub fn create_big_random_points<'a>(
         fbb: &mut flatbuffers::FlatBufferBuilder<'a>,
+        table: &str,
         num: usize,
     ) -> WIPOffset<Points<'a>> {
         let db = fbb.create_vector("db".as_bytes());
@@ -534,7 +537,7 @@ mod test {
         let fb_schema = build_fb_schema_offset(fbb, &schema);
 
         let point = fbb.create_vector(&points);
-        let tab = fbb.create_vector("table".as_bytes());
+        let tab = fbb.create_vector(table.as_bytes());
 
         let mut table_builder = TableBuilder::new(fbb);
 

--- a/common/trace/src/lib.rs
+++ b/common/trace/src/lib.rs
@@ -5,6 +5,7 @@ pub mod span;
 pub mod span_ctx;
 
 use std::net::SocketAddr;
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -28,7 +29,7 @@ use tracing_subscriber::{filter, fmt, EnvFilter, Layer, Registry};
 
 /// only use for unit test
 /// parameter only use for first call
-pub fn init_default_global_tracing(dir: &str, file_name: &str, level: &str) {
+pub fn init_default_global_tracing(dir: impl AsRef<Path>, file_name: &str, level: &str) {
     static START: Once = Once::new();
 
     START.call_once(|| {
@@ -87,7 +88,7 @@ pub fn targets_filter(level: LevelFilter, defined_tokio_trace: bool) -> filter::
 }
 
 pub fn init_process_global_tracing(
-    log_path: &str,
+    log_path: impl AsRef<Path>,
     log_level: &str,
     log_file_prefix_name: &str,
     tokio_trace: Option<&TokioTrace>,
@@ -107,7 +108,7 @@ pub fn init_process_global_tracing(
 }
 
 pub fn init_global_tracing(
-    log_path: &str,
+    log_path: impl AsRef<Path>,
     log_level: &str,
     log_file_prefix_name: &str,
     tokio_trace: Option<&TokioTrace>,

--- a/meta/src/bin/main.rs
+++ b/meta/src/bin/main.rs
@@ -131,7 +131,12 @@ async fn detect_node_heartbeat(heartbeat_config: HeartBeatConfig, app: Data<Meta
         interval.tick().await;
 
         if let Ok(_leader) = app.raft.is_leader().await {
-            let opt_list = app.store.state_machine.write().await.children_data::<NodeMetrics>(&metrics_path);
+            let opt_list = app
+                .store
+                .state_machine
+                .write()
+                .await
+                .children_data::<NodeMetrics>(&metrics_path);
 
             if let Ok(list) = opt_list {
                 let node_metrics_list: Vec<NodeMetrics> = list.into_values().collect();

--- a/tskv/benches/kvcore_bench.rs
+++ b/tskv/benches/kvcore_bench.rs
@@ -69,7 +69,7 @@ fn big_write(c: &mut Criterion) {
             for _i in 0..50 {
                 let _database = "db".to_string();
                 let mut fbb = flatbuffers::FlatBufferBuilder::new();
-                let points = models_helper::create_big_random_points(&mut fbb, 10);
+                let points = models_helper::create_big_random_points(&mut fbb, "big_write", 10);
                 fbb.finish(points, None);
                 let points = fbb.finished_data().to_vec();
 

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -201,11 +201,9 @@ impl Database {
     pub async fn del_tsfamily(&mut self, tf_id: u32, summary_task_sender: Sender<SummaryTask>) {
         if let Some(tf) = self.ts_families.remove(&tf_id) {
             tf.read().await.close();
-        } else {
-            // If no ts_family recovered from summary, do not write summary.
-            return;
         }
 
+        // TODO(zipper): If no ts_family recovered from summary, do not write summary.
         let edits = vec![VersionEdit::new_del_vnode(tf_id)];
         let (task_state_sender, _task_state_receiver) = oneshot::channel();
         let task = SummaryTask::new(edits, None, None, task_state_sender);

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -201,6 +201,9 @@ impl Database {
     pub async fn del_tsfamily(&mut self, tf_id: u32, summary_task_sender: Sender<SummaryTask>) {
         if let Some(tf) = self.ts_families.remove(&tf_id) {
             tf.read().await.close();
+        } else {
+            // If no ts_family recovered from summary, do not write summary.
+            return;
         }
 
         let edits = vec![VersionEdit::new_del_vnode(tf_id)];

--- a/tskv/src/engine_mock.rs
+++ b/tskv/src/engine_mock.rs
@@ -55,12 +55,30 @@ impl Engine for MockEngine {
         Ok(())
     }
 
+    async fn remove_tsfamily_from_wal(
+        &self,
+        tenant: &str,
+        database: &str,
+        vnode_id: VnodeId,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     async fn flush_tsfamily(&self, tenant: &str, database: &str, id: u32) -> Result<()> {
         Ok(())
     }
 
     async fn drop_database(&self, tenant: &str, database: &str) -> Result<()> {
         println!("drop_database.sql {:?}", database);
+        Ok(())
+    }
+
+    async fn drop_table(&self, tenant: &str, database: &str, table: &str) -> Result<()> {
+        println!("drop_table db:{:?}, table:{:?}", database, table);
+        Ok(())
+    }
+
+    async fn drop_table_from_wal(&self, tenant: &str, database: &str, table: &str) -> Result<()> {
         Ok(())
     }
 
@@ -83,11 +101,6 @@ impl Engine for MockEngine {
     // fn get_db_schema(&self, tenant: &str, name: &str) -> Result<Option<DatabaseSchema>> {
     //     Ok(Some(DatabaseSchema::new(tenant, name)))
     // }
-
-    async fn drop_table(&self, tenant: &str, database: &str, table: &str) -> Result<()> {
-        println!("drop_table db:{:?}, table:{:?}", database, table);
-        Ok(())
-    }
 
     async fn delete_series(
         &self,

--- a/tskv/src/engine_mock.rs
+++ b/tskv/src/engine_mock.rs
@@ -55,6 +55,15 @@ impl Engine for MockEngine {
         Ok(())
     }
 
+    async fn remove_tsfamily_from_wal(
+        &self,
+        tenant: &str,
+        database: &str,
+        vnode_id: VnodeId,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     async fn flush_tsfamily(&self, tenant: &str, database: &str, id: u32) -> Result<()> {
         Ok(())
     }
@@ -86,6 +95,10 @@ impl Engine for MockEngine {
 
     async fn drop_table(&self, tenant: &str, database: &str, table: &str) -> Result<()> {
         println!("drop_table db:{:?}, table:{:?}", database, table);
+        Ok(())
+    }
+
+    async fn drop_table_from_wal(&self, tenant: &str, database: &str, table: &str) -> Result<()> {
         Ok(())
     }
 

--- a/tskv/src/engine_mock.rs
+++ b/tskv/src/engine_mock.rs
@@ -55,30 +55,12 @@ impl Engine for MockEngine {
         Ok(())
     }
 
-    async fn remove_tsfamily_from_wal(
-        &self,
-        tenant: &str,
-        database: &str,
-        vnode_id: VnodeId,
-    ) -> Result<()> {
-        Ok(())
-    }
-
     async fn flush_tsfamily(&self, tenant: &str, database: &str, id: u32) -> Result<()> {
         Ok(())
     }
 
     async fn drop_database(&self, tenant: &str, database: &str) -> Result<()> {
         println!("drop_database.sql {:?}", database);
-        Ok(())
-    }
-
-    async fn drop_table(&self, tenant: &str, database: &str, table: &str) -> Result<()> {
-        println!("drop_table db:{:?}, table:{:?}", database, table);
-        Ok(())
-    }
-
-    async fn drop_table_from_wal(&self, tenant: &str, database: &str, table: &str) -> Result<()> {
         Ok(())
     }
 
@@ -101,6 +83,11 @@ impl Engine for MockEngine {
     // fn get_db_schema(&self, tenant: &str, name: &str) -> Result<Option<DatabaseSchema>> {
     //     Ok(Some(DatabaseSchema::new(tenant, name)))
     // }
+
+    async fn drop_table(&self, tenant: &str, database: &str, table: &str) -> Result<()> {
+        println!("drop_table db:{:?}, table:{:?}", database, table);
+        Ok(())
+    }
 
     async fn delete_series(
         &self,

--- a/tskv/src/engine_mock.rs
+++ b/tskv/src/engine_mock.rs
@@ -40,27 +40,7 @@ impl Engine for MockEngine {
         Ok(WritePointsResponse { points_number: 0 })
     }
 
-    async fn write_from_wal(
-        &self,
-        id: u32,
-        precision: Precision,
-        write_batch: WritePointsRequest,
-        seq: u64,
-    ) -> Result<()> {
-        debug!("write point");
-        Ok(())
-    }
-
     async fn remove_tsfamily(&self, tenant: &str, database: &str, id: u32) -> Result<()> {
-        Ok(())
-    }
-
-    async fn remove_tsfamily_from_wal(
-        &self,
-        tenant: &str,
-        database: &str,
-        vnode_id: VnodeId,
-    ) -> Result<()> {
         Ok(())
     }
 
@@ -95,10 +75,6 @@ impl Engine for MockEngine {
 
     async fn drop_table(&self, tenant: &str, database: &str, table: &str) -> Result<()> {
         println!("drop_table db:{:?}, table:{:?}", database, table);
-        Ok(())
-    }
-
-    async fn drop_table_from_wal(&self, tenant: &str, database: &str, table: &str) -> Result<()> {
         Ok(())
     }
 

--- a/tskv/src/error.rs
+++ b/tskv/src/error.rs
@@ -321,9 +321,10 @@ pub enum ChannelReceiveError {
 #[test]
 fn test_mod_code() {
     let e = Error::Schema {
-        source: SchemaError::ColumnAlreadyExists {
-            name: "".to_string(),
+        source: SchemaError::TableNotFound {
+            database: String::new(),
+            table: String::new(),
         },
     };
-    assert!(e.code().starts_with("02"));
+    assert_eq!(e.code(), "020004");
 }

--- a/tskv/src/error.rs
+++ b/tskv/src/error.rs
@@ -201,6 +201,12 @@ pub enum Error {
     Points {
         source: PointsError,
     },
+
+    #[snafu(display("non-UTF-8 string '{message}': {source}"))]
+    InvalidUtf8 {
+        message: String,
+        source: std::str::Utf8Error,
+    },
 }
 
 impl From<PointsError> for Error {

--- a/tskv/src/file_utils.rs
+++ b/tskv/src/file_utils.rs
@@ -16,21 +16,24 @@ lazy_static! {
     static ref INDEX_BINLOG_FILE_NAME_PATTERN: Regex = Regex::new(r"_\d{6}\.binlog").unwrap();
 }
 
-// Summary file.
+/// Make a path for summary file by it's directory and id.
 pub fn make_summary_file(path: impl AsRef<Path>, number: u64) -> PathBuf {
     let p = format!("summary-{:06}", number);
     path.as_ref().join(p)
 }
 
+/// Make a path for summary temporary file by it's directory.
 pub fn make_summary_file_tmp(path: impl AsRef<Path>) -> PathBuf {
     let p = "summary.tmp".to_string();
     path.as_ref().join(p)
 }
 
+/// Check a summary file's name.
 pub fn check_summary_file_name(file_name: &str) -> bool {
     SUMMARY_FILE_NAME_PATTERN.is_match(file_name)
 }
 
+/// Rename a file, from old path to new path.
 pub async fn rename(old_name: impl AsRef<Path>, new_name: impl AsRef<Path>) -> Result<()> {
     fs::create_dir_all(new_name.as_ref().parent().unwrap()).await?;
     fs::rename(old_name, new_name)
@@ -38,6 +41,7 @@ pub async fn rename(old_name: impl AsRef<Path>, new_name: impl AsRef<Path>) -> R
         .map_err(|e| Error::IO { source: e })
 }
 
+/// Get id from a summary file's name.
 pub fn get_summary_file_id(file_name: &str) -> Result<u64> {
     if !check_summary_file_name(file_name) {
         return Err(Error::InvalidFileName {
@@ -54,17 +58,18 @@ pub fn get_summary_file_id(file_name: &str) -> Result<u64> {
         })
 }
 
-// index binlog files.
-
+/// Make a path for index binlog file by it's directory and id.
 pub fn make_index_binlog_file(path: impl AsRef<Path>, sequence: u64) -> PathBuf {
     let p = format!("_{:06}.binlog", sequence);
     path.as_ref().join(p)
 }
 
+/// Check a index binlog file's name.
 pub fn check_index_binlog_file_name(file_name: &str) -> bool {
     INDEX_BINLOG_FILE_NAME_PATTERN.is_match(file_name)
 }
 
+/// Get id from a index binlog file's name.
 pub fn get_index_binlog_file_id(file_name: &str) -> Result<u64> {
     if !check_index_binlog_file_name(file_name) {
         return Err(Error::InvalidFileName {
@@ -81,16 +86,18 @@ pub fn get_index_binlog_file_id(file_name: &str) -> Result<u64> {
         })
 }
 
-// WAL (write ahead log) file.
+/// Make a path for WAL (write ahead log) file by it's directory and id.
 pub fn make_wal_file(path: impl AsRef<Path>, sequence: u64) -> PathBuf {
     let p = format!("_{:06}.wal", sequence);
     path.as_ref().join(p)
 }
 
+/// Check a WAL file's name.
 pub fn check_wal_file_name(file_name: &str) -> bool {
     WAL_FILE_NAME_PATTERN.is_match(file_name)
 }
 
+/// Get id from a WAL file's name.
 pub fn get_wal_file_id(file_name: &str) -> Result<u64> {
     if !check_wal_file_name(file_name) {
         return Err(Error::InvalidFileName {
@@ -107,12 +114,13 @@ pub fn get_wal_file_id(file_name: &str) -> Result<u64> {
         })
 }
 
-// TSM file
+/// Make a path for TSM file by it's directory and id.
 pub fn make_tsm_file_name(path: impl AsRef<Path>, sequence: u64) -> PathBuf {
     let p = format!("_{:06}.tsm", sequence);
     path.as_ref().join(p)
 }
 
+/// Get id from a TSM file's name.
 pub fn get_tsm_file_id_by_path(tsm_path: impl AsRef<Path>) -> Result<u64> {
     let path = tsm_path.as_ref();
     let file_name = path
@@ -137,19 +145,19 @@ pub fn get_tsm_file_id_by_path(tsm_path: impl AsRef<Path>) -> Result<u64> {
         })
 }
 
-// TSM tombstone file
+/// Make a path for TSM tombstone file by it's directory and id.
 pub fn make_tsm_tombstone_file_name(path: impl AsRef<Path>, sequence: u64) -> PathBuf {
     let p = format!("_{:06}.tombstone", sequence);
     path.as_ref().join(p)
 }
 
-// delta file
+/// Make a path for TSM delta file by it's directory and id.
 pub fn make_delta_file_name(path: impl AsRef<Path>, sequence: u64) -> PathBuf {
     let p = format!("_{:06}.delta", sequence);
     path.as_ref().join(p)
 }
 
-// Common
+/// Get the file's path that has the maximum id of files in a directory.
 pub fn get_max_sequence_file_name<F>(
     dir: impl AsRef<Path>,
     get_sequence: F,

--- a/tskv/src/lib.rs
+++ b/tskv/src/lib.rs
@@ -87,7 +87,9 @@ pub trait Engine: Send + Sync + Debug {
     /// - precision - The timestamp precision of table rows.
     /// - seq - The WAL sequence of the stored gRPC message.
     ///
-    /// Data is from the WAL(write-ahead-log), so won't write back to WAL.
+    /// Data is from the WAL(write-ahead-log), so won't write back to WAL, and
+    /// would not create any schema, if database of vnode does not exist, record
+    /// will be ignored.
     async fn write_from_wal(
         &self,
         vnode_id: VnodeId,
@@ -103,25 +105,9 @@ pub trait Engine: Send + Sync + Debug {
     /// Delete all data of a table.
     async fn drop_table(&self, tenant: &str, database: &str, table: &str) -> Result<()>;
 
-    /// Delete all data of a table.
-    ///
-    /// Data is from the WAL(write-ahead-log), so won't write back to WAL.
-    async fn drop_table_from_wal(&self, tenant: &str, database: &str, table: &str) -> Result<()>;
-
     /// Remove the storage unit(caches and files) managed by engine,
     /// then remove directory of the storage unit.
     async fn remove_tsfamily(&self, tenant: &str, database: &str, vnode_id: VnodeId) -> Result<()>;
-
-    /// Remove the storage unit(caches and files) managed by engine,
-    /// then remove directory of the storage unit.
-    ///
-    /// Data is from the WAL(write-ahead-log), so won't write back to WAL.
-    async fn remove_tsfamily_from_wal(
-        &self,
-        tenant: &str,
-        database: &str,
-        vnode_id: VnodeId,
-    ) -> Result<()>;
 
     /// Mark the storage unit as `Copying` and flush caches.
     async fn prepare_copy_vnode(
@@ -235,4 +221,8 @@ pub trait Engine: Send + Sync + Debug {
 
     /// Close all background jobs of engine.
     async fn close(&self);
+}
+
+pub mod test {
+    pub use crate::memcache::test::{get_one_series_cache_data, put_rows_to_cache};
 }

--- a/tskv/src/lib.rs
+++ b/tskv/src/lib.rs
@@ -105,9 +105,25 @@ pub trait Engine: Send + Sync + Debug {
     /// Delete all data of a table.
     async fn drop_table(&self, tenant: &str, database: &str, table: &str) -> Result<()>;
 
+    /// Delete all data of a table.
+    ///
+    /// Data is from the WAL(write-ahead-log), so won't write back to WAL.
+    async fn drop_table_from_wal(&self, tenant: &str, database: &str, table: &str) -> Result<()>;
+
     /// Remove the storage unit(caches and files) managed by engine,
     /// then remove directory of the storage unit.
     async fn remove_tsfamily(&self, tenant: &str, database: &str, vnode_id: VnodeId) -> Result<()>;
+
+    /// Remove the storage unit(caches and files) managed by engine,
+    /// then remove directory of the storage unit.
+    ///
+    /// Data is from the WAL(write-ahead-log), so won't write back to WAL.
+    async fn remove_tsfamily_from_wal(
+        &self,
+        tenant: &str,
+        database: &str,
+        vnode_id: VnodeId,
+    ) -> Result<()>;
 
     /// Mark the storage unit as `Copying` and flush caches.
     async fn prepare_copy_vnode(

--- a/tskv/src/memcache.rs
+++ b/tskv/src/memcache.rs
@@ -627,22 +627,19 @@ impl Display for DataType {
     }
 }
 
-#[cfg(test)]
 pub(crate) mod test {
     use std::collections::HashMap;
     use std::mem::size_of;
     use std::sync::Arc;
 
-    use datafusion::arrow::datatypes::TimeUnit;
-    use memory_pool::{GreedyMemoryPool, MemoryPool};
     use models::predicate::domain::TimeRange;
-    use models::schema::{ColumnType, TableColumn, TskvTableSchema};
-    use models::{SchemaId, SeriesId, Timestamp, ValueType};
+    use models::schema::TskvTableSchema;
+    use models::{SchemaId, SeriesId, Timestamp};
     use parking_lot::RwLock;
 
     use super::{FieldVal, MemCache, RowData, RowGroup};
 
-    pub(crate) fn put_rows_to_cache(
+    pub fn put_rows_to_cache(
         cache: &mut MemCache,
         series_id: SeriesId,
         schema_id: SchemaId,
@@ -677,7 +674,7 @@ pub(crate) mod test {
         cache.write_group(series_id, 1, row_group).unwrap();
     }
 
-    pub(crate) fn get_one_series_cache_data(
+    pub fn get_one_series_cache_data(
         cache: Arc<RwLock<MemCache>>,
     ) -> HashMap<String, Vec<(Timestamp, FieldVal)>> {
         let mut fname_vals_map: HashMap<String, Vec<(Timestamp, FieldVal)>> = HashMap::new();
@@ -706,6 +703,19 @@ pub(crate) mod test {
 
         fname_vals_map
     }
+}
+
+#[cfg(test)]
+mod test_memcache {
+    use std::sync::Arc;
+
+    use datafusion::arrow::datatypes::TimeUnit;
+    use memory_pool::{GreedyMemoryPool, MemoryPool};
+    use models::predicate::domain::TimeRange;
+    use models::schema::{ColumnType, TableColumn, TskvTableSchema};
+    use models::{SeriesId, ValueType};
+
+    use super::{FieldVal, MemCache, RowData, RowGroup};
 
     #[test]
     fn test_write_group() {

--- a/tskv/src/record_file/mod.rs
+++ b/tskv/src/record_file/mod.rs
@@ -23,7 +23,7 @@
 //! ### Wal
 //! ```text
 //! +------------+--------------+---------------+--------------+--------------+
-//! | 0: 4 bytes | 4: 4 bytes   | 8: 8 bytes   | 16: 8 bytes  | 24: 8 bytes  |
+//! | 0: 4 bytes | 4: 4 bytes   | 8: 8 bytes   | 16: 8 bytes  | 24: 8 bytes   |
 //! +------------+--------------+---------------+--------------+--------------+
 //! | "walo"     | crc32_number | padding_zeros | min_sequence | max_sequence |
 //! +------------+--------------+---------------+--------------+--------------+
@@ -36,6 +36,8 @@
 mod reader;
 mod record;
 mod writer;
+
+use std::fmt::Display;
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 pub use reader::*;
@@ -83,4 +85,15 @@ pub enum RecordDataType {
     Tombstone = 4,
     Wal = 8,
     IndexLog = 16,
+}
+
+impl Display for RecordDataType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RecordDataType::Summary => write!(f, "summary"),
+            RecordDataType::Tombstone => write!(f, "tombstone"),
+            RecordDataType::Wal => write!(f, "WAL"),
+            RecordDataType::IndexLog => write!(f, "indexlog"),
+        }
+    }
 }

--- a/tskv/src/schema/error.rs
+++ b/tskv/src/schema/error.rs
@@ -23,7 +23,7 @@ pub enum SchemaError {
     },
 
     #[snafu(display("field '{database}.{table}'.'{}' not found", field))]
-    FiledNotFound {
+    FieldNotFound {
         database: String,
         table: String,
         field: String,

--- a/tskv/src/schema/error.rs
+++ b/tskv/src/schema/error.rs
@@ -11,8 +11,9 @@ pub enum SchemaError {
         source: MetaError,
     },
 
-    #[snafu(display("table '{}' not found", table))]
+    #[snafu(display("table '{database}.{table}' not found"))]
     TableNotFound {
+        database: String,
         table: String,
     },
 
@@ -21,8 +22,10 @@ pub enum SchemaError {
         field: String,
     },
 
-    #[snafu(display("field not found '{}'", field))]
-    NotFoundField {
+    #[snafu(display("field '{database}.{table}'.'{}' not found", field))]
+    FiledNotFound {
+        database: String,
+        table: String,
         field: String,
     },
 

--- a/tskv/src/schema/schemas.rs
+++ b/tskv/src/schema/schemas.rs
@@ -68,7 +68,7 @@ impl DBschemas {
                     });
                 }
             } else {
-                return Err(SchemaError::FiledNotFound {
+                return Err(SchemaError::FieldNotFound {
                     database: self.database_name(),
                     table: table_name.to_string(),
                     field: field_name.to_string(),
@@ -85,7 +85,7 @@ impl DBschemas {
                     });
                 }
             } else {
-                return Err(SchemaError::FiledNotFound {
+                return Err(SchemaError::FieldNotFound {
                     database: self.database_name(),
                     table: table_name.to_string(),
                     field: tag_name.to_string(),

--- a/tskv/src/schema/schemas.rs
+++ b/tskv/src/schema/schemas.rs
@@ -68,7 +68,9 @@ impl DBschemas {
                     });
                 }
             } else {
-                return Err(SchemaError::NotFoundField {
+                return Err(SchemaError::FiledNotFound {
+                    database: self.database_name(),
+                    table: table_name.to_string(),
                     field: field_name.to_string(),
                 });
             }
@@ -83,7 +85,9 @@ impl DBschemas {
                     });
                 }
             } else {
-                return Err(SchemaError::NotFoundField {
+                return Err(SchemaError::FiledNotFound {
+                    database: self.database_name(),
+                    table: table_name.to_string(),
                     field: tag_name.to_string(),
                 });
             }

--- a/tskv/src/wal/reader.rs
+++ b/tskv/src/wal/reader.rs
@@ -1,0 +1,430 @@
+use std::path::{Path, PathBuf};
+
+use models::codec::Encoding;
+use models::meta_data::VnodeId;
+use models::schema::Precision;
+use protos::models_helper::print_points;
+
+use super::{
+    WalEntryType, ENTRY_DATABASE_SIZE_LEN, ENTRY_HEADER_LEN, ENTRY_PRECISION_LEN,
+    ENTRY_TENANT_SIZE_LEN, ENTRY_VNODE_ID_LEN, FOOTER_MAGIC_NUMBER,
+};
+use crate::byte_utils::{decode_be_u32, decode_be_u64};
+use crate::file_system::file_manager;
+use crate::tsm::codec::get_str_codec;
+use crate::{record_file, Error, Result};
+
+/// Reads a wal file and parse footer, returns sequence range
+pub async fn read_footer(path: impl AsRef<Path>) -> Result<Option<(u64, u64)>> {
+    if file_manager::try_exists(&path) {
+        let reader = WalReader::open(path).await?;
+        Ok(Some((reader.min_sequence, reader.max_sequence)))
+    } else {
+        Ok(None)
+    }
+}
+
+pub struct WalReader {
+    inner: record_file::Reader,
+    /// Min write sequence in the wal file, may be 0 if wal file is new or
+    /// CnosDB was crushed or force-killed.
+    min_sequence: u64,
+    /// Max write sequence in the wal file, may be 0 if wal file is new or
+    /// CnosDB was crushed or force-killed.
+    max_sequence: u64,
+}
+
+impl WalReader {
+    pub async fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let reader = record_file::Reader::open(&path).await?;
+
+        let (min_sequence, max_sequence) = match reader.footer() {
+            Some(footer) => Self::parse_footer(footer).unwrap_or((0_u64, 0_u64)),
+            None => (0_u64, 0_u64),
+        };
+
+        Ok(Self {
+            inner: reader,
+            min_sequence,
+            max_sequence,
+        })
+    }
+
+    /// Parses wal footer, returns sequence range.
+    pub fn parse_footer(footer: [u8; record_file::FILE_FOOTER_LEN]) -> Option<(u64, u64)> {
+        let magic_number = decode_be_u32(&footer[0..4]);
+        if magic_number != FOOTER_MAGIC_NUMBER {
+            // There is no footer in wal file.
+            return None;
+        }
+        let min_sequence = decode_be_u64(&footer[16..24]);
+        let max_sequence = decode_be_u64(&footer[24..32]);
+        Some((min_sequence, max_sequence))
+    }
+
+    pub async fn next_wal_entry(&mut self) -> Result<Option<WalEntryBlock>> {
+        let data = match self.inner.read_record().await {
+            Ok(r) => r.data,
+            Err(Error::Eof) => {
+                return Ok(None);
+            }
+            Err(e) => {
+                trace::error!("Error reading wal: {:?}", e);
+                return Err(Error::WalTruncated);
+            }
+        };
+        Ok(Some(WalEntryBlock::new(data)))
+    }
+
+    pub fn min_sequence(&self) -> u64 {
+        self.min_sequence
+    }
+
+    pub fn max_sequence(&self) -> u64 {
+        self.max_sequence
+    }
+
+    pub fn path(&self) -> PathBuf {
+        self.inner.path()
+    }
+
+    pub fn len(&self) -> u64 {
+        self.inner.len()
+    }
+
+    /// If this record file has some records in it.
+    pub fn is_empty(&self) -> bool {
+        match self
+            .len()
+            .checked_sub((record_file::FILE_MAGIC_NUMBER_LEN + record_file::FILE_FOOTER_LEN) as u64)
+        {
+            Some(d) => d == 0,
+            None => true,
+        }
+    }
+}
+
+pub struct WalEntryBlock {
+    pub typ: WalEntryType,
+    pub seq: u64,
+    pub entry: WalEntry,
+}
+
+impl WalEntryBlock {
+    pub fn new(buf: Vec<u8>) -> WalEntryBlock {
+        if buf.len() < ENTRY_HEADER_LEN {
+            return Self {
+                typ: WalEntryType::Unknown,
+                seq: 0,
+                entry: WalEntry::Unknown,
+            };
+        }
+        let seq = decode_be_u64(&buf[1..9]);
+        let entry_type: WalEntryType = buf[0].into();
+        let entry: WalEntry = match entry_type {
+            WalEntryType::Write => WalEntry::Write(WriteBlock::new(buf)),
+            WalEntryType::DeleteVnode => WalEntry::DeleteVnode(DeleteVnodeBlock::new(buf)),
+            WalEntryType::DeleteTable => WalEntry::DeleteTable(DeleteTableBlock::new(buf)),
+            WalEntryType::Unknown => WalEntry::Unknown,
+        };
+        Self {
+            typ: entry_type,
+            seq,
+            entry,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum WalEntry {
+    Write(WriteBlock),
+    DeleteVnode(DeleteVnodeBlock),
+    DeleteTable(DeleteTableBlock),
+    Unknown,
+}
+
+/// buf:
+/// - header: ENTRY_HEADER_LEN
+/// - vnode_id: ENTRY_VNODE_ID_LEN
+/// - precision: ENTRY_PRECISION_LEN
+/// - tenant_size: ENTRY_TENANT_SIZE_LEN
+/// - tenant: tenant_size
+/// - data: ..
+#[derive(Debug, Clone, PartialEq)]
+pub struct WriteBlock {
+    buf: Vec<u8>,
+    tenant_size: usize,
+}
+
+impl WriteBlock {
+    pub fn new(buf: Vec<u8>) -> WriteBlock {
+        let tenatn_size_pos = ENTRY_HEADER_LEN + ENTRY_VNODE_ID_LEN + ENTRY_PRECISION_LEN;
+        let tenant_size =
+            decode_be_u64(&buf[tenatn_size_pos..tenatn_size_pos + ENTRY_TENANT_SIZE_LEN]) as usize;
+        Self { buf, tenant_size }
+    }
+
+    pub fn check_buf_size(size: usize) -> bool {
+        size >= ENTRY_HEADER_LEN + ENTRY_VNODE_ID_LEN + ENTRY_PRECISION_LEN + ENTRY_TENANT_SIZE_LEN
+    }
+
+    pub fn vnode_id(&self) -> VnodeId {
+        decode_be_u32(&self.buf[ENTRY_HEADER_LEN..ENTRY_HEADER_LEN + ENTRY_VNODE_ID_LEN])
+    }
+
+    pub fn precision(&self) -> Precision {
+        Precision::from(self.buf[ENTRY_HEADER_LEN + ENTRY_VNODE_ID_LEN])
+    }
+
+    pub fn tenant(&self) -> &[u8] {
+        let tenant_pos =
+            ENTRY_HEADER_LEN + ENTRY_VNODE_ID_LEN + ENTRY_PRECISION_LEN + ENTRY_TENANT_SIZE_LEN;
+        &self.buf[tenant_pos..tenant_pos + self.tenant_size]
+    }
+
+    pub fn points(&self) -> &[u8] {
+        let points_pos = ENTRY_HEADER_LEN
+            + ENTRY_VNODE_ID_LEN
+            + ENTRY_PRECISION_LEN
+            + ENTRY_TENANT_SIZE_LEN
+            + self.tenant_size;
+        &self.buf[points_pos..]
+    }
+}
+
+/// buf:
+/// - header: ENTRY_HEADER_LEN
+/// - vnode_id: ENTRY_VNODE_ID_LEN
+/// - tenant_size: ENTRY_TENANT_SIZE_LEN
+/// - tenant: tenant_size
+/// - database: ..
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeleteVnodeBlock {
+    buf: Vec<u8>,
+    tenant_size: usize,
+}
+
+impl DeleteVnodeBlock {
+    pub fn new(buf: Vec<u8>) -> Self {
+        let tenant_len = decode_be_u64(
+            &buf[ENTRY_HEADER_LEN + ENTRY_VNODE_ID_LEN
+                ..ENTRY_HEADER_LEN + ENTRY_VNODE_ID_LEN + ENTRY_TENANT_SIZE_LEN],
+        ) as usize;
+        Self {
+            buf,
+            tenant_size: tenant_len,
+        }
+    }
+
+    pub fn check_buf_size(size: usize) -> bool {
+        size > ENTRY_HEADER_LEN + ENTRY_VNODE_ID_LEN + ENTRY_TENANT_SIZE_LEN
+    }
+
+    pub fn vnode_id(&self) -> VnodeId {
+        decode_be_u32(&self.buf[ENTRY_HEADER_LEN..ENTRY_HEADER_LEN + ENTRY_VNODE_ID_LEN])
+    }
+
+    pub fn tenant(&self) -> &[u8] {
+        let tenant_pos = ENTRY_HEADER_LEN + ENTRY_VNODE_ID_LEN + ENTRY_TENANT_SIZE_LEN;
+        &self.buf[tenant_pos..tenant_pos + self.tenant_size]
+    }
+
+    pub fn database(&self) -> &[u8] {
+        let database_pos =
+            ENTRY_HEADER_LEN + ENTRY_VNODE_ID_LEN + ENTRY_TENANT_SIZE_LEN + self.tenant_size;
+        &self.buf[database_pos..]
+    }
+}
+
+/// buf:
+/// - header: ENTRY_HEADER_LEN
+/// - tenant_size: ENTRY_TENANT_SIZE_LEN
+/// - database_size: ENTRY_DATABASE_SIZE_LEN
+/// - tenant: tenant_size
+/// - database: database_size
+/// - table: ..
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeleteTableBlock {
+    buf: Vec<u8>,
+    tenant_len: usize,
+    database_len: usize,
+}
+
+impl DeleteTableBlock {
+    pub fn new(buf: Vec<u8>) -> DeleteTableBlock {
+        let tenant_len =
+            decode_be_u64(&buf[ENTRY_HEADER_LEN..ENTRY_HEADER_LEN + ENTRY_TENANT_SIZE_LEN])
+                as usize;
+        let database_len_pos = ENTRY_HEADER_LEN + ENTRY_TENANT_SIZE_LEN;
+        let database_len =
+            decode_be_u32(&buf[database_len_pos..database_len_pos + ENTRY_DATABASE_SIZE_LEN])
+                as usize;
+        Self {
+            buf,
+            tenant_len,
+            database_len,
+        }
+    }
+
+    pub fn check_buf_size(size: usize) -> bool {
+        size >= ENTRY_HEADER_LEN + ENTRY_TENANT_SIZE_LEN + ENTRY_DATABASE_SIZE_LEN
+    }
+
+    pub fn tenant(&self) -> &[u8] {
+        let tenant_pos = ENTRY_HEADER_LEN + ENTRY_TENANT_SIZE_LEN + ENTRY_DATABASE_SIZE_LEN;
+        &self.buf[tenant_pos..tenant_pos + self.tenant_len]
+    }
+
+    pub fn database(&self) -> &[u8] {
+        let database_pos =
+            ENTRY_HEADER_LEN + ENTRY_TENANT_SIZE_LEN + ENTRY_DATABASE_SIZE_LEN + self.tenant_len;
+        &self.buf[database_pos..database_pos + self.database_len]
+    }
+
+    pub fn table(&self) -> &[u8] {
+        let table_pos = ENTRY_HEADER_LEN
+            + ENTRY_TENANT_SIZE_LEN
+            + ENTRY_DATABASE_SIZE_LEN
+            + self.tenant_len
+            + self.database_len;
+        &self.buf[table_pos..]
+    }
+}
+
+pub async fn print_wal_statistics(path: impl AsRef<Path>) {
+    use protos::models as fb_models;
+
+    let mut reader = WalReader::open(path).await.unwrap();
+    let decoder = get_str_codec(Encoding::Zstd);
+    loop {
+        match reader.next_wal_entry().await {
+            Ok(Some(entry_block)) => {
+                println!("============================================================");
+                println!("Seq: {}, Typ: {}", entry_block.seq, entry_block.typ);
+                match entry_block.entry {
+                    WalEntry::Write(blk) => {
+                        println!(
+                            "Tenant: {}, VnodeId: {}, Precision: {}",
+                            std::str::from_utf8(blk.tenant()).unwrap(),
+                            blk.vnode_id(),
+                            blk.precision(),
+                        );
+                        let ety_points = blk.points();
+                        let mut data_buf = Vec::with_capacity(ety_points.len());
+                        decoder.decode(ety_points, &mut data_buf).unwrap();
+                        match flatbuffers::root::<fb_models::Points>(&data_buf[0]) {
+                            Ok(points) => {
+                                print_points(points);
+                            }
+                            Err(e) => panic!("unexpected data: '{:?}'", e),
+                        }
+                    }
+                    WalEntry::DeleteVnode(blk) => {
+                        println!(
+                            "Tenant: {}, Database: {}, VnodeId: {}",
+                            std::str::from_utf8(blk.tenant()).unwrap(),
+                            std::str::from_utf8(blk.database()).unwrap(),
+                            blk.vnode_id(),
+                        );
+                    }
+                    WalEntry::DeleteTable(blk) => {
+                        println!(
+                            "Tenant: {}, VnodeId: {}, Precision: {}",
+                            std::str::from_utf8(blk.tenant()).unwrap(),
+                            std::str::from_utf8(blk.database()).unwrap(),
+                            std::str::from_utf8(blk.table()).unwrap(),
+                        );
+                    }
+                    WalEntry::Unknown => {
+                        println!("Unknown WAL entry type.");
+                    }
+                }
+            }
+            Ok(None) => {
+                println!("============================================================");
+                break;
+            }
+            Err(Error::WalTruncated) => {
+                println!("============================================================");
+                println!("WAL file truncated");
+                break;
+            }
+            Err(e) => {
+                panic!("Failed to read wal file: {:?}", e);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use models::meta_data::VnodeId;
+    use models::schema::Precision;
+
+    use crate::wal::reader::{DeleteTableBlock, DeleteVnodeBlock, WriteBlock};
+    use crate::wal::WalEntryType;
+
+    impl WriteBlock {
+        pub fn build(
+            seq: u64,
+            tenant: &str,
+            vnode_id: VnodeId,
+            precision: Precision,
+            points: Vec<u8>,
+        ) -> Self {
+            let mut buf = Vec::new();
+            buf.push(WalEntryType::Write as u8);
+            buf.extend_from_slice(&seq.to_be_bytes());
+            buf.extend_from_slice(&vnode_id.to_be_bytes());
+            buf.push(precision as u8);
+            buf.extend_from_slice(&(tenant.len() as u64).to_be_bytes());
+            buf.extend_from_slice(tenant.as_bytes());
+            buf.extend_from_slice(&points);
+
+            Self {
+                buf,
+                tenant_size: tenant.len(),
+            }
+        }
+    }
+
+    impl DeleteVnodeBlock {
+        pub fn build(seq: u64, tenant: &str, database: &str, vnode_id: VnodeId) -> Self {
+            let mut buf = Vec::new();
+            let tenant_bytes = tenant.as_bytes();
+            buf.push(WalEntryType::DeleteVnode as u8);
+            buf.extend_from_slice(&seq.to_be_bytes());
+            buf.extend_from_slice(&vnode_id.to_be_bytes());
+            buf.extend_from_slice(&(tenant_bytes.len() as u64).to_be_bytes());
+            buf.extend_from_slice(tenant_bytes);
+            buf.extend_from_slice(database.as_bytes());
+
+            Self {
+                buf,
+                tenant_size: tenant_bytes.len(),
+            }
+        }
+    }
+
+    impl DeleteTableBlock {
+        pub fn build(seq: u64, tenant: &str, database: &str, table: &str) -> Self {
+            let mut buf = Vec::new();
+            let tenant_bytes = tenant.as_bytes();
+            let database_bytes = database.as_bytes();
+            let table_bytes = table.as_bytes();
+            buf.push(WalEntryType::DeleteTable as u8);
+            buf.extend_from_slice(&seq.to_be_bytes());
+            buf.extend_from_slice(&(tenant_bytes.len() as u64).to_be_bytes());
+            buf.extend_from_slice(&(database_bytes.len() as u32).to_be_bytes());
+            buf.extend_from_slice(tenant_bytes);
+            buf.extend_from_slice(database_bytes);
+            buf.extend_from_slice(table_bytes);
+
+            Self {
+                buf,
+                tenant_len: tenant_bytes.len(),
+                database_len: database_bytes.len(),
+            }
+        }
+    }
+}

--- a/tskv/src/wal/writer.rs
+++ b/tskv/src/wal/writer.rs
@@ -1,0 +1,301 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use models::meta_data::VnodeId;
+use models::schema::Precision;
+
+use super::reader::WalReader;
+use super::{WalEntryType, FOOTER_MAGIC_NUMBER};
+use crate::file_system::file_manager;
+use crate::kv_option::WalOptions;
+use crate::record_file::{RecordDataType, RecordDataVersion};
+use crate::{record_file, Result};
+
+fn build_footer(min_sequence: u64, max_sequence: u64) -> [u8; record_file::FILE_FOOTER_LEN] {
+    let mut footer = [0_u8; record_file::FILE_FOOTER_LEN];
+    footer[0..4].copy_from_slice(&FOOTER_MAGIC_NUMBER.to_be_bytes());
+    footer[16..24].copy_from_slice(&min_sequence.to_be_bytes());
+    footer[24..32].copy_from_slice(&max_sequence.to_be_bytes());
+    footer
+}
+
+pub struct WalWriter {
+    id: u64,
+    inner: record_file::Writer,
+    size: u64,
+    path: PathBuf,
+    config: Arc<WalOptions>,
+
+    buf: Vec<u8>,
+    min_sequence: u64,
+    max_sequence: u64,
+}
+
+impl WalWriter {
+    /// Opens a wal file at path, returns a WalWriter with id and config.
+    /// If wal file doesn't exist, create new wal file and set it's min_log_sequence(default 0).
+    pub async fn open(
+        config: Arc<WalOptions>,
+        id: u64,
+        path: impl AsRef<Path>,
+        min_seq: u64,
+    ) -> Result<Self> {
+        let path = path.as_ref();
+
+        // Use min_sequence existing in file, otherwise in parameter
+        let (writer, min_sequence, max_sequence) = if file_manager::try_exists(path) {
+            let writer = record_file::Writer::open(path, RecordDataType::Wal).await?;
+            let (min_sequence, max_sequence) = match writer.footer() {
+                Some(footer) => WalReader::parse_footer(footer).unwrap_or((min_seq, min_seq)),
+                None => (min_seq, min_seq),
+            };
+            (writer, min_sequence, max_sequence)
+        } else {
+            (
+                record_file::Writer::open(path, RecordDataType::Wal).await?,
+                min_seq,
+                min_seq,
+            )
+        };
+
+        let size = writer.file_size();
+
+        Ok(Self {
+            id,
+            inner: writer,
+            size,
+            path: PathBuf::from(path),
+            config,
+            buf: Vec::new(),
+            min_sequence,
+            max_sequence,
+        })
+    }
+
+    /// Writes data, returns data sequence and data size.
+    pub async fn write(
+        &mut self,
+        tenant: String,
+        vnode_id: VnodeId,
+        precision: Precision,
+        points: Vec<u8>,
+    ) -> Result<(u64, usize)> {
+        let seq = self.max_sequence;
+        let tenant_len = tenant.len() as u64;
+
+        let written_size = self
+            .inner
+            .write_record(
+                RecordDataVersion::V1 as u8,
+                RecordDataType::Wal as u8,
+                [
+                    &[WalEntryType::Write as u8][..],
+                    &seq.to_be_bytes(),
+                    &vnode_id.to_be_bytes(),
+                    &(precision as u8).to_be_bytes(),
+                    &tenant_len.to_be_bytes(),
+                    tenant.as_bytes(),
+                    &points,
+                ]
+                .as_slice(),
+            )
+            .await?;
+
+        if self.config.sync {
+            self.inner.sync().await?;
+        }
+        // write & fsync succeed
+        self.max_sequence += 1;
+        self.size += written_size as u64;
+        Ok((seq, written_size))
+    }
+
+    pub async fn delete_vnode(
+        &mut self,
+        tenant: String,
+        database: String,
+        vnode_id: VnodeId,
+    ) -> Result<(u64, usize)> {
+        let seq = self.max_sequence;
+        let tenant_len = tenant.len() as u64;
+
+        let written_size = self
+            .inner
+            .write_record(
+                RecordDataVersion::V1 as u8,
+                RecordDataType::Wal as u8,
+                [
+                    &[WalEntryType::DeleteVnode as u8][..],
+                    &seq.to_be_bytes(),
+                    &vnode_id.to_be_bytes(),
+                    &tenant_len.to_be_bytes(),
+                    tenant.as_bytes(),
+                    database.as_bytes(),
+                ]
+                .as_slice(),
+            )
+            .await?;
+
+        if self.config.sync {
+            self.inner.sync().await?;
+        }
+        // write & fsync succeed
+        self.max_sequence += 1;
+        self.size += written_size as u64;
+        Ok((seq, written_size))
+    }
+
+    pub async fn delete_table(
+        &mut self,
+        tenant: String,
+        database: String,
+        table: String,
+    ) -> Result<(u64, usize)> {
+        let seq = self.max_sequence;
+        let tenant_len = tenant.len() as u64;
+        let database_len = database.len() as u32;
+
+        let written_size = self
+            .inner
+            .write_record(
+                RecordDataVersion::V1 as u8,
+                RecordDataType::Wal as u8,
+                [
+                    &[WalEntryType::DeleteTable as u8][..],
+                    &seq.to_be_bytes(),
+                    &tenant_len.to_be_bytes(),
+                    &database_len.to_be_bytes(),
+                    tenant.as_bytes(),
+                    database.as_bytes(),
+                    table.as_bytes(),
+                ]
+                .as_slice(),
+            )
+            .await?;
+
+        if self.config.sync {
+            self.inner.sync().await?;
+        }
+        // write & fsync succeed
+        self.max_sequence += 1;
+        self.size += written_size as u64;
+        Ok((seq, written_size))
+    }
+
+    pub async fn sync(&self) -> Result<()> {
+        self.inner.sync().await
+    }
+
+    pub async fn close(mut self) -> Result<usize> {
+        trace::info!(
+            "Closing wal with sequence: [{}, {})",
+            self.min_sequence,
+            self.max_sequence
+        );
+        let footer = build_footer(self.min_sequence, self.max_sequence);
+        let size = self.inner.write_footer(footer).await?;
+        self.inner.close().await?;
+        Ok(size)
+    }
+
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    pub fn min_sequence(&self) -> u64 {
+        self.min_sequence
+    }
+
+    pub fn max_sequence(&self) -> u64 {
+        self.max_sequence
+    }
+
+    pub fn set_max_sequence(&mut self, new_max_sequence: u64) {
+        self.max_sequence = new_max_sequence
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use models::schema::Precision;
+
+    use crate::kv_option::WalOptions;
+    use crate::wal::reader::{DeleteTableBlock, DeleteVnodeBlock, WalEntry, WalReader, WriteBlock};
+    use crate::wal::writer::WalWriter;
+    use crate::Error;
+
+    #[tokio::test]
+    async fn test_write() {
+        let dir = "/tmp/test/wal_writer/1";
+        let _ = std::fs::remove_dir_all(dir);
+
+        let mut global_config = config::get_config_for_test();
+        global_config.wal.path = dir.to_string();
+        let wal_config = Arc::new(WalOptions::from(&global_config));
+
+        #[rustfmt::skip]
+        let entries = vec![
+            WalEntry::Write(WriteBlock::build(
+                1,  "cnosdb", 3, Precision::NS, vec![1, 2, 3],
+            )),
+            WalEntry::DeleteVnode(DeleteVnodeBlock::build(2, "cnosdb", "public", 6)),
+            WalEntry::DeleteTable(DeleteTableBlock::build(3, "cnosdb", "public", "table")),
+        ];
+
+        let wal_path = PathBuf::from(dir).join("1.wal");
+        let wal_path = {
+            let mut writer = WalWriter::open(wal_config, 1, wal_path, 1).await.unwrap();
+            for ent in entries.iter() {
+                match ent {
+                    WalEntry::Write(d) => {
+                        let tenant = String::from_utf8(d.tenant().to_vec()).unwrap();
+                        writer
+                            .write(tenant, d.vnode_id(), d.precision(), d.points().to_vec())
+                            .await
+                            .unwrap();
+                    }
+                    WalEntry::DeleteVnode(d) => {
+                        let tenant = String::from_utf8(d.tenant().to_vec()).unwrap();
+                        let database = String::from_utf8(d.database().to_vec()).unwrap();
+                        writer
+                            .delete_vnode(tenant, database, d.vnode_id())
+                            .await
+                            .unwrap();
+                    }
+                    WalEntry::DeleteTable(d) => {
+                        let tenant = String::from_utf8(d.tenant().to_vec()).unwrap();
+                        let database = String::from_utf8(d.database().to_vec()).unwrap();
+                        let table = String::from_utf8(d.table().to_vec()).unwrap();
+                        writer.delete_table(tenant, database, table).await.unwrap();
+                    }
+                    WalEntry::Unknown => {
+                        // ignore
+                    }
+                }
+            }
+            writer.path
+        };
+
+        let mut reader = WalReader::open(&wal_path).await.unwrap();
+        let mut i = 0;
+        loop {
+            match reader.next_wal_entry().await {
+                Ok(Some(blk)) => {
+                    assert_eq!(blk.entry, entries[i]);
+                }
+                Ok(None) | Err(Error::WalTruncated) => break,
+                Err(e) => {
+                    panic!("Failed reading from wal {}: {e}", wal_path.display());
+                }
+            }
+            i += 1;
+        }
+    }
+}

--- a/tskv/tests/test_kvcore_interface.rs
+++ b/tskv/tests/test_kvcore_interface.rs
@@ -176,12 +176,10 @@ mod tests {
         init_default_global_tracing("tskv_log", "tskv.log", "debug");
         let (rt, tskv) = get_tskv("/tmp/test/kvcore/kvcore_flush_delta", None);
         let mut fbb = flatbuffers::FlatBufferBuilder::new();
-        let points = models_helper::create_random_points_include_delta(
-            &mut fbb,
-            "db",
-            "kvcore_flush_delta",
-            20,
-        );
+        let database = "db_flush_delta";
+        let table = "kvcore_flush_delta";
+        let points =
+            models_helper::create_random_points_include_delta(&mut fbb, database, table, 20);
         fbb.finish(points, None);
         let points = fbb.finished_data().to_vec();
         let request = kv_service::WritePointsRequest {
@@ -219,12 +217,12 @@ mod tests {
             tokio::time::sleep(Duration::from_secs(3)).await;
         });
 
-        assert!(file_manager::try_exists(
-            "/tmp/test/kvcore/kvcore_flush_delta/data/cnosdb.db/0/tsm"
-        ));
-        assert!(file_manager::try_exists(
-            "/tmp/test/kvcore/kvcore_flush_delta/data/cnosdb.db/0/delta"
-        ));
+        assert!(file_manager::try_exists(format!(
+            "/tmp/test/kvcore/kvcore_flush_delta/data/cnosdb.{database}/0/tsm"
+        )));
+        assert!(file_manager::try_exists(format!(
+            "/tmp/test/kvcore/kvcore_flush_delta/data/cnosdb.{database}/0/delta"
+        )));
     }
 
     #[tokio::test]
@@ -245,7 +243,7 @@ mod tests {
         let mut fbb = flatbuffers::FlatBufferBuilder::new();
         let points = models_helper::create_random_points_include_delta(
             &mut fbb,
-            "db",
+            "db_build_row_data",
             "kvcore_build_row_data",
             20,
         );
@@ -276,7 +274,7 @@ mod tests {
 
         init_default_global_tracing(dir.join("log"), "tskv.log", "debug");
         let tenant = "cnosdb";
-        let database = "db";
+        let database = "db_recover";
         let table = "kvcore_recover";
         let vnode_id = 10;
 

--- a/tskv/tests/test_kvcore_interface.rs
+++ b/tskv/tests/test_kvcore_interface.rs
@@ -308,7 +308,7 @@ mod tests {
             .unwrap()
             .unwrap();
         let cached_data = tskv::test::get_one_series_cache_data(version.caches.mut_cache.clone());
-        // TODO: compare cached_data and the wrote_dataa
+        // TODO: compare cached_data and the wrote_data
         assert!(!cached_data.is_empty());
     }
 


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

Related #1178, but has some differences.

# Rationale for this change

## WAL changes

- Simplify WAL write api in `kvcore.rs`
- Store `drop_table` and `remove_tsfamily` in WAL files.
  - Recovering tskv from WAL `write` will not create database schemas, and if database&table&tsfamily of a WAL record does not exist in tskv, this WAL record will be ignored.
  - Recovering tskv from WAL `drop_table` or `remove_tsfamily` will not do anything, because WAL `write` that schema not existed in tskv was ignored.

Here is the newest schema of the record data in WAL file:

```
# type = Write
+------------+------------+------------+------------+--------------+-----------------+-----------+
| 0: 1 byte  | 1: 8 bytes | 9: 4 bytes | 13: 1 byte | 14: 8 bytes  | 22: tenant_size |  n bytes  |
+------------+------------+------------+------------+--------------+-----------------+-----------+
|    type    |  sequence  |  vnode_id  |  precision | tenant_size  |  tenant         |   data    |
+------------+------------+------------+------------+--------------+-----------------+-----------+

# type = DeleteVnode
+------------+------------+------------+-------------+-------------+----------+
| 0: 1 byte  | 1: 8 bytes | 9: 4 bytes | 13: 8 bytes | 21: n bytes | n bytes  |
+------------+------------+------------+-------------+-------------+----------+
|    type    |  sequence  |  vnode_id  | tenant_size |  tenant     | database |
+------------+------------+------------+-------------+-------------+----------+

# type = DeleteTable
+------------+------------+-------------+---------------+-----------------+---------------+---------+
| 0: 1 byte  | 1: 8 bytes | 9: 8 bytes  | 17: 4 bytes   | 21: tenant_size | database_size | n bytes |
+------------+------------+-------------+---------------+-----------------+---------------+---------+
|    type    |  sequence  | tenant_size | database_size |  tenant         |  database     | table   |
+------------+------------+-------------+---------------+-----------------+---------------+---------+
```

## Other improves

- Fix unit tests in `test_kvcore_interface.rs` sometime report unexpected error: `update table conflict`.
- Fix some errors that holds some strings instanced too earily, for those errors that stores data in heap:
  - Use `Option::ok_or_else()` instead of `Option::ok_or()`
  - Use `Result::with_context()` insead of `Result::context()`
  - Some others.

# Are there any user-facing changes?

 

