### PR TITLE
refactor(tskv): record_file & codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5805,7 +5805,6 @@ name = "tskv"
 version = "2.3.2"
 dependencies = [
  "async-backtrace",
- "async-recursion",
  "async-trait",
  "bincode",
  "blake3",

--- a/tskv/Cargo.toml
+++ b/tskv/Cargo.toml
@@ -17,7 +17,6 @@ utils = { path = "../common/utils" }
 http_protocol = { path = "../common/http_protocol" }
 
 async-backtrace = { workspace = true, optional = true }
-async-recursion = { workspace = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }
 blake3 = { workspace = true }

--- a/tskv/src/error.rs
+++ b/tskv/src/error.rs
@@ -9,6 +9,7 @@ use snafu::Snafu;
 use tonic::{Code, Status};
 
 use crate::index::IndexError;
+use crate::record_file;
 use crate::schema::error::SchemaError;
 use crate::tsm::{ReadTsmError, WriteTsmError};
 
@@ -161,6 +162,25 @@ pub enum Error {
     #[snafu(display("Faield to decode record file block: {}", source))]
     RecordFileDecode {
         source: bincode::Error,
+    },
+
+    /// This error is handled by the caller of record_file::Reader::read_record()
+    #[snafu(display("Record data at [{pos}..{}] is invalid", pos + *len as u64))]
+    RecordFileInvalidDataSize {
+        pos: u64,
+        len: u32,
+    },
+
+    /// This error is handled by the caller of record_file::Reader::read_record()
+    #[snafu(display(
+        "Record CRC not match at [{}..{}], expected: {crc}, calculated: {crc_calculated}",
+        record.pos,
+        record.pos + record.data.len() as u64 + record_file::RECORD_HEADER_LEN as u64,
+    ))]
+    RecordFileHashCheckFailed {
+        crc: u32,
+        crc_calculated: u32,
+        record: record_file::Record,
     },
 
     #[snafu(display("Failed to do encode: {}", source))]

--- a/tskv/src/record_file/reader.rs
+++ b/tskv/src/record_file/reader.rs
@@ -1,9 +1,6 @@
 use std::cmp::Ordering;
 use std::path::{Path, PathBuf};
 
-use async_recursion::async_recursion;
-use num_traits::ToPrimitive;
-
 use super::{
     file_crc_source_len, Record, FILE_FOOTER_CRC32_NUMBER_LEN, FILE_FOOTER_LEN,
     FILE_FOOTER_MAGIC_NUMBER_LEN, FILE_MAGIC_NUMBER_LEN, READER_BUF_SIZE, RECORD_CRC32_NUMBER_LEN,
@@ -36,7 +33,7 @@ impl Reader {
             Err(Error::NoFooter) => (file.len(), None),
             Err(e) => {
                 trace::error!(
-                    "Failed to read footer of record_file '{}': {e}",
+                    "Record file: Failed to read footer in '{}': {e}",
                     path.display(),
                 );
                 return Err(e);
@@ -61,6 +58,7 @@ impl Reader {
         })
     }
 
+    /// Set self.pos, load buffer if needed.
     async fn set_pos(&mut self, pos: usize) -> Result<()> {
         if self.pos - self.buf_use == pos {
             self.pos = pos;
@@ -68,9 +66,7 @@ impl Reader {
             return Ok(());
         }
         if pos as u64 > self.file.len() {
-            return Err(Error::InvalidParam {
-                reason: format!("pos ({}) is too large (> {})", pos, self.file.len()),
-            });
+            return Err(Error::Eof);
         }
 
         match self.pos.cmp(&pos) {
@@ -100,27 +96,33 @@ impl Reader {
         }
     }
 
+    /// Returns a position where to read the header and the header slice.
     async fn find_record_header(&mut self) -> Result<(usize, &[u8])> {
         loop {
-            let origin_pos = self.pos;
-            let (_, magic_number_sli) = self.read_buf(RECORD_MAGIC_NUMBER_LEN).await?;
+            let magic_number_sli = self.read_buf(RECORD_MAGIC_NUMBER_LEN).await?;
             let magic_number = decode_be_u32(magic_number_sli);
             if magic_number == RECORD_MAGIC_NUMBER {
-                self.set_pos(origin_pos).await?;
-                return self.read_buf(RECORD_HEADER_LEN).await;
+                let pos = self.pos;
+                let header = self.read_buf(RECORD_HEADER_LEN).await?;
+                return Ok((pos, header));
             } else {
-                self.set_pos(origin_pos + 1).await?;
+                self.set_pos(self.pos + 1).await?;
             }
         }
     }
 
-    /// Returns Ok(record), it means EOF when returns Err.
-    #[async_recursion]
+    /// Read the next record, return Ok(record) if succeeded.
+    /// There are three special error type:
+    /// - Eof - file reads to a end.
+    /// - RecordFileInvalidDataSize - file is broken that data size is too big.
+    /// - RecordFileHashCheckFailed - file may be broken that data crc not match.
     pub async fn read_record(&mut self) -> Result<Record> {
-        if self.pos as u64 >= self.footer_pos {
+        // The previous position, if the previous error is not the HashCheckFailed,
+        // this value will be updated.
+        if (self.pos + RECORD_HEADER_LEN) as u64 >= self.footer_pos {
             return Err(Error::Eof);
         }
-        let (origin_pos, header) = self.find_record_header().await?;
+        let (header_pos, header) = self.find_record_header().await?;
 
         let mut p = RECORD_MAGIC_NUMBER_LEN;
         let data_version = header[p];
@@ -138,31 +140,62 @@ impl Reader {
             .update(&header[RECORD_MAGIC_NUMBER_LEN..RECORD_HEADER_LEN - RECORD_CRC32_NUMBER_LEN]);
 
         // TODO: Check if data_size is too large.
+        let data_pos = header_pos + RECORD_HEADER_LEN;
+        self.set_pos(data_pos).await?;
         let data = match self.read_buf(data_size as usize).await {
-            Ok((_, d)) => d.to_vec(),
+            Ok(record_bytes) => {
+                let record_data = record_bytes.to_vec();
+                if record_bytes.len() < data_size as usize {
+                    trace::error!(
+                        "Record file: Failed to read data: Data size ({}) at pos {} is greater than bytes readed ({})",
+                        data_size, data_pos, record_bytes.len()
+                    );
+                    return Err(Error::RecordFileInvalidDataSize {
+                        pos: header_pos as u64,
+                        len: data_size,
+                    });
+                }
+                self.set_pos(data_pos + data_size as usize).await?;
+                record_data
+            }
             Err(e) => {
                 trace::error!(
-                    "Failed to read record data at {origin_pos} for {data_size} bytes: {e}",
+                    "Record file: Failed to read data at {header_pos} for {} bytes: {e}",
+                    data_size + RECORD_HEADER_LEN as u32
                 );
-                self.set_pos(origin_pos + 1).await?;
-                return self.read_record().await;
+                self.set_pos(header_pos + 1).await?;
+                return Err(e);
             }
         };
 
         // Hash record data
         hasher.update(&data);
         // check crc32 number
-        if hasher.finalize() != data_crc {
-            trace::error!("Data crc check failed at {origin_pos} for {data_size} bytes",);
-            self.set_pos(origin_pos + 1).await?;
-            return self.read_record().await;
+        let data_crc_calculated = hasher.finalize();
+        if data_crc_calculated != data_crc {
+            // If crc not match, try to get header from the next pos.
+            trace::error!(
+                "Record file: Failed to read data: Data crc check failed at {header_pos} for {} bytes",
+                data_size + RECORD_HEADER_LEN as u32
+            );
+            self.set_pos(header_pos + 1).await?;
+            return Err(Error::RecordFileHashCheckFailed {
+                crc: data_crc,
+                crc_calculated: data_crc_calculated,
+                record: Record {
+                    data_type,
+                    data_version,
+                    data,
+                    pos: header_pos as u64,
+                },
+            });
         }
 
         Ok(Record {
-            pos: origin_pos.to_u64().unwrap(),
             data_type,
             data_version,
             data,
+            pos: header_pos as u64,
         })
     }
 
@@ -213,13 +246,10 @@ impl Reader {
         self.footer
     }
 
+    /// Load buf from self.pos, reset self.buf_len and self.buf_use.
     async fn load_buf(&mut self) -> Result<()> {
-        if (self.pos + self.buf_len) as u64 > self.footer_pos {
-            self.buf
-                .truncate((self.footer_pos - self.pos as u64) as usize);
-        }
         trace::trace!(
-            "Trying load buf at {} for {} bytes",
+            "Record file: Trying load buf at {} for {} bytes",
             self.pos,
             self.buf.len()
         );
@@ -235,22 +265,12 @@ impl Reader {
         Ok(())
     }
 
-    /// Returns a position where to read a slice and that slice.
-    async fn read_buf(&mut self, size: usize) -> Result<(usize, &[u8])> {
+    async fn read_buf(&mut self, size: usize) -> Result<&[u8]> {
         if self.buf_len - self.buf_use < size {
             self.load_buf().await?;
-            // TODO: If size may be greater than READER_BUF_SIZE,
-            // this would be a wrong logic.
-            if self.buf_len - self.buf_use < size {
-                return Err(Error::Eof);
-            }
         }
-
-        let origin_pos = self.pos;
-        let buf_sli = &self.buf[self.buf_use..self.buf_use + size];
-        self.pos += size;
-        self.buf_use += size;
-        Ok((origin_pos, buf_sli))
+        let right_bound = (self.buf_use + size).min(self.buf_len);
+        Ok(&self.buf[self.buf_use..right_bound])
     }
 
     pub fn path(&self) -> PathBuf {
@@ -260,102 +280,281 @@ impl Reader {
     pub fn len(&self) -> u64 {
         self.file.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.file.is_empty()
+    }
+
+    pub fn pos(&self) -> usize {
+        self.pos
+    }
 }
 
 #[cfg(test)]
 pub(crate) mod test {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use super::Reader;
-    use crate::byte_utils::decode_be_u32;
-    use crate::error::{Error, Result};
-    use crate::file_system::file::IFile;
+    use crate::byte_utils;
+    use crate::error::Error;
+    use crate::record_file::writer::test::record_length;
     use crate::record_file::{
-        Record, RECORD_CRC32_NUMBER_LEN, RECORD_DATA_SIZE_LEN, RECORD_DATA_TYPE_LEN,
+        RecordDataType, Writer, FILE_FOOTER_LEN, FILE_MAGIC_NUMBER, FILE_MAGIC_NUMBER_LEN,
+        RECORD_CRC32_NUMBER_LEN, RECORD_DATA_SIZE_LEN, RECORD_DATA_TYPE_LEN,
         RECORD_DATA_VERSION_LEN, RECORD_HEADER_LEN, RECORD_MAGIC_NUMBER, RECORD_MAGIC_NUMBER_LEN,
     };
 
-    impl Reader {
-        pub(crate) async fn read_at(&mut self, pos: usize) -> Result<Record> {
-            let mut record_header_buf = [0_u8; RECORD_HEADER_LEN];
-            let len = match self.file.read_at(pos as u64, &mut record_header_buf).await {
-                Ok(len) => len,
-                Err(e) => {
-                    return Err(Error::ReadFile {
-                        path: self.path.clone(),
-                        source: e,
-                    })
-                }
+    /// Read a record_file and see if records in file are the same as given records.
+    pub async fn assert_record_file_data_eq<L, R, D>(
+        path: impl AsRef<Path>,
+        records: L,
+        has_footer: bool,
+    ) where
+        D: AsRef<[u8]>,
+        R: AsRef<[D]>,
+        L: AsRef<[R]>,
+    {
+        let records = records.as_ref();
+
+        let file_content = std::fs::read(&path).unwrap();
+        assert_eq!(
+            &file_content[..FILE_MAGIC_NUMBER_LEN],
+            &FILE_MAGIC_NUMBER.to_be_bytes()
+        );
+
+        let max_pos = if has_footer {
+            if file_content.len() < FILE_FOOTER_LEN {
+                panic!(
+                    "Record file size ({})is less than {FILE_FOOTER_LEN}",
+                    file_content.len()
+                );
+            }
+            file_content.len() - FILE_FOOTER_LEN
+        } else {
+            file_content.len()
+        };
+        let mut pos = FILE_MAGIC_NUMBER_LEN;
+        let mut i = 0_usize;
+        while pos < max_pos {
+            if pos + RECORD_HEADER_LEN >= max_pos {
+                break;
+            }
+            let record_to_check = match records.get(i) {
+                Some(d) => d.as_ref(),
+                None => break,
             };
-            if len != RECORD_HEADER_LEN {
-                return Err(Error::RecordFileIo {
-                    reason: format!("invalid record header (pos is {})", pos),
-                });
-            }
+            i += 1;
 
-            let mut p = 0_usize;
-            let magic_number = decode_be_u32(&record_header_buf[p..p + RECORD_MAGIC_NUMBER_LEN]);
-            if magic_number != RECORD_MAGIC_NUMBER {
-                return Err(Error::RecordFileIo {
-                    reason: format!("invalid magic number (pos is {})", pos),
-                });
-            }
-            p += RECORD_MAGIC_NUMBER_LEN;
-            let data_version = record_header_buf[p];
-            p += RECORD_DATA_VERSION_LEN;
-            let data_type = record_header_buf[p];
-            p += RECORD_DATA_TYPE_LEN;
-            let data_size = decode_be_u32(&record_header_buf[p..p + RECORD_DATA_SIZE_LEN]);
-            p += RECORD_DATA_SIZE_LEN;
-            let _data_crc = decode_be_u32(&record_header_buf[p..p + RECORD_CRC32_NUMBER_LEN]);
-            p += RECORD_CRC32_NUMBER_LEN;
+            // Skip magic number.
+            pos += RECORD_MAGIC_NUMBER_LEN;
 
-            // TODO: Reuse data vector.
-            // TODO: Check if data_size is too large.
-            let mut data = vec![0_u8; data_size as usize];
-            let read_data_len = match self.file.read_at((pos + p) as u64, &mut data).await {
-                Ok(len) => len,
-                Err(e) => {
-                    return Err(Error::ReadFile {
-                        path: self.path.clone(),
-                        source: e,
-                    });
-                }
-            };
-            if read_data_len != data_size as usize {
-                return Err(Error::RecordFileIo {
-                    reason: format!(
-                        "data truncated to {} (pos is {}, len is {})",
-                        read_data_len, pos, data_size
-                    ),
-                });
-            }
+            let mut hasher = crc32fast::Hasher::new();
+            hasher.update(&file_content[pos..pos + RECORD_DATA_VERSION_LEN + RECORD_DATA_TYPE_LEN]);
+            pos += RECORD_DATA_VERSION_LEN + RECORD_DATA_TYPE_LEN;
 
-            Ok(Record {
-                pos: pos as u64,
-                data_type,
-                data_version,
-                data,
-            })
+            // Check data size.
+            let data_size_sli = &file_content[pos..pos + RECORD_DATA_SIZE_LEN];
+            hasher.update(data_size_sli);
+            let data_size = byte_utils::decode_be_u32(data_size_sli) as usize;
+            assert_eq!(
+                data_size,
+                record_to_check
+                    .iter()
+                    .map(|d| d.as_ref().len())
+                    .sum::<usize>(),
+                "unexpected data_size at pos {pos}"
+            );
+            pos += RECORD_DATA_SIZE_LEN;
+
+            // Check crc.
+            let crc_record_file =
+                byte_utils::decode_be_u32(&file_content[pos..pos + RECORD_CRC32_NUMBER_LEN]);
+            for d in record_to_check {
+                hasher.update(d.as_ref());
+            }
+            let crc_to_check = hasher.finalize();
+            assert_eq!(crc_record_file, crc_to_check, "unexpected crc at pos {pos}");
+            pos += RECORD_CRC32_NUMBER_LEN;
+
+            // Skip data in file.
+            pos += data_size;
+        }
+        if i < records.len() {
+            panic!(
+                "Given record data is more than that in record file: index({i}) < max_index({})",
+                records.len()
+            );
+        }
+        if pos < max_pos {
+            panic!("Given record data is less than that in record file: pos({pos}) < max_pos({max_pos})");
         }
     }
 
-    pub(crate) async fn test_reader_read_one(path: impl AsRef<Path>, pos: usize, data: &[u8]) {
-        let mut r = Reader::open(path).await.unwrap();
-        let record = r.read_at(pos).await.unwrap();
-        assert_eq!(record.data, data);
+    /// Call reader.set_pos(pos) and then do check.
+    async fn set_pos_and_check(reader: &mut Reader, pos: usize) {
+        reader.set_pos(pos).await.unwrap();
+        assert_eq!(reader.pos, pos, "unexpected pos after set_pos({pos}");
     }
 
-    pub(crate) async fn test_reader(path: impl AsRef<Path>, data: &[Vec<u8>]) {
-        let mut r = Reader::open(path).await.unwrap();
+    /// Call reader.set_pos(from_pos) by check_set_pos() if from_pos is set,
+    /// then call reader.find_record_header() and then do check.
+    ///
+    /// - If from_pos is none, then do not call reader.set_pos().
+    /// - If assumed_header_pos is nont, then reader.find_record_header need return Error::Eof.
+    async fn find_record_header_and_check(
+        reader: &mut Reader,
+        from_pos: Option<usize>,
+        assumed_header_pos: Option<usize>,
+    ) {
+        let str_set_pos_and: String = if let Some(pos) = from_pos {
+            set_pos_and_check(reader, pos).await;
+            format!("set_pos({pos}) and")
+        } else {
+            String::new()
+        };
 
-        for d in data {
-            let record = match r.read_record().await {
-                Ok(r) => r,
-                Err(Error::Eof) => break,
-                Err(e) => panic!("Error reading record: {:?}", e),
-            };
-            assert_eq!(record.data, *d);
+        let ret = reader.find_record_header().await;
+        if let Some(assumed_header_pos) = assumed_header_pos {
+            let (found_header_pos, found_header) = ret.unwrap();
+            assert_eq!(
+                found_header_pos, assumed_header_pos,
+                "unexpected found header pos"
+            );
+            assert_eq!(
+                &found_header[..4],
+                &RECORD_MAGIC_NUMBER.to_be_bytes(),
+                "unexpected found header after {str_set_pos_and} find_record_header()"
+            );
+            // drop(found_header);
+            assert_eq!(
+                reader.pos, found_header_pos,
+                "unexpected pos after {str_set_pos_and} find_record_header()",
+            );
+        } else {
+            // EOF expected, `Error` is not able to Eq, so use match.
+            match ret {
+                Err(Error::Eof) => {}
+                Err(e) => panic!("Unexpected error: {e}, Error::EOF was expected."),
+                Ok((header_pos, _)) => {
+                    panic!("Unexpected Ok((header_pos, header)) at {header_pos}, Error::EOF was expected.",)
+                }
+            }
         }
+    }
+
+    #[tokio::test]
+    async fn test_record_reader_open_and_read() {
+        let dir = PathBuf::from("/tmp/test/record_file/reader/1");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        {
+            // Test open a file not exist.
+            let ret = Reader::open(dir.join("no.record")).await;
+            assert!(ret.is_err());
+        }
+        {
+            let path = dir.join("1.log");
+            let data = b"hello world";
+            let data_version = 1_u8;
+            let data_type = 1_u8;
+            let mut footer = [0_u8; FILE_FOOTER_LEN];
+            {
+                let mut writer = Writer::open(&path, RecordDataType::Summary).await.unwrap();
+                let data_size = writer
+                    .write_record(data_version, data_type, &[data])
+                    .await
+                    .unwrap();
+                assert_eq!(data_size, record_length(11));
+                writer.write_footer(&mut footer).await.unwrap();
+                assert_record_file_data_eq(&path, [[data]], true).await;
+            }
+            // Test open file.
+            let mut reader = Reader::open(&path).await.unwrap();
+            assert_eq!(reader.pos, 4);
+            assert_eq!(
+                reader.buf.len() as u64,
+                reader.len() - FILE_MAGIC_NUMBER_LEN as u64 - FILE_FOOTER_LEN as u64
+            );
+            assert_eq!(reader.buf_len, 0);
+            assert_eq!(reader.buf_use, 0);
+            assert_eq!(reader.footer, Some(footer));
+            assert_eq!(reader.footer_pos, reader.len() - FILE_FOOTER_LEN as u64);
+            // Test read record.
+            let record = reader.read_record().await.unwrap();
+            assert_eq!(record.pos, 4);
+            assert_eq!(record.data_version, data_version);
+            assert_eq!(record.data_type, data_type);
+            assert_eq!(&record.data, data);
+            // Test read twice, EOF expected, `Error` is not able to Eq, so use match.
+            match reader.read_record().await {
+                Err(Error::Eof) => {}
+                Err(e) => panic!("Unexpected error: {e}, Error::EOF was expected."),
+                Ok(r) => panic!(
+                    "Unexpected Ok(record) at pos {}, Error::EOF was expected.",
+                    r.pos
+                ),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_record_file_find_record_header() {
+        let dir = PathBuf::from("/tmp/test/record_file/reader/2");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = dir.join("1.log");
+        {
+            // Write record file, 1804 bytes:
+            // - header(0-4): RECO(4)
+            // - record(4-1804):
+            //   14 bytes header: FlOg(4), version(1), type(1), size(4), crc(4)
+            //   4 bytes data: 0000 - 0099
+            let mut writer = Writer::open(&path, RecordDataType::Summary).await.unwrap();
+            for i in 0..100 {
+                let data = format!("{i:04}");
+                writer.write_record(1, 1, &[data]).await.unwrap();
+            }
+            writer.close().await.unwrap();
+        }
+        let mut reader = Reader::open(&path).await.unwrap();
+        // For this test case, make buf_len smaller
+        const BUF_LEN: usize = 64;
+        reader.buf = vec![0_u8; BUF_LEN];
+
+        // Test load buffer from pos 4.
+        assert_eq!(reader.pos, 4);
+        reader.load_buf().await.unwrap();
+        assert_eq!(reader.pos, 4);
+        assert_eq!(reader.buf.len(), BUF_LEN);
+        assert_eq!(reader.buf_len, BUF_LEN); // [4..68]
+        assert_eq!(reader.buf_use, 0);
+
+        // Test find the first header
+        find_record_header_and_check(&mut reader, None, Some(4)).await;
+        // Test find header that need to load half of the buffer.
+        find_record_header_and_check(&mut reader, Some(63), Some(76)).await;
+        // Test find header that need to load entire of the buffer.
+        find_record_header_and_check(&mut reader, Some(1024), Some(1030)).await;
+        // Test find the last header
+        find_record_header_and_check(&mut reader, Some(1786), Some(1786)).await;
+        // Test find previous header.
+        find_record_header_and_check(&mut reader, Some(1024), Some(1030)).await;
+        // Test find header and return Err(EOF).
+        find_record_header_and_check(&mut reader, Some(1787), None).await;
+
+        // Test set_pos
+        set_pos_and_check(&mut reader, 0).await; // old buf, pos: 62
+        set_pos_and_check(&mut reader, 67).await; // old buf, pos: 63
+        set_pos_and_check(&mut reader, 68).await; // new buf, pos: 0
+        set_pos_and_check(&mut reader, 69).await; // new buf, pos: 1
+
+        // Re-run those find_record_header() tests.
+        find_record_header_and_check(&mut reader, Some(0), Some(4)).await;
+        find_record_header_and_check(&mut reader, Some(63), Some(76)).await;
+        find_record_header_and_check(&mut reader, Some(1024), Some(1030)).await;
+        find_record_header_and_check(&mut reader, Some(1786), Some(1786)).await;
+        find_record_header_and_check(&mut reader, Some(1787), None).await;
     }
 }

--- a/tskv/src/summary.rs
+++ b/tskv/src/summary.rs
@@ -434,6 +434,7 @@ impl Summary {
                     }
                 }
                 Err(Error::Eof) => break,
+                Err(Error::RecordFileHashCheckFailed { .. }) => continue,
                 Err(e) => {
                     return Err(e);
                 }
@@ -706,10 +707,9 @@ pub async fn print_summary_statistics(path: impl AsRef<Path>) {
                     }
                 }
             }
-            Err(err) => match err {
-                Error::Eof => break,
-                _ => panic!("Errors when read summary file: {}", err),
-            },
+            Err(Error::Eof) => break,
+            Err(Error::RecordFileHashCheckFailed { .. }) => continue,
+            Err(err) => panic!("Errors when read summary file: {}", err),
         }
         println!("============================================================");
     }

--- a/tskv/src/tsm/codec/boolean.rs
+++ b/tskv/src/tsm/codec/boolean.rs
@@ -24,7 +24,6 @@ pub fn bool_bitpack_encode(
     src: &[bool],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear();
     if src.is_empty() {
         return Ok(());
     }

--- a/tskv/src/tsm/codec/float.rs
+++ b/tskv/src/tsm/codec/float.rs
@@ -31,7 +31,6 @@ pub fn f64_gorilla_encode(
     src: &[f64],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear(); // reset buffer.
     if src.is_empty() {
         return Ok(());
     }
@@ -248,7 +247,6 @@ pub fn f64_q_compress_encode(
     src: &[f64],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear();
     if src.is_empty() {
         return Ok(());
     }
@@ -263,8 +261,6 @@ pub fn f64_without_compress_encode(
     src: &[f64],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear();
-
     if src.is_empty() {
         return Ok(());
     }

--- a/tskv/src/tsm/codec/integer.rs
+++ b/tskv/src/tsm/codec/integer.rs
@@ -44,7 +44,6 @@ pub fn i64_zigzag_simple8b_encode(
     src: &[i64],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear(); // reset buffer.
     if src.is_empty() {
         return Ok(());
     }

--- a/tskv/src/tsm/codec/string.rs
+++ b/tskv/src/tsm/codec/string.rs
@@ -31,7 +31,6 @@ pub fn str_snappy_encode(
     src: &[&[u8]],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear(); // reset buffer
     if src.is_empty() {
         return Ok(());
     }
@@ -93,7 +92,6 @@ pub fn str_zstd_encode(
     src: &[&[u8]],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear(); // reset buffer
     if src.is_empty() {
         return Ok(());
     }
@@ -114,7 +112,6 @@ pub fn str_gzip_encode(
     src: &[&[u8]],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear(); // reset buffer
     if src.is_empty() {
         return Ok(());
     }
@@ -138,7 +135,6 @@ pub fn str_bzip_encode(
     src: &[&[u8]],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear(); // reset buffer
     if src.is_empty() {
         return Ok(());
     }
@@ -162,7 +158,6 @@ pub fn str_zlib_encode(
     src: &[&[u8]],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear(); // reset buffer
     if src.is_empty() {
         return Ok(());
     }
@@ -184,7 +179,6 @@ pub fn str_without_compress_encode(
     src: &[&[u8]],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear(); // reset buffer
     if src.is_empty() {
         return Ok(());
     }

--- a/tskv/src/tsm/codec/timestamp.rs
+++ b/tskv/src/tsm/codec/timestamp.rs
@@ -21,7 +21,6 @@ pub fn ts_without_compress_encode(
     src: &[i64],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear();
     if src.is_empty() {
         return Ok(());
     }
@@ -37,7 +36,6 @@ pub fn ts_q_compress_encode(
     src: &[i64],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear();
     if src.is_empty() {
         return Ok(());
     }
@@ -59,7 +57,6 @@ pub fn ts_zigzag_simple8b_encode(
     src: &[i64],
     dst: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    dst.clear(); // reset buffer.
     if src.is_empty() {
         return Ok(());
     }

--- a/tskv/src/tsm/codec/unsigned.rs
+++ b/tskv/src/tsm/codec/unsigned.rs
@@ -42,7 +42,6 @@ pub fn u64_zigzag_simple8b_decode(
     }
     let mut signed_results = vec![];
     super::integer::i64_zigzag_simple8b_decode(src, &mut signed_results)?;
-    dst.clear();
     dst.reserve_exact(signed_results.len() - dst.capacity());
     for s in signed_results {
         dst.push(s as u64);
@@ -59,7 +58,6 @@ pub fn u64_q_compress_decode(
     }
     let mut signed_results = vec![];
     super::integer::i64_q_compress_decode(src, &mut signed_results)?;
-    dst.clear();
     dst.reserve_exact(signed_results.len() - dst.capacity());
     for s in signed_results {
         dst.push(s as u64);
@@ -76,7 +74,6 @@ pub fn u64_without_compress_decode(
     }
     let mut signed_results = vec![];
     super::integer::i64_without_compress_decode(src, &mut signed_results)?;
-    dst.clear();
     dst.reserve_exact(signed_results.len() - dst.capacity());
     for s in signed_results {
         dst.push(s as u64);

--- a/tskv/src/tsm/tombstone.rs
+++ b/tskv/src/tsm/tombstone.rs
@@ -91,6 +91,7 @@ impl TsmTombstone {
             let data = match reader.read_record().await {
                 Ok(r) => r.data,
                 Err(Error::Eof) => break,
+                Err(Error::RecordFileHashCheckFailed { .. }) => continue,
                 Err(e) => return Err(e),
             };
             if data.len() < ENTRY_LEN {

--- a/tskv/src/wal/writer.rs
+++ b/tskv/src/wal/writer.rs
@@ -192,8 +192,8 @@ impl WalWriter {
             self.min_sequence,
             self.max_sequence
         );
-        let footer = build_footer(self.min_sequence, self.max_sequence);
-        let size = self.inner.write_footer(footer).await?;
+        let mut footer = build_footer(self.min_sequence, self.max_sequence);
+        let size = self.inner.write_footer(&mut footer).await?;
         self.inner.close().await?;
         Ok(size)
     }


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [x] If there are any breaking changes to public APIs, please add the `api change` label.
- [x] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

## Codec

Encoders now do not clear the distant buffer.

## Record file refactors

### Reader

#### Public methods

##### `read_record()`

- Remove async_recursion.
- When there is an error, return that error instead of continue trying to read the next record.
- Add two possible errors: `RecordFileInvalidDataSize` and `RecordFileHashCheckFailed`.

#### Private methods

- `set_pos(pos)` - Return `Error::Eof` instead of `Error::InvalidParam` if pos > file length
- `find_record_header()` - Do not call `set_pos(header_pos)`.
- `load_buf()` - Do not truncate `Reader::buf` when read to end.
- `read_buf(size)` - When read to end, load as many bytes as possible form file, instead of return `Error::Eof`.

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

