### PR TITLE
feat(compaction): add delta compaction

### DIFF
--- a/tskv/src/compaction/compact.rs
+++ b/tskv/src/compaction/compact.rs
@@ -1170,12 +1170,12 @@ impl WriterWrapper {
     fn warp_write_tsm_result<T: Default>(write_result: WriteTsmResult<T>) -> Result<T> {
         match write_result {
             Ok(size) => Ok(size),
-            Err(tsm::WriteTsmError::WriteIO { source }) => {
+            Err(WriteTsmError::WriteIO { source }) => {
                 // TODO try re-run compaction on other time.
                 error!("Failed compaction: IO error when write tsm: {:?}", source);
                 Err(Error::IO { source })
             }
-            Err(tsm::WriteTsmError::Encode { source }) => {
+            Err(WriteTsmError::Encode { source }) => {
                 // TODO try re-run compaction on other time.
                 error!(
                     "Failed compaction: encoding error when write tsm: {:?}",
@@ -1183,7 +1183,7 @@ impl WriterWrapper {
                 );
                 Err(Error::Encode { source })
             }
-            Err(tsm::WriteTsmError::Finished { path }) => {
+            Err(WriteTsmError::Finished { path }) => {
                 error!(
                     "Failed compaction: Trying write already finished tsm file: '{}'",
                     path.display()
@@ -1192,7 +1192,7 @@ impl WriterWrapper {
                     source: tsm::WriteTsmError::Finished { path },
                 })
             }
-            Err(tsm::WriteTsmError::MaxFileSizeExceed { .. }) => {
+            Err(WriteTsmError::MaxFileSizeExceed { .. }) => {
                 // This error should be already handled before, ignore.
                 error!("WriteTsmError::MaxFileSizeExceed should be handled before.");
                 Ok(T::default())

--- a/tskv/src/compaction/compact.rs
+++ b/tskv/src/compaction/compact.rs
@@ -1,5 +1,6 @@
 use std::collections::{BinaryHeap, HashMap, VecDeque};
 use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -17,7 +18,7 @@ use crate::summary::{CompactMeta, VersionEdit};
 use crate::tseries_family::TseriesFamily;
 use crate::tsm::{
     self, BlockMeta, BlockMetaIterator, DataBlock, EncodedDataBlock, IndexIterator, IndexMeta,
-    TsmReader, TsmWriter,
+    TsmReader, TsmWriter, WriteTsmError, WriteTsmResult,
 };
 use crate::{ColumnFileId, Error, LevelId, TseriesFamilyId};
 
@@ -108,6 +109,7 @@ pub(crate) struct CompactingBlockMetaGroup {
     blk_metas: Vec<CompactingBlockMeta>,
     time_range: TimeRange,
 }
+
 impl CompactingBlockMetaGroup {
     pub fn new(field_id: FieldId, blk_meta: CompactingBlockMeta) -> Self {
         let time_range = blk_meta.time_range();
@@ -141,7 +143,7 @@ impl CompactingBlockMetaGroup {
         let merged_block;
         if self.blk_metas.len() == 1 && !self.blk_metas[0].has_tombstone() {
             // Only one compacting block and has no tombstone, write as raw block.
-            trace!("only one compacting block, write as raw block");
+            trace!("only one compacting block, handled as raw block");
             let meta_0 = &self.blk_metas[0].meta;
             let mut buf_0 = Vec::with_capacity(meta_0.size() as usize);
             let data_len_0 = self.blk_metas[0].get_raw_data(&mut buf_0).await?;
@@ -150,8 +152,8 @@ impl CompactingBlockMetaGroup {
             if meta_0.size() >= max_block_size as u64 {
                 // Raw data block is full, so do not merge with the previous, directly return.
                 let mut merged_blks = Vec::new();
-                if let Some(blk) = previous_block {
-                    merged_blks.push(blk);
+                if let Some(prev_compacting_block) = previous_block {
+                    merged_blks.push(prev_compacting_block);
                 }
                 merged_blks.push(CompactingBlock::raw(
                     self.blk_metas[0].reader_idx,
@@ -160,7 +162,7 @@ impl CompactingBlockMetaGroup {
                 ));
 
                 return Ok(merged_blks);
-            } else if let Some(compacting_block) = previous_block {
+            } else if let Some(prev_compacting_block) = previous_block {
                 // Raw block is not full, so decode and merge with compacting_block.
                 let decoded_raw_block = tsm::decode_data_block(
                     &buf_0,
@@ -168,13 +170,12 @@ impl CompactingBlockMetaGroup {
                     meta_0.val_off() - meta_0.offset(),
                 )
                 .context(error::ReadTsmSnafu)?;
-                let mut data_block = compacting_block.decode()?;
+                let mut data_block = prev_compacting_block.decode()?;
                 data_block.extend(decoded_raw_block);
 
                 merged_block = data_block;
             } else {
                 // Raw block is not full, but nothing to merge with, directly return.
-
                 return Ok(vec![CompactingBlock::raw(
                     self.blk_metas[0].reader_idx,
                     meta_0.clone(),
@@ -190,8 +191,8 @@ impl CompactingBlockMetaGroup {
             let head = &mut self.blk_metas[0];
             let mut head_block = head.get_data_block().await?;
 
-            if let Some(compacting_block) = previous_block {
-                let mut data_block = compacting_block.decode()?;
+            if let Some(prev_compacting_block) = previous_block {
+                let mut data_block = prev_compacting_block.decode()?;
                 data_block.extend(head_block);
                 head_block = data_block;
             }
@@ -231,7 +232,7 @@ impl CompactingBlockMetaGroup {
                     })?;
                 merged_blks.push(CompactingBlock::encoded(0, self.field_id, encoded_blk));
 
-                start += end;
+                start = end;
                 end = len.min(start + max_block_size);
             }
             if start < len {
@@ -259,6 +260,21 @@ impl CompactingBlockMetaGroup {
 
     pub fn len(&self) -> usize {
         self.blk_metas.len()
+    }
+}
+
+impl Display for CompactingBlockMetaGroup {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{field_id: {}, blk_metas: [{}] }}",
+            self.field_id,
+            self.blk_metas
+                .iter()
+                .map(|b| format!("{}", b))
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
     }
 }
 
@@ -422,17 +438,12 @@ pub(crate) struct CompactIterator {
     compacting_files: BinaryHeap<Pin<Box<CompactingFile>>>,
     /// Maximum values in generated CompactingBlock
     max_data_block_size: usize,
-    // /// The time range of data to be merged of level-0 data blocks.
-    // /// The level-0 data that out of the thime range will write back to level-0.
-    // level_time_range: TimeRange,
     /// Decode a data block even though it doesn't need to merge with others,
     /// return CompactingBlock::DataBlock rather than CompactingBlock::Raw .
     decode_non_overlap_blocks: bool,
-
-    tmp_tsm_blk_meta_iters: Vec<BlockMetaIterator>,
-    /// Index to mark `Peekable<BlockMetaIterator>` in witch `TsmReader`,
-    /// tmp_tsm_blks[i] is in self.tsm_readers[ tmp_tsm_blk_tsm_reader_idx[i] ]
-    tmp_tsm_blk_tsm_reader_idx: Vec<usize>,
+    /// Temporarily stored index of `TsmReader` in self.tsm_readers,
+    /// and `BlockMetaIterator` of current field_id.
+    tmp_tsm_blk_meta_iters: Vec<(usize, BlockMetaIterator)>,
     /// When a TSM file at index i is ended, finished_idxes[i] is set to true.
     finished_readers: Vec<bool>,
     /// How many finished_idxes is set to true.
@@ -451,7 +462,6 @@ impl Default for CompactIterator {
             max_data_block_size: 0,
             decode_non_overlap_blocks: false,
             tmp_tsm_blk_meta_iters: Default::default(),
-            tmp_tsm_blk_tsm_reader_idx: Default::default(),
             finished_readers: Default::default(),
             finished_reader_cnt: Default::default(),
             curr_fid: Default::default(),
@@ -478,6 +488,7 @@ impl CompactIterator {
             compacting_files,
             max_data_block_size,
             decode_non_overlap_blocks,
+            tmp_tsm_blk_meta_iters: Vec::with_capacity(compacting_files_cnt),
             finished_readers: vec![false; compacting_files_cnt],
             ..Default::default()
         }
@@ -485,6 +496,7 @@ impl CompactIterator {
 
     /// Update tmp_tsm_blks and tmp_tsm_blk_tsm_reader_idx for field id in next iteration.
     fn next_field_id(&mut self) {
+        trace!("===============================");
         self.curr_fid = None;
 
         if let Some(f) = self.compacting_files.peek() {
@@ -501,14 +513,16 @@ impl CompactIterator {
             trace!("no file to select, mark finished");
             self.finished_reader_cnt += 1;
         }
+        self.tmp_tsm_blk_meta_iters.clear();
         while let Some(mut f) = self.compacting_files.pop() {
             let loop_field_id = f.field_id;
             let loop_file_i = f.i;
             if self.curr_fid == loop_field_id {
                 if let Some(idx_meta) = f.peek() {
-                    self.tmp_tsm_blk_meta_iters.push(idx_meta.block_iterator());
-                    self.tmp_tsm_blk_tsm_reader_idx.push(loop_file_i);
-                    trace!("merging idx_meta: field_id: {}, field_type: {:?}, block_count: {}, time_range: {:?}",
+                    self.tmp_tsm_blk_meta_iters
+                        .push((loop_file_i, idx_meta.block_iterator()));
+                    trace!("merging idx_meta({}): field_id: {}, field_type: {:?}, block_count: {}, time_range: {:?}",
+                        self.tmp_tsm_blk_meta_iters.len(),
                         idx_meta.field_id(),
                         idx_meta.field_type(),
                         idx_meta.block_count(),
@@ -530,7 +544,7 @@ impl CompactIterator {
     }
 
     /// Collect merging `DataBlock`s.
-    async fn fetch_merging_block_meta_groups(&mut self) -> bool {
+    fn fetch_merging_block_meta_groups(&mut self) -> bool {
         if self.tmp_tsm_blk_meta_iters.is_empty() {
             return false;
         }
@@ -542,12 +556,11 @@ impl CompactIterator {
         let mut blk_metas: Vec<CompactingBlockMeta> =
             Vec::with_capacity(self.tmp_tsm_blk_meta_iters.len());
         // Get all block_meta, and check if it's tsm file has a related tombstone file.
-        for (i, blk_iter) in self.tmp_tsm_blk_meta_iters.iter_mut().enumerate() {
+        for (tsm_reader_idx, blk_iter) in self.tmp_tsm_blk_meta_iters.iter_mut() {
             for blk_meta in blk_iter.by_ref() {
-                let tsm_reader_idx = self.tmp_tsm_blk_tsm_reader_idx[i];
-                let tsm_reader_ptr = self.tsm_readers[tsm_reader_idx].clone();
+                let tsm_reader_ptr = self.tsm_readers[*tsm_reader_idx].clone();
                 blk_metas.push(CompactingBlockMeta::new(
-                    tsm_reader_idx,
+                    *tsm_reader_idx,
                     tsm_reader_ptr,
                     blk_meta,
                 ));
@@ -596,14 +609,7 @@ impl CompactIterator {
             "selected merging meta groups: {}",
             blk_meta_groups
                 .iter()
-                .map(|g| format!(
-                    "[{}]",
-                    g.blk_metas
-                        .iter()
-                        .map(|b| format!("{}", b))
-                        .collect::<Vec<String>>()
-                        .join(", ")
-                ))
+                .map(|g| g.to_string())
                 .collect::<Vec<String>>()
                 .join(", ")
         );
@@ -634,7 +640,7 @@ impl CompactIterator {
         }
 
         // Get all of block_metas of this field id, and merge these blocks
-        self.fetch_merging_block_meta_groups().await;
+        self.fetch_merging_block_meta_groups();
 
         if let Some(g) = self.merging_blk_meta_groups.pop_front() {
             return Some(g);
@@ -681,7 +687,6 @@ pub async fn run_compaction_job(
     }
 
     // Buffers all tsm-files and it's indexes for this compaction
-    let tsf_id = request.ts_family_id;
     let mut tsm_readers = Vec::new();
     for col_file in request.files.iter() {
         let tsm_reader = request.version.get_tsm_reader(col_file.file_path()).await?;
@@ -690,41 +695,17 @@ pub async fn run_compaction_job(
 
     let max_block_size = TseriesFamily::MAX_DATA_BLOCK_SIZE as usize;
     let mut iter = CompactIterator::new(tsm_readers, max_block_size, false);
-    let tsm_dir = request.storage_opt.tsm_dir(&request.database, tsf_id);
-    let mut tsm_writer = tsm::new_tsm_writer(&tsm_dir, kernel.file_id_next(), false, 0).await?;
-    info!(
-        "Compaction: File: {} been created (level: {}).",
-        tsm_writer.sequence(),
-        request.out_level
-    );
-    let mut version_edit = VersionEdit::new(tsf_id);
-    let mut file_metas: HashMap<ColumnFileId, Arc<BloomFilter>> = HashMap::new();
+    let mut writer_wrapper = WriterWrapper::new(&request, kernel.clone());
 
     let mut previous_merged_block: Option<CompactingBlock> = None;
     let mut fid = iter.curr_fid;
     while let Some(blk_meta_group) = iter.next().await {
-        trace!("===============================");
+        trace!("selected merging meta group: {blk_meta_group}");
         if fid.is_some() && fid != iter.curr_fid {
             // Iteration of next field id, write previous merged block.
             if let Some(blk) = previous_merged_block.take() {
                 // Write the small previous merged block.
-                if write_tsm(
-                    &mut tsm_writer,
-                    blk,
-                    &mut file_metas,
-                    &mut version_edit,
-                    &request,
-                )
-                .await?
-                {
-                    tsm_writer =
-                        tsm::new_tsm_writer(&tsm_dir, kernel.file_id_next(), false, 0).await?;
-                    info!(
-                        "Compaction: File: {} been created (level: {}).",
-                        tsm_writer.sequence(),
-                        request.out_level
-                    );
-                }
+                writer_wrapper.write(blk).await?;
             }
         }
 
@@ -746,45 +727,14 @@ pub async fn run_compaction_job(
                 previous_merged_block = Some(blk);
                 break;
             }
-            if write_tsm(
-                &mut tsm_writer,
-                blk,
-                &mut file_metas,
-                &mut version_edit,
-                &request,
-            )
-            .await?
-            {
-                tsm_writer = tsm::new_tsm_writer(&tsm_dir, kernel.file_id_next(), false, 0).await?;
-                info!(
-                    "Compaction: File: {} been created (level: {}).",
-                    tsm_writer.sequence(),
-                    request.out_level
-                );
-            }
+            writer_wrapper.write(blk).await?;
         }
     }
     if let Some(blk) = previous_merged_block {
-        let _max_file_size_exceed = write_tsm(
-            &mut tsm_writer,
-            blk,
-            &mut file_metas,
-            &mut version_edit,
-            &request,
-        )
-        .await?;
-    }
-    if !tsm_writer.finished() {
-        finish_write_tsm(
-            &mut tsm_writer,
-            &mut file_metas,
-            &mut version_edit,
-            &request,
-            request.version.max_level_ts(),
-        )
-        .await?;
+        writer_wrapper.write(blk).await?;
     }
 
+    let (mut version_edit, file_metas) = writer_wrapper.close().await?;
     for file in request.files {
         version_edit.del_file(file.level(), file.file_id(), file.is_delta());
     }
@@ -796,91 +746,459 @@ pub async fn run_compaction_job(
     Ok(Some((version_edit, file_metas)))
 }
 
-async fn write_tsm(
-    tsm_writer: &mut TsmWriter,
-    blk: CompactingBlock,
-    file_metas: &mut HashMap<ColumnFileId, Arc<BloomFilter>>,
-    version_edit: &mut VersionEdit,
-    request: &CompactReq,
-) -> Result<bool> {
-    let write_ret = match blk {
-        CompactingBlock::Decoded {
-            field_id: fid,
-            data_block: b,
-            ..
-        } => tsm_writer.write_block(fid, &b).await,
-        CompactingBlock::Encoded {
-            field_id,
-            data_block,
-            ..
-        } => tsm_writer.write_encoded_block(field_id, &data_block).await,
-        CompactingBlock::Raw { meta, raw, .. } => tsm_writer.write_raw(&meta, &raw).await,
-    };
-    if let Err(e) = write_ret {
-        match e {
-            tsm::WriteTsmError::WriteIO { source } => {
+pub(crate) struct WriterWrapper {
+    // Init values.
+    delta_compaction: bool,
+    ts_family_id: TseriesFamilyId,
+    out_level: LevelId,
+    out_level_max_ts: Timestamp,
+    max_level_ts: Timestamp,
+    max_file_size: u64,
+    tsm_dir: PathBuf,
+    delta_dir: PathBuf,
+    context: Arc<GlobalContext>,
+
+    // Temporary values.
+    tsm_writer_full: bool,
+    tsm_writer: Option<TsmWriter>,
+    delta_writer_full: bool,
+    delta_writer: Option<TsmWriter>,
+
+    // Result values.
+    version_edit: VersionEdit,
+    file_metas: HashMap<ColumnFileId, Arc<BloomFilter>>,
+}
+
+impl WriterWrapper {
+    pub fn new(request: &CompactReq, context: Arc<GlobalContext>) -> Self {
+        Self {
+            delta_compaction: request.in_level == 0,
+            ts_family_id: request.ts_family_id,
+            out_level: request.out_level,
+            out_level_max_ts: request.time_range.max_ts,
+            max_level_ts: request.version.max_level_ts(),
+            max_file_size: request
+                .version
+                .storage_opt()
+                .level_max_file_size(request.out_level),
+            tsm_dir: request
+                .storage_opt
+                .tsm_dir(&request.tenant_database, request.ts_family_id),
+            delta_dir: request
+                .storage_opt
+                .delta_dir(&request.tenant_database, request.ts_family_id),
+            context,
+
+            tsm_writer_full: false,
+            tsm_writer: None,
+            delta_writer_full: false,
+            delta_writer: None,
+
+            version_edit: VersionEdit::new(request.ts_family_id),
+            file_metas: HashMap::new(),
+        }
+    }
+
+    pub async fn close(mut self) -> Result<(VersionEdit, HashMap<ColumnFileId, Arc<BloomFilter>>)> {
+        if let Some(ref mut w) = self.delta_writer {
+            Self::close_writer(
+                w,
+                &mut self.file_metas,
+                &mut self.version_edit,
+                0,
+                self.ts_family_id,
+                self.max_level_ts,
+            )
+            .await?;
+        }
+        if let Some(ref mut w) = self.tsm_writer {
+            Self::close_writer(
+                w,
+                &mut self.file_metas,
+                &mut self.version_edit,
+                self.out_level,
+                self.ts_family_id,
+                self.max_level_ts,
+            )
+            .await?;
+        }
+
+        Ok((self.version_edit, self.file_metas))
+    }
+
+    /// Write CompactingBlock to TsmWriter, fill file_metas and version_edit.
+    pub async fn write(&mut self, blk: CompactingBlock) -> Result<()> {
+        match blk {
+            CompactingBlock::Decoded {
+                priority: _priority,
+                field_id,
+                data_block,
+            } => {
+                if self.delta_compaction {
+                    if let Some(tr) = data_block.time_range() {
+                        if tr.0 < self.out_level_max_ts && tr.1 > self.out_level_max_ts {
+                            // Split block.
+                            let (tsm_blk, delta_blk) = data_block.split(self.out_level_max_ts);
+                            if !tsm_blk.is_empty() {
+                                self.write_tsm_data_block(field_id, &tsm_blk).await?;
+                            }
+                            if !delta_blk.is_empty() {
+                                self.write_delta_data_block(field_id, &delta_blk).await?;
+                            }
+                        } else if tr.0 > self.out_level_max_ts {
+                            self.write_delta_data_block(field_id, &data_block).await?;
+                        } else {
+                            self.write_tsm_data_block(field_id, &data_block).await?;
+                        }
+                    }
+                } else {
+                    self.write_tsm_data_block(field_id, &data_block).await?;
+                }
+            }
+            CompactingBlock::Encoded {
+                priority,
+                field_id,
+                data_block,
+            } => {
+                if self.delta_compaction {
+                    if let Some(tr) = data_block.time_range {
+                        if tr.min_ts < self.out_level_max_ts && tr.max_ts > self.out_level_max_ts {
+                            // Split block.
+                            let decoded_blk =
+                                CompactingBlock::encoded(priority, field_id, data_block)
+                                    .decode()?;
+                            let (tsm_blk, delta_blk) = decoded_blk.split(self.out_level_max_ts);
+                            if !tsm_blk.is_empty() {
+                                self.write_tsm_data_block(field_id, &tsm_blk).await?;
+                            }
+                            if !delta_blk.is_empty() {
+                                self.write_delta_data_block(field_id, &delta_blk).await?;
+                            }
+                        } else if tr.min_ts > self.out_level_max_ts {
+                            self.write_delta_encoded_data_block(field_id, &data_block)
+                                .await?;
+                        } else {
+                            self.write_tsm_encoded_data_block(field_id, &data_block)
+                                .await?;
+                        }
+                    }
+                } else {
+                    self.write_tsm_encoded_data_block(field_id, &data_block)
+                        .await?;
+                }
+            }
+            CompactingBlock::Raw {
+                priority,
+                meta,
+                raw,
+            } => {
+                if self.delta_compaction {
+                    let tr = meta.time_range();
+                    if tr.min_ts < self.out_level_max_ts && tr.max_ts > self.out_level_max_ts {
+                        // Split block.
+                        let field_id = meta.field_id();
+                        let decoded_blk = CompactingBlock::raw(priority, meta, raw).decode()?;
+                        let (tsm_blk, delta_blk) = decoded_blk.split(self.out_level_max_ts);
+                        if !tsm_blk.is_empty() {
+                            self.write_tsm_data_block(field_id, &tsm_blk).await?;
+                        }
+                        if !delta_blk.is_empty() {
+                            self.write_delta_data_block(field_id, &delta_blk).await?;
+                        }
+                    } else if tr.min_ts > self.out_level_max_ts {
+                        self.write_delta_raw_data_block(&meta, &raw).await?;
+                    } else {
+                        self.write_tsm_raw_data_block(&meta, &raw).await?;
+                    }
+                } else {
+                    self.write_tsm_raw_data_block(&meta, &raw).await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn write_delta_data_block(
+        &mut self,
+        field_id: FieldId,
+        data_block: &DataBlock,
+    ) -> Result<usize> {
+        self.write_block_inner(field_id, data_block, true).await
+    }
+
+    pub async fn write_tsm_data_block(
+        &mut self,
+        field_id: FieldId,
+        data_block: &DataBlock,
+    ) -> Result<usize> {
+        self.write_block_inner(field_id, data_block, false).await
+    }
+
+    async fn write_block_inner(
+        &mut self,
+        field_id: FieldId,
+        data_block: &DataBlock,
+        is_delta: bool,
+    ) -> Result<usize> {
+        let write_ret = if is_delta {
+            let write_ret = self
+                .delta_writer_mut()
+                .await?
+                .write_block(field_id, data_block)
+                .await;
+            if let Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) = write_ret {
+                self.delta_writer_full = true;
+                return Ok(write_size);
+            }
+            write_ret
+        } else {
+            let write_ret = self
+                .tsm_writer_mut()
+                .await?
+                .write_block(field_id, data_block)
+                .await;
+            if let Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) = write_ret {
+                self.tsm_writer_full = true;
+                return Ok(write_size);
+            }
+            write_ret
+        };
+        Self::warp_write_tsm_result(write_ret)
+    }
+
+    pub async fn write_delta_encoded_data_block(
+        &mut self,
+        field_id: FieldId,
+        data_block: &EncodedDataBlock,
+    ) -> Result<usize> {
+        self.write_encoded_block_inner(field_id, data_block, true)
+            .await
+    }
+
+    pub async fn write_tsm_encoded_data_block(
+        &mut self,
+        field_id: FieldId,
+        data_block: &EncodedDataBlock,
+    ) -> Result<usize> {
+        self.write_encoded_block_inner(field_id, data_block, false)
+            .await
+    }
+
+    async fn write_encoded_block_inner(
+        &mut self,
+        field_id: FieldId,
+        data_block: &EncodedDataBlock,
+        is_delta: bool,
+    ) -> Result<usize> {
+        let write_ret = if is_delta {
+            let write_ret = self
+                .delta_writer_mut()
+                .await?
+                .write_encoded_block(field_id, data_block)
+                .await;
+            if let Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) = write_ret {
+                self.delta_writer_full = true;
+                return Ok(write_size);
+            }
+            write_ret
+        } else {
+            let write_ret = self
+                .tsm_writer_mut()
+                .await?
+                .write_encoded_block(field_id, data_block)
+                .await;
+            if let Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) = write_ret {
+                self.tsm_writer_full = true;
+                return Ok(write_size);
+            }
+            write_ret
+        };
+        Self::warp_write_tsm_result(write_ret)
+    }
+
+    pub async fn write_delta_raw_data_block(
+        &mut self,
+        block_meta: &BlockMeta,
+        data_block: &[u8],
+    ) -> Result<usize> {
+        self.write_raw_inner(block_meta, data_block, true).await
+    }
+
+    pub async fn write_tsm_raw_data_block(
+        &mut self,
+        block_meta: &BlockMeta,
+        data_block: &[u8],
+    ) -> Result<usize> {
+        self.write_raw_inner(block_meta, data_block, false).await
+    }
+
+    async fn write_raw_inner(
+        &mut self,
+        block_meta: &BlockMeta,
+        data_block: &[u8],
+        is_delta: bool,
+    ) -> Result<usize> {
+        let write_ret = if is_delta {
+            let write_ret = self
+                .delta_writer_mut()
+                .await?
+                .write_raw(block_meta, data_block)
+                .await;
+            if let Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) = write_ret {
+                self.delta_writer_full = true;
+                return Ok(write_size);
+            }
+            write_ret
+        } else {
+            let write_ret = self
+                .tsm_writer_mut()
+                .await?
+                .write_raw(block_meta, data_block)
+                .await;
+            if let Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) = write_ret {
+                self.tsm_writer_full = true;
+                return Ok(write_size);
+            }
+            write_ret
+        };
+        Self::warp_write_tsm_result(write_ret)
+    }
+
+    async fn tsm_writer_mut(&mut self) -> Result<&mut TsmWriter> {
+        if self.tsm_writer_full {
+            if let Some(ref mut w) = self.tsm_writer {
+                Self::close_writer(
+                    w,
+                    &mut self.file_metas,
+                    &mut self.version_edit,
+                    self.out_level,
+                    self.ts_family_id,
+                    self.out_level_max_ts,
+                )
+                .await?;
+            }
+            self.new_writer(false).await
+        } else {
+            match self.tsm_writer {
+                Some(ref mut w) => Ok(w),
+                None => self.new_writer(false).await,
+            }
+        }
+    }
+
+    async fn delta_writer_mut(&mut self) -> Result<&mut TsmWriter> {
+        if self.delta_writer_full {
+            if let Some(ref mut w) = self.tsm_writer {
+                Self::close_writer(
+                    w,
+                    &mut self.file_metas,
+                    &mut self.version_edit,
+                    0,
+                    self.ts_family_id,
+                    self.out_level_max_ts,
+                )
+                .await?;
+            }
+            self.new_writer(true).await
+        } else {
+            match self.delta_writer {
+                Some(ref mut w) => Ok(w),
+                None => self.new_writer(true).await,
+            }
+        }
+    }
+
+    async fn new_writer(&mut self, is_delta: bool) -> Result<&mut TsmWriter> {
+        let writer_path = if is_delta {
+            &self.delta_dir
+        } else {
+            &self.tsm_dir
+        };
+        let writer = tsm::new_tsm_writer(
+            writer_path,
+            self.context.file_id_next(),
+            is_delta,
+            self.max_file_size,
+        )
+        .await?;
+        info!(
+            "Compaction: File: {} been created (level: {}).",
+            writer.sequence(),
+            if is_delta { 0 } else { self.out_level }
+        );
+
+        if is_delta {
+            self.delta_writer_full = false;
+            Ok(self.delta_writer.insert(writer))
+        } else {
+            self.tsm_writer_full = false;
+            Ok(self.tsm_writer.insert(writer))
+        }
+    }
+
+    async fn close_writer(
+        tsm_writer: &mut TsmWriter,
+        file_metas: &mut HashMap<ColumnFileId, Arc<BloomFilter>>,
+        version_edit: &mut VersionEdit,
+        out_level: LevelId,
+        ts_family_id: TseriesFamilyId,
+        max_level_ts: Timestamp,
+    ) -> Result<()> {
+        tsm_writer
+            .write_index()
+            .await
+            .context(error::WriteTsmSnafu)?;
+        tsm_writer.finish().await.context(error::WriteTsmSnafu)?;
+        file_metas.insert(
+            tsm_writer.sequence(),
+            Arc::new(tsm_writer.bloom_filter_cloned()),
+        );
+        info!(
+            "Compaction: File: {} write finished (level: {}, {} B).",
+            tsm_writer.sequence(),
+            out_level,
+            tsm_writer.size()
+        );
+
+        let cm = new_compact_meta(tsm_writer, ts_family_id, out_level);
+        version_edit.add_file(cm, max_level_ts);
+
+        Ok(())
+    }
+
+    fn warp_write_tsm_result<T: Default>(write_result: WriteTsmResult<T>) -> Result<T> {
+        match write_result {
+            Ok(size) => Ok(size),
+            Err(tsm::WriteTsmError::WriteIO { source }) => {
                 // TODO try re-run compaction on other time.
                 error!("Failed compaction: IO error when write tsm: {:?}", source);
-                return Err(Error::IO { source });
+                Err(Error::IO { source })
             }
-            tsm::WriteTsmError::Encode { source } => {
+            Err(tsm::WriteTsmError::Encode { source }) => {
                 // TODO try re-run compaction on other time.
                 error!(
                     "Failed compaction: encoding error when write tsm: {:?}",
                     source
                 );
-                return Err(Error::Encode { source });
+                Err(Error::Encode { source })
             }
-            tsm::WriteTsmError::MaxFileSizeExceed { .. } => {
-                finish_write_tsm(
-                    tsm_writer,
-                    file_metas,
-                    version_edit,
-                    request,
-                    request.version.max_level_ts(),
-                )
-                .await?;
-                return Ok(true);
-            }
-            tsm::WriteTsmError::Finished { path } => {
+            Err(tsm::WriteTsmError::Finished { path }) => {
                 error!(
-                    "Trying to write by a finished tsm writer: {}",
+                    "Failed compaction: Trying write already finished tsm file: '{}'",
                     path.display()
                 );
+                Err(Error::WriteTsm {
+                    source: tsm::WriteTsmError::Finished { path },
+                })
+            }
+            Err(tsm::WriteTsmError::MaxFileSizeExceed { .. }) => {
+                // This error should be already handled before, ignore.
+                error!("WriteTsmError::MaxFileSizeExceed should be handled before.");
+                Ok(T::default())
             }
         }
     }
-
-    Ok(false)
-}
-
-async fn finish_write_tsm(
-    tsm_writer: &mut TsmWriter,
-    file_metas: &mut HashMap<ColumnFileId, Arc<BloomFilter>>,
-    version_edit: &mut VersionEdit,
-    request: &CompactReq,
-    max_level_ts: Timestamp,
-) -> Result<()> {
-    tsm_writer
-        .write_index()
-        .await
-        .context(error::WriteTsmSnafu)?;
-    tsm_writer.finish().await.context(error::WriteTsmSnafu)?;
-    file_metas.insert(
-        tsm_writer.sequence(),
-        Arc::new(tsm_writer.bloom_filter_cloned()),
-    );
-    info!(
-        "Compaction: File: {} write finished (level: {}, {} B).",
-        tsm_writer.sequence(),
-        request.out_level,
-        tsm_writer.size()
-    );
-
-    let cm = new_compact_meta(tsm_writer, request.ts_family_id, request.out_level);
-    version_edit.add_file(cm, max_level_ts);
-
-    Ok(())
 }
 
 fn new_compact_meta(
@@ -910,6 +1228,7 @@ pub mod test {
 
     use cache::ShardedAsyncCache;
     use minivec::MiniVec;
+    use models::codec::Encoding;
     use models::predicate::domain::TimeRange;
     use models::{FieldId, PhysicalDType as ValueType, Timestamp};
 
@@ -921,7 +1240,7 @@ pub mod test {
     use crate::tseries_family::{ColumnFile, LevelInfo, Version};
     use crate::tsm::codec::DataBlockEncoding;
     use crate::tsm::{self, DataBlock, TsmReader, TsmTombstone};
-    use crate::{file_utils, ColumnFileId};
+    use crate::{file_utils, ColumnFileId, LevelId};
 
     pub(crate) async fn write_data_blocks_to_column_file(
         dir: impl AsRef<Path>,
@@ -971,13 +1290,26 @@ pub mod test {
         data
     }
 
-    fn get_result_file_path(dir: impl AsRef<Path>, version_edit: VersionEdit) -> PathBuf {
+    fn get_result_file_path(
+        dir: impl AsRef<Path>,
+        version_edit: VersionEdit,
+        level: LevelId,
+    ) -> PathBuf {
         if version_edit.has_file_id && !version_edit.add_files.is_empty() {
-            let file_id = version_edit.add_files.first().unwrap().file_id;
-            return file_utils::make_tsm_file(dir, file_id);
+            if let Some(f) = version_edit
+                .add_files
+                .into_iter()
+                .find(|f| f.level == level)
+            {
+                if level == 0 {
+                    return file_utils::make_delta_file(dir, f.file_id);
+                } else {
+                    return file_utils::make_tsm_file(dir, f.file_id);
+                }
+            }
+            panic!("VersionEdit::add_files doesn't contain any file matches level-{level}.");
         }
-
-        panic!("VersionEdit doesn't contain any add_files.");
+        panic!("VersionEdit::add_files is empty, no file to read.");
     }
 
     /// Compare DataBlocks in path with the expected_Data using assert_eq.
@@ -985,8 +1317,9 @@ pub mod test {
         dir: impl AsRef<Path>,
         version_edit: VersionEdit,
         expected_data: HashMap<FieldId, Vec<DataBlock>>,
+        expected_data_level: LevelId,
     ) {
-        let path = get_result_file_path(dir, version_edit);
+        let path = get_result_file_path(dir, version_edit, expected_data_level);
         let data = read_data_blocks_from_column_file(path).await;
         let mut data_field_ids = data.keys().copied().collect::<Vec<_>>();
         data_field_ids.sort_unstable();
@@ -1010,38 +1343,41 @@ pub mod test {
 
     pub(crate) fn create_options(base_dir: String) -> Arc<Options> {
         let mut config = config::get_config_for_test();
-        config.storage.path = base_dir;
-        let opt = Options::from(&config);
-        Arc::new(opt)
+        config.storage.path = base_dir.clone();
+        config.log.path = base_dir;
+        Arc::new(Options::from(&config))
     }
 
-    fn prepare_compact_req_and_kernel(
-        database: Arc<String>,
+    fn prepare_compaction(
+        tenant_database: Arc<String>,
         opt: Arc<Options>,
-        next_file_id: u64,
+        next_file_id: ColumnFileId,
         files: Vec<Arc<ColumnFile>>,
+        max_level_ts: Timestamp,
     ) -> (CompactReq, Arc<GlobalContext>) {
         let version = Arc::new(Version::new(
             1,
-            database.clone(),
+            tenant_database.clone(),
             opt.storage.clone(),
             1,
-            LevelInfo::init_levels(database.clone(), 0, opt.storage.clone()),
-            1000,
+            LevelInfo::init_levels(tenant_database.clone(), 0, opt.storage.clone()),
+            max_level_ts,
             Arc::new(ShardedAsyncCache::create_lru_sharded_cache(1)),
         ));
         let compact_req = CompactReq {
             ts_family_id: 1,
-            database,
+            tenant_database,
             storage_opt: opt.storage.clone(),
             files,
             version,
+            in_level: 1,
             out_level: 2,
+            time_range: TimeRange::all(),
         };
-        let kernel = Arc::new(GlobalContext::new());
-        kernel.set_file_id(next_file_id);
+        let context = Arc::new(GlobalContext::new());
+        context.set_file_id(next_file_id);
 
-        (compact_req, kernel)
+        (compact_req, context)
     }
 
     fn format_data_blocks(data_blocks: &[DataBlock]) -> String {
@@ -1055,6 +1391,7 @@ pub mod test {
         )
     }
 
+    /// Test compaction with ordered data.
     #[tokio::test]
     async fn test_compaction_fast() {
         #[rustfmt::skip]
@@ -1082,104 +1419,118 @@ pub mod test {
             (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
         ]);
 
-        let dir = "/tmp/test/compaction";
-        let database = Arc::new("dba".to_string());
+        let dir = "/tmp/test/compaction/0";
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
+        let max_level_ts = 9;
 
         let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, files);
+            prepare_compaction(tenant_database, opt, next_file_id, files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
+
+    const INT_BLOCK_ENCODING: DataBlockEncoding =
+        DataBlockEncoding::new(Encoding::Delta, Encoding::Delta);
 
     #[tokio::test]
     async fn test_compaction_1() {
+        trace::init_default_global_tracing("/tmp/test/log", "test", "trace");
         #[rustfmt::skip]
         let data = vec![
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
             ]),
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
             ]),
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
             ]),
         ];
         #[rustfmt::skip]
         let expected_data = HashMap::from([
-            (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (2, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
+            (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (2, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
         ]);
 
         let dir = "/tmp/test/compaction/1";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
+        let max_level_ts = 9;
 
         let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, files);
+            prepare_compaction(tenant_database, opt, next_file_id, files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
+    /// Test compact with duplicate timestamp.
     #[tokio::test]
     async fn test_compaction_2() {
         #[rustfmt::skip]
         let data = vec![
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4], val: vec![1, 2, 3, 5], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4], val: vec![1, 2, 3, 5], enc: DataBlockEncoding::default() }]),
-                (4, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4], val: vec![1, 2, 3, 5], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4], val: vec![1, 2, 3, 5], enc: INT_BLOCK_ENCODING }]),
+                (4, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
             ]),
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![4, 5, 6, 7], val: vec![4, 5, 6, 8], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![4, 5, 6, 7], val: vec![4, 5, 6, 8], enc: INT_BLOCK_ENCODING }]),
             ]),
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
             ]),
         ];
         #[rustfmt::skip]
         let expected_data = HashMap::from([
-            (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (2, vec![DataBlock::I64 { ts: vec![4, 5, 6, 7, 8, 9], val: vec![4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (4, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
+            (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (2, vec![DataBlock::I64 { ts: vec![4, 5, 6, 7, 8, 9], val: vec![4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (4, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
         ]);
 
         let dir = "/tmp/test/compaction/2";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
+        let max_level_ts = 9;
 
         let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, files);
+            prepare_compaction(tenant_database, opt, next_file_id, files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
     /// Returns a generated `DataBlock` with default value and specified size, `DataBlock::ts`
@@ -1206,7 +1557,7 @@ pub mod test {
                 DataBlock::U64 {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::Delta),
                 }
             }
             ValueType::Integer => {
@@ -1221,7 +1572,7 @@ pub mod test {
                 DataBlock::I64 {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::Delta),
                 }
             }
             ValueType::String => {
@@ -1237,7 +1588,7 @@ pub mod test {
                 DataBlock::Str {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::Snappy),
                 }
             }
             ValueType::Float => {
@@ -1252,7 +1603,7 @@ pub mod test {
                 DataBlock::F64 {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::Gorilla),
                 }
             }
             ValueType::Boolean => {
@@ -1267,7 +1618,7 @@ pub mod test {
                 DataBlock::Bool {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::BitPack),
                 }
             }
             ValueType::Unknown => {
@@ -1276,10 +1627,57 @@ pub mod test {
         }
     }
 
+    type DataDesc = (
+        ColumnFileId,
+        Vec<(ValueType, FieldId, Timestamp, Timestamp)>,
+        Vec<(FieldId, Timestamp, Timestamp)>,
+    );
+
+    #[allow(clippy::type_complexity)]
+    async fn write_data_block_desc(
+        dir: impl AsRef<Path>,
+        data_desc: &[DataDesc],
+    ) -> Vec<Arc<ColumnFile>> {
+        let mut column_files = Vec::new();
+        for (tsm_sequence, tsm_desc, tombstone_desc) in data_desc.iter() {
+            let mut tsm_writer = tsm::new_tsm_writer(&dir, *tsm_sequence, false, 0)
+                .await
+                .unwrap();
+            for &(val_type, fid, min_ts, max_ts) in tsm_desc.iter() {
+                tsm_writer
+                    .write_block(fid, &generate_data_block(val_type, vec![(min_ts, max_ts)]))
+                    .await
+                    .unwrap();
+            }
+            tsm_writer.write_index().await.unwrap();
+            tsm_writer.finish().await.unwrap();
+            let tsm_tombstone = TsmTombstone::open(&dir, *tsm_sequence).await.unwrap();
+            for (fid, min_ts, max_ts) in tombstone_desc.iter() {
+                tsm_tombstone
+                    .add_range(&[*fid][..], &TimeRange::new(*min_ts, *max_ts), None)
+                    .await
+                    .unwrap();
+            }
+
+            tsm_tombstone.flush().await.unwrap();
+            column_files.push(Arc::new(ColumnFile::new(
+                *tsm_sequence,
+                2,
+                TimeRange::new(tsm_writer.min_ts(), tsm_writer.max_ts()),
+                tsm_writer.size(),
+                false,
+                tsm_writer.path(),
+            )));
+        }
+
+        column_files
+    }
+
+    /// Test compaction without tombstones.
     #[tokio::test]
     async fn test_compaction_3() {
         #[rustfmt::skip]
-        let data_desc = [
+        let data_desc: [DataDesc; 3] = [
             // [( tsm_sequence, vec![ (ValueType, FieldId, Timestamp_Begin, Timestamp_end) ] )]
             (1_u64, vec![
                 // 1, 1~2500
@@ -1292,7 +1690,7 @@ pub mod test {
                 // 3, 1~1500
                 (ValueType::Boolean, 3, 1, 1000),
                 (ValueType::Boolean, 3, 1001, 1500),
-            ]),
+            ], vec![]),
             (2, vec![
                 // 1, 2001~4500
                 (ValueType::Unsigned, 1, 2001, 3000),
@@ -1307,7 +1705,7 @@ pub mod test {
                 // 4, 1~1500
                 (ValueType::Float, 4, 1, 1000),
                 (ValueType::Float, 4, 1001, 1500),
-            ]),
+            ], vec![]),
             (3, vec![
                 // 1, 4001~6500
                 (ValueType::Unsigned, 1, 4001, 5000),
@@ -1322,7 +1720,7 @@ pub mod test {
                 // 4. 1001~2500
                 (ValueType::Float, 4, 1001, 2000),
                 (ValueType::Float, 4, 2001, 2500),
-            ]),
+            ], vec![]),
         ];
         #[rustfmt::skip]
         let expected_data: HashMap<FieldId, Vec<DataBlock>> = HashMap::from(
@@ -1362,102 +1760,46 @@ pub mod test {
         );
 
         let dir = "/tmp/test/compaction/3";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
+        let max_level_ts = 6500;
 
-        let mut column_files = Vec::new();
-        for (tsm_sequence, args) in data_desc.iter() {
-            let mut tsm_writer = tsm::new_tsm_writer(&dir, *tsm_sequence, false, 0)
-                .await
-                .unwrap();
-            for arg in args.iter() {
-                tsm_writer
-                    .write_block(arg.1, &generate_data_block(arg.0, vec![(arg.2, arg.3)]))
-                    .await
-                    .unwrap();
-            }
-            tsm_writer.write_index().await.unwrap();
-            tsm_writer.finish().await.unwrap();
-            column_files.push(Arc::new(ColumnFile::new(
-                *tsm_sequence,
-                2,
-                TimeRange::new(tsm_writer.min_ts(), tsm_writer.max_ts()),
-                tsm_writer.size(),
-                false,
-                tsm_writer.path(),
-            )));
-        }
-
+        let column_files = write_data_block_desc(&dir, &data_desc).await;
         let next_file_id = 4_u64;
 
-        let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
-
+        let (compact_req, kernel) = prepare_compaction(
+            tenant_database,
+            opt,
+            next_file_id,
+            column_files,
+            max_level_ts,
+        );
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
 
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
-    #[allow(clippy::type_complexity)]
-    async fn write_data_block_desc(
-        dir: impl AsRef<Path>,
-        data_desc: &[(
-            ColumnFileId,
-            Vec<(ValueType, FieldId, Timestamp, Timestamp)>,
-            Vec<(FieldId, Timestamp, Timestamp)>,
-        )],
-    ) -> Vec<Arc<ColumnFile>> {
-        let mut column_files = Vec::new();
-        for (tsm_sequence, tsm_desc, tombstone_desc) in data_desc.iter() {
-            let mut tsm_writer = tsm::new_tsm_writer(&dir, *tsm_sequence, false, 0)
-                .await
-                .unwrap();
-            for &(val_type, fid, min_ts, max_ts) in tsm_desc.iter() {
-                tsm_writer
-                    .write_block(fid, &generate_data_block(val_type, vec![(min_ts, max_ts)]))
-                    .await
-                    .unwrap();
-            }
-            tsm_writer.write_index().await.unwrap();
-            tsm_writer.finish().await.unwrap();
-            let tsm_tombstone = TsmTombstone::open(&dir, *tsm_sequence).await.unwrap();
-            for (fid, min_ts, max_ts) in tombstone_desc.iter() {
-                tsm_tombstone
-                    .add_range(&[*fid][..], &TimeRange::new(*min_ts, *max_ts), None)
-                    .await
-                    .unwrap();
-            }
-
-            tsm_tombstone.flush().await.unwrap();
-            column_files.push(Arc::new(ColumnFile::new(
-                *tsm_sequence,
-                2,
-                TimeRange::new(tsm_writer.min_ts(), tsm_writer.max_ts()),
-                tsm_writer.size(),
-                false,
-                tsm_writer.path(),
-            )));
-        }
-
-        column_files
-    }
-
+    /// Test compaction with tombstones
     #[tokio::test]
     async fn test_compaction_4() {
         #[rustfmt::skip]
-        let data_desc = [
-            // [( tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)], vec![Option<(FieldId, MinTimestamp, MaxTimestamp)>] )]
-            (1_u64, vec![
+        let data_desc: [DataDesc; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
                 // 1, 1~2500
-                (ValueType::Unsigned, 1_u64, 1_i64, 1000_i64), (ValueType::Unsigned, 1, 1001, 2000), (ValueType::Unsigned, 1, 2001, 2500),
-            ], vec![(1_u64, 1_i64, 2_i64), (1, 2001, 2100)]),
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000), (ValueType::Unsigned, 1, 2001, 2500),
+            ], vec![(1, 1, 2), (1, 2001, 2100)]),
             (2, vec![
                 // 1, 2001~4500
                 // 2101~3100, 3101~4100, 4101~4499
@@ -1486,40 +1828,50 @@ pub mod test {
         );
 
         let dir = "/tmp/test/compaction/4";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
+        let max_level_ts = 6500;
 
         let column_files = write_data_block_desc(&dir, &data_desc).await;
         let next_file_id = 4_u64;
-        let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
-
+        let (compact_req, kernel) = prepare_compaction(
+            tenant_database,
+            opt,
+            next_file_id,
+            column_files,
+            max_level_ts,
+        );
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
 
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
+    /// Test compaction with multi-field and tombstones.
     #[tokio::test]
     async fn test_compaction_5() {
         #[rustfmt::skip]
-        let data_desc = [
-            // [( tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)], vec![Option<(FieldId, MinTimestamp, MaxTimestamp)>] )]
-            (1_u64, vec![
+        let data_desc: [DataDesc; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
                 // 1, 1~2500
-                (ValueType::Unsigned, 1_u64, 1_i64, 1000_i64), (ValueType::Unsigned, 1, 1001, 2000),  (ValueType::Unsigned, 1, 2001, 2500),
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000),  (ValueType::Unsigned, 1, 2001, 2500),
                 // 2, 1~1500
                 (ValueType::Integer, 2, 1, 1000), (ValueType::Integer, 2, 1001, 1500),
                 // 3, 1~1500
                 (ValueType::Boolean, 3, 1, 1000), (ValueType::Boolean, 3, 1001, 1500),
             ], vec![
-                (1_u64, 1_i64, 2_i64), (1, 2001, 2100),
+                (1, 1, 2), (1, 2001, 2100),
                 (2, 1001, 1002),
                 (3, 1499, 1500),
             ]),
@@ -1589,23 +1941,160 @@ pub mod test {
         );
 
         let dir = "/tmp/test/compaction/5";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
+        let max_level_ts = 6500;
 
         let column_files = write_data_block_desc(&dir, &data_desc).await;
         let next_file_id = 4_u64;
-        let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
+        let (compact_req, kernel) = prepare_compaction(
+            tenant_database,
+            opt,
+            next_file_id,
+            column_files,
+            max_level_ts,
+        );
+        let out_level = compact_req.out_level;
+        let (version_edit, _) = run_compaction_job(compact_req, kernel)
+            .await
+            .unwrap()
+            .unwrap();
+
+        check_column_file(dir, version_edit, expected_data, out_level).await;
+    }
+
+    /// Test compaction on level-0 (delta compaction) with multi-field.
+    #[tokio::test]
+    async fn test_compaction_6() {
+        #[rustfmt::skip]
+        let data_desc: [DataDesc; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
+                // 1, 1~2500
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000),  (ValueType::Unsigned, 1, 2001, 2500),
+                // 2, 1~1500
+                (ValueType::Integer, 2, 1, 1000), (ValueType::Integer, 2, 1001, 1500),
+                // 3, 1~1500
+                (ValueType::Boolean, 3, 1, 1000), (ValueType::Boolean, 3, 1001, 1500),
+            ], vec![]),
+            (2, vec![
+                // 1, 2001~4500
+                (ValueType::Unsigned, 1, 2001, 3000), (ValueType::Unsigned, 1, 3001, 4000), (ValueType::Unsigned, 1, 4001, 4500),
+                // 2, 1001~3000
+                (ValueType::Integer, 2, 1001, 2000), (ValueType::Integer, 2, 2001, 3000),
+                // 3, 1001~2500
+                (ValueType::Boolean, 3, 1001, 2000), (ValueType::Boolean, 3, 2001, 2500),
+                // 4, 1~1500
+                (ValueType::Float, 4, 1, 1000), (ValueType::Float, 4, 1001, 1500),
+            ], vec![]),
+            (3, vec![
+                // 1, 4001~6500
+                (ValueType::Unsigned, 1, 4001, 5000), (ValueType::Unsigned, 1, 5001, 6000), (ValueType::Unsigned, 1, 6001, 6500),
+                // 2, 3001~5000
+                (ValueType::Integer, 2, 3001, 4000), (ValueType::Integer, 2, 4001, 5000),
+                // 3, 2001~3500
+                (ValueType::Boolean, 3, 2001, 3000), (ValueType::Boolean, 3, 3001, 3500),
+                // 4. 1001~2500
+                (ValueType::Float, 4, 1001, 2000), (ValueType::Float, 4, 2001, 2500),
+            ], vec![]),
+        ];
+        #[rustfmt::skip]
+        let expected_data_target_level: HashMap<FieldId, Vec<DataBlock>> = HashMap::from(
+            [
+                // 1, 1~6500
+                (1, vec![
+                    generate_data_block(ValueType::Unsigned, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(2001, 3000)]),
+                ]),
+                // 2, 1~5000
+                (2, vec![
+                    generate_data_block(ValueType::Integer, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Integer, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Integer, vec![(2001, 3000)]),
+                ]),
+                // 3, 1~3500
+                (3, vec![
+                    generate_data_block(ValueType::Boolean, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Boolean, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Boolean, vec![(2001, 3000)]),
+                ]),
+                // 4, 1~2500
+                (4, vec![
+                    generate_data_block(ValueType::Float, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Float, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Float, vec![(2001, 2500)]),
+                ]),
+            ]
+        );
+        #[rustfmt::skip]
+        let expected_data_delta_level: HashMap<FieldId, Vec<DataBlock>> = HashMap::from(
+            [
+                // 1, 1~6500
+                (1, vec![
+                    generate_data_block(ValueType::Unsigned, vec![(3001, 4000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(4001, 5000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(5001, 6000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(6001, 6500)]),
+                ]),
+                // 2, 1~5000
+                (2, vec![
+                    generate_data_block(ValueType::Integer, vec![(3001, 4000)]),
+                    generate_data_block(ValueType::Integer, vec![(4001, 5000)]),
+                ]),
+                // 3, 1~3500
+                (3, vec![
+                    generate_data_block(ValueType::Boolean, vec![(3001, 3500)]),
+                ]),
+            ]
+        );
+
+        let dir = "/tmp/test/compaction/6";
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
+        let opt = create_options(dir.to_string());
+        let tsm_dir = opt.storage.tsm_dir(&tenant_database, 1);
+        if !file_manager::try_exists(&tsm_dir) {
+            std::fs::create_dir_all(&tsm_dir).unwrap();
+        }
+        let delta_dir = opt.storage.delta_dir(&tenant_database, 1);
+        if !file_manager::try_exists(&delta_dir) {
+            std::fs::create_dir_all(&delta_dir).unwrap();
+        }
+        let max_level_ts = 9000;
+
+        let column_files = write_data_block_desc(&delta_dir, &data_desc).await;
+        let next_file_id = 4_u64;
+        let (mut compact_req, kernel) = prepare_compaction(
+            tenant_database,
+            opt,
+            next_file_id,
+            column_files,
+            max_level_ts,
+        );
+        compact_req.in_level = 0;
+        compact_req.out_level = 2;
+        compact_req.time_range = TimeRange::new(1, 3000);
 
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
 
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(
+            &delta_dir,
+            version_edit.clone(),
+            expected_data_delta_level,
+            0,
+        )
+        .await;
+        check_column_file(tsm_dir, version_edit, expected_data_target_level, 2).await;
     }
 }

--- a/tskv/src/compaction/flush.rs
+++ b/tskv/src/compaction/flush.rs
@@ -252,7 +252,7 @@ pub async fn run_flush_memtable_job(
         if trigger_compact {
             let _ = ctx
                 .compact_task_sender
-                .send(CompactTask::Vnode(req.ts_family_id))
+                .send(CompactTask::Normal(req.ts_family_id))
                 .await;
         }
     }
@@ -538,15 +538,15 @@ pub mod flush_tests {
         let test_case = flush_test_case_1(&memory_pool, 10);
 
         let ts_family_id = 1;
-        let database = Arc::new("test_db".to_string());
+        let tenant_database = Arc::new("cnosdb.test_db".to_string());
         let global_context = Arc::new(GlobalContext::new());
         let options = Options::from(&config);
         let version = Arc::new(Version::new(
             ts_family_id,
-            database.clone(),
+            tenant_database.clone(),
             options.storage.clone(),
             1,
-            LevelInfo::init_levels(database, 0, options.storage),
+            LevelInfo::init_levels(tenant_database, 0, options.storage),
             test_case.max_level_ts_before,
             Arc::new(ShardedAsyncCache::create_lru_sharded_cache(1)),
         ));

--- a/tskv/src/compaction/mod.rs
+++ b/tskv/src/compaction/mod.rs
@@ -7,31 +7,38 @@ mod picker;
 
 use std::sync::Arc;
 
+use chrono::Utc;
 pub use compact::*;
 pub use flush::*;
+use models::predicate::domain::TimeRange;
 use parking_lot::RwLock;
 pub use picker::*;
 
 use crate::kv_option::StorageOptions;
 use crate::memcache::MemCache;
-use crate::tseries_family::{ColumnFile, Version};
+use crate::tseries_family::{ColumnFile, LevelInfo, Version};
 use crate::{LevelId, TseriesFamilyId};
 
 pub enum CompactTask {
-    Vnode(TseriesFamilyId),
-    ColdVnode(TseriesFamilyId),
+    Normal(TseriesFamilyId),
+    Cold(TseriesFamilyId),
+    Delta(TseriesFamilyId),
 }
 
+#[derive(Debug, Clone)]
 pub struct CompactReq {
-    pub ts_family_id: TseriesFamilyId,
-    pub database: Arc<String>,
+    ts_family_id: TseriesFamilyId,
+    tenant_database: Arc<String>,
     storage_opt: Arc<StorageOptions>,
 
     files: Vec<Arc<ColumnFile>>,
     version: Arc<Version>,
-    pub out_level: LevelId,
+    in_level: LevelId,
+    out_level: LevelId,
+    time_range: TimeRange,
 }
 
+#[derive(Debug, Clone)]
 pub struct FlushReq {
     pub ts_family_id: TseriesFamilyId,
     pub mems: Vec<Arc<RwLock<MemCache>>>,
@@ -52,4 +59,28 @@ impl std::fmt::Display for FlushReq {
             self.force_flush,
         )
     }
+}
+
+fn format_level_infos(levels: &[LevelInfo]) -> String {
+    levels
+        .iter()
+        .map(|l| format!("{l}"))
+        .collect::<Vec<String>>()
+        .join(", ")
+}
+
+fn format_column_files(files: &[Arc<ColumnFile>]) -> String {
+    files
+        .iter()
+        .map(|f| format!("{f}"))
+        .collect::<Vec<String>>()
+        .join(", ")
+}
+
+const PICKER_CONTEXT_DATETIME_FORMAT: &str = "%d%m%Y_%H%M%S_%3f";
+
+fn context_datetime() -> String {
+    Utc::now()
+        .format(PICKER_CONTEXT_DATETIME_FORMAT)
+        .to_string()
 }

--- a/tskv/src/compaction/picker.rs
+++ b/tskv/src/compaction/picker.rs
@@ -1,12 +1,9 @@
 use std::fmt::Debug;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use models::predicate::domain::TimeRange;
 use trace::{debug, info};
 
-use crate::compaction::CompactReq;
-use crate::kv_option::StorageOptions;
+use crate::compaction::{context_datetime, format_column_files, format_level_infos, CompactReq};
 use crate::tseries_family::{ColumnFile, LevelInfo, Version};
 use crate::LevelId;
 
@@ -14,11 +11,16 @@ pub trait Picker: Send + Sync + Debug {
     fn pick_compaction(&self, version: Arc<Version>) -> Option<CompactReq>;
 }
 
-/// Compaction picker for picking files in level
+const LEVEL_WEIGHT_FILE_NUM: [f64; 5] = [1.0, 1.0, 1.0, 1.0, 1.0];
+const LEVEL_WEIGHT_REMAINING_SIZE: [f64; 5] = [1.0, 1.0, 1.0, 1.0, 1.0];
+
+/// Compaction picker for picking a level from level-1 to level-4, and then
+/// pick inner files of the level.
 #[derive(Debug)]
 pub struct LevelCompactionPicker {
-    picking: AtomicBool,
-    storage: Arc<StorageOptions>,
+    /// Datetime when this picker created.
+    strategy: String,
+    datetime: String,
 }
 
 impl Picker for LevelCompactionPicker {
@@ -28,49 +30,25 @@ impl Picker for LevelCompactionPicker {
         //! 3. Get files(`Vec<Arc<ColumnFile>>`) from the picked level, sorted by min_ts(ascending)
         //!    and size(ascending), pick ColumnFile until picking_files_size reaches
         //!    max_compact_size, remove away the last picked files with overlapped time_range.
-        //! 4. Get files(`Vec<Arc<ColumnFile>>`) from level-0, sorted by min_ts(ascending)
-        //!    and size(ascending), pick ColumnFile until picking_files_size reaches
-        //!    max_compact_size.
+        //! 4. (Deprecated and skipped): Pick files from level-0.
         //! 5. Build CompactReq using **version**, picked level and picked files.
 
         debug!(
-            "Picker: Version info: [ {} ]",
-            version
-                .levels_info()
-                .iter()
-                .enumerate()
-                .map(|(i, lvl)| {
-                    format!(
-                        "Level-{}: files: [ {} ]",
-                        i,
-                        lvl.files
-                            .iter()
-                            .map(|f| format!(
-                                "{}(C:{}, {}-{}, {} B)",
-                                f.file_id(),
-                                if f.is_compacting() { "Y" } else { "N" },
-                                f.time_range().min_ts,
-                                f.time_range().max_ts,
-                                f.size()
-                            ))
-                            .collect::<Vec<String>>()
-                            .join(", ")
-                    )
-                })
-                .collect::<Vec<String>>()
-                .join(", ")
+            "Picker: strategy: {}, version: [ {} ]",
+            self.strategy,
+            format_level_infos(version.levels_info())
         );
 
         let storage_opt = version.storage_opt();
         let level_infos = version.levels_info();
 
-        // Pick a level to compact with level 0
+        // Pick a level to compact
         let level_start: &LevelInfo;
+        let in_level;
         let out_level;
-
         if let Some((start_lvl, out_lvl)) = self.pick_level(level_infos) {
-            info!("Picker: picked level: {} to {}", start_lvl, out_lvl);
             level_start = &level_infos[start_lvl as usize];
+            in_level = start_lvl;
             out_level = out_lvl;
 
             // If start_lvl is L1, compare the number of L1 files
@@ -80,86 +58,55 @@ impl Picker for LevelCompactionPicker {
                 && (level_infos[1].files.len() as u32) < storage_opt.compact_trigger_file_num
             {
                 info!(
-                    "Picker: picked L1 files({}) does not reach trigger({}), return None",
+                    "Picker: strategy: {}, picked L1 files({}) does not reach trigger({}), return None",
+                    self.strategy,
                     level_infos[1].files.len(),
                     storage_opt.compact_trigger_file_num
                 );
                 return None;
             }
         } else {
-            info!("Picker: picked no level");
+            info!("Picker: strategy: {}, picked no level", self.strategy);
             return None;
         }
 
         // Pick selected level files.
-        let mut picking_files: Vec<Arc<ColumnFile>> = Vec::new();
-        let (mut picking_files_size, picking_time_range) = if level_start.files.is_empty() {
-            info!("Picker: picked no files from level {}", level_start.level);
+        if level_start.files.is_empty() {
             return None;
-        } else {
-            let mut files = level_start.files.clone();
-            files.sort_by(Self::compare_column_file);
-            Self::pick_files(files, storage_opt.max_compact_size, &mut picking_files)
-        };
-
-        // Pick level 0 files.
-        let mut files = level_infos[0].files.clone();
-        files.sort_by(Self::compare_column_file);
-        for file in files.iter() {
-            if file.time_range().min_ts > picking_time_range.max_ts {
-                break;
-            }
-            if file.is_compacting() || !file.time_range().overlaps(&picking_time_range) {
-                continue;
-            }
-            if !file.mark_compacting() {
-                // If file already compacting, continue to next file.
-                continue;
-            }
-            picking_files.push(file.clone());
-            picking_files_size += file.size();
-
-            if picking_files_size > storage_opt.max_compact_size {
-                // Picked file size >= max_compact_size, try break picking files.
-                break;
-            }
         }
 
-        // Even if picked only 1 file, send it to the next level.
-
+        let mut files = level_start.files.clone();
+        files.sort_by(Self::compare_column_file);
+        let picking_files: Vec<Arc<ColumnFile>> =
+            Self::pick_files(files, storage_opt.max_compact_size);
         info!(
-            "Picker: Picked files: [ {} ]",
-            picking_files
-                .iter()
-                .map(|f| {
-                    format!(
-                        "{{ Level-{}, file_id: {}, time_range: {}-{} }}",
-                        f.level(),
-                        f.file_id(),
-                        f.time_range().min_ts,
-                        f.time_range().max_ts
-                    )
-                })
-                .collect::<Vec<String>>()
-                .join(", ")
+            "Picker: strategy: {}, Picked files: [ {} ]",
+            self.strategy,
+            format_column_files(&picking_files)
         );
+        if picking_files.is_empty() {
+            return None;
+        }
 
+        // Run compaction and send them to the next level, even if picked only 1 file,.
         Some(CompactReq {
             ts_family_id: version.tf_id(),
-            database: version.tenant_database(),
+            tenant_database: version.tenant_database(),
             storage_opt: version.storage_opt(),
             files: picking_files,
             version: version.clone(),
+            in_level,
             out_level,
+            time_range: level_infos[out_level as usize].time_range,
         })
     }
 }
 
 impl LevelCompactionPicker {
-    pub fn new(storage_opt: Arc<StorageOptions>) -> LevelCompactionPicker {
+    pub fn new() -> LevelCompactionPicker {
         Self {
-            picking: AtomicBool::new(false),
-            storage: storage_opt,
+            strategy: "normal".to_string(),
+            datetime: context_datetime(),
         }
     }
 
@@ -247,8 +194,9 @@ impl LevelCompactionPicker {
             score_a.partial_cmp(score_b).expect("a NaN score").reverse()
         });
 
-        info!(
-            "Picker: Calculate level scores: [ {} ]",
+        debug!(
+            "Picker: strategy: {}, level scores: [ {} ]",
+            self.strategy,
             level_scores
                 .iter()
                 .map(|lc| format!("{{ Level-{}: {} }}", lc.0, lc.4))
@@ -265,30 +213,147 @@ impl LevelCompactionPicker {
         })
     }
 
-    fn pick_files(
-        src_files: Vec<Arc<ColumnFile>>,
-        max_compact_size: u64,
-        dst_files: &mut Vec<Arc<ColumnFile>>,
-    ) -> (u64, TimeRange) {
+    fn pick_files(src_files: Vec<Arc<ColumnFile>>, max_compact_size: u64) -> Vec<Arc<ColumnFile>> {
+        let mut dst_files = Vec::with_capacity(src_files.len());
+
         let mut picking_file_size = 0_u64;
-        let mut picking_time_range = TimeRange::none();
         for file in src_files.iter() {
             if file.is_compacting() || !file.mark_compacting() {
                 // If file already compacting, continue to next file.
                 continue;
             }
             picking_file_size += file.size();
-            picking_time_range.merge(file.time_range());
             dst_files.push(file.clone());
 
             if picking_file_size >= max_compact_size {
                 // Picked file size >= max_compact_size, try break picking files.
-                picking_file_size -= file.size();
                 break;
             }
         }
 
-        (picking_file_size, picking_time_range)
+        dst_files
+    }
+}
+
+/// Compaction picker for picking files in level-0 (delta files)
+#[derive(Debug)]
+pub struct DeltaCompactionPicker {
+    strategy: String,
+    /// Datetime when this picker created.
+    datetime: String,
+}
+
+impl Picker for DeltaCompactionPicker {
+    fn pick_compaction(&self, version: Arc<Version>) -> Option<CompactReq> {
+        debug!(
+            "Picker: strategy: {}, version: [ {} ]",
+            self.strategy,
+            format_level_infos(version.levels_info())
+        );
+
+        let levels = version.levels_info();
+        if levels[0].files.is_empty() {
+            return None;
+        }
+
+        let mut level_overlaped_files: [Vec<Arc<ColumnFile>>; 5] =
+            [vec![], Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+        let mut file_picked: bool;
+        let mut level_picking: usize;
+        for file in levels[0].files.iter() {
+            if file.is_compacting() {
+                continue;
+            }
+            file_picked = false;
+            level_picking = 4;
+            // Form level-4 to level-1, put the overlapped files.
+            for level in levels.iter().skip(1).rev() {
+                if file.time_range().min_ts < level.time_range.max_ts {
+                    level_overlaped_files[level_picking].push(file.clone());
+                    file_picked = true;
+                    break;
+                }
+                level_picking -= 1;
+            }
+            // If time_range of a file is too old than level-4, put to level-4 files.
+            if !file_picked {
+                level_overlaped_files[4].push(file.clone());
+            }
+        }
+        debug!(
+            "Picker: strategy: {}, level overlaped files: [ {} ]",
+            self.strategy,
+            level_overlaped_files
+                .iter()
+                .enumerate()
+                .map(|(i, files)| format!("{{ Level-{}: {} }}", i, files.len()))
+                .collect::<Vec<String>>()
+                .join(", ")
+        );
+
+        // Find the level with maximum overlaped level-0 files.
+        let mut out_level = 0;
+        let mut max_files = 0_usize;
+        for (i, files) in level_overlaped_files.iter().enumerate() {
+            if files.len() > max_files {
+                out_level = i;
+                max_files = files.len();
+            }
+        }
+        if out_level == 0 || max_files == 0 {
+            info!(
+                "Picker: strategy: {}, picked out-level is 0 or picked no files",
+                self.strategy
+            );
+            return None;
+        }
+
+        // Pick files from level-0 files overlapped with that level.
+        let max_compact_size = version.storage_opt().max_compact_size;
+        let mut picking_files = Vec::with_capacity(level_overlaped_files.len());
+        let mut picking_file_size = 0_u64;
+        for file in level_overlaped_files[out_level].iter() {
+            if file.is_compacting() || !file.mark_compacting() {
+                // If file already compacting, continue to next file.
+                continue;
+            }
+            picking_file_size += file.size();
+            picking_files.push(file.clone());
+
+            if picking_file_size >= max_compact_size {
+                // Picked file size >= max_compact_size
+                break;
+            }
+        }
+        info!(
+            "Picker: strategy: {}, Picked files: [ {} ]",
+            self.strategy,
+            format_column_files(&picking_files)
+        );
+        if picking_files.is_empty() {
+            return None;
+        }
+
+        // Run compaction and send them to the target level, even if picked only 1 file,.
+        Some(CompactReq {
+            ts_family_id: version.tf_id(),
+            tenant_database: version.tenant_database(),
+            storage_opt: version.storage_opt(),
+            files: picking_files,
+            version: version.clone(),
+            in_level: 0,
+            out_level: out_level as u32,
+            time_range: levels[out_level].time_range,
+        })
+    }
+}
+
+impl DeltaCompactionPicker {
+    pub fn new() -> Self {
+        Self {
+            strategy: "delta".to_string(),
+            datetime: context_datetime(),
+        }
     }
 }
 
@@ -302,7 +367,7 @@ mod test {
     use models::predicate::domain::TimeRange;
 
     use crate::compaction::test::create_options;
-    use crate::compaction::{LevelCompactionPicker, Picker};
+    use crate::compaction::{DeltaCompactionPicker, LevelCompactionPicker, Picker};
     use crate::file_utils::make_tsm_file;
     use crate::kv_option::Options;
     use crate::memcache::MemCache;
@@ -388,11 +453,11 @@ mod test {
     }
 
     #[test]
-    fn test_pick_1() {
+    fn test_pick_level_files_1() {
         //! There are Level 0-4, and Level 1 is now in compaction.
         //! In this case, Level 2, and serial files in Level 0 will be picked,
         //! and compact to Level 3.
-        let dir = "/tmp/test/pick/1";
+        let dir = "/tmp/test/pick/level_files_1";
         let opt = create_options(dir.to_string());
 
         #[rustfmt::skip]
@@ -422,11 +487,58 @@ mod test {
             ]), // 0.00001
         ];
 
-        let storage_opt = opt.storage.clone();
         let tsf = create_tseries_family(Arc::new("dba".to_string()), opt, levels_sketch);
-        let picker = LevelCompactionPicker::new(storage_opt);
+        let picker = LevelCompactionPicker::new();
         let compact_req = picker.pick_compaction(tsf.version()).unwrap();
         assert_eq!(compact_req.out_level, 2);
         assert_eq!(compact_req.files.len(), 2);
+    }
+
+    #[test]
+    fn test_pick_delta_files_1() {
+        //! There are Level 0-4, and Level 0 is now in compaction.
+        //! In this case, Level 2, and serial files in Level 0 will be picked,
+        //! and compact to Level 3.
+        let dir = "/tmp/test/pick/delta_files_1";
+        let opt = create_options(dir.to_string());
+
+        #[rustfmt::skip]
+        let levels_sketch: LevelsSketch = vec![
+            // vec![( level, Timestamp_Begin, Timestamp_end, vec![(file_id, Timestamp_Begin, Timestamp_end, size, being_compact)] )]
+            (0_u32, 1_i64, 370_i64, vec![
+                (11_u64, 1_i64, 5_i64, 10_u64, false), // 4
+                (12, 10, 20, 10, true),                // 4
+                (12, 30, 40, 10, false),               // 4
+                (12, 110, 120, 10, false),             // 4
+                (12, 230, 240, 10, false),             // 3
+                (12, 300, 350, 10, false),             // 3
+                (12, 340, 350, 10, false),             // 2
+                (12, 360, 370, 10, false),             // 1
+            ]),
+            (1, 341, 380, vec![
+                (7, 341, 350, 1000, false),
+                (8, 351, 360, 1000, false),
+                (9, 361, 370, 1000, true),
+                (10, 371, 380, 1000, true),
+            ]), // 1
+            (2, 301, 340, vec![
+                (5, 301, 320, 2000, false),
+                (6, 321, 340, 2000, false),
+            ]), // 1
+            (3, 201, 300, vec![
+                (3, 201, 250, 5000, false),
+                (4, 251, 300, 5000, false),
+            ]), // 2
+            (4, 1, 200, vec![
+                (1, 10, 100, 10000, false),
+                (2, 101, 200, 10000, false),
+            ]), // 3
+        ];
+
+        let tsf = create_tseries_family(Arc::new("dba".to_string()), opt, levels_sketch);
+        let picker = DeltaCompactionPicker::new();
+        let compact_req = picker.pick_compaction(tsf.version()).unwrap();
+        assert_eq!(compact_req.out_level, 4);
+        assert_eq!(compact_req.files.len(), 3);
     }
 }

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -203,6 +203,11 @@ impl Database {
         if let Some(tsf) = self.ts_families.get(&tsf_id) {
             return Ok(tsf.clone());
         }
+        schedule_vnode_compaction(
+            self.runtime.clone(),
+            tf.clone(),
+            ctx.compact_task_sender.clone(),
+        );
         self.ts_families.insert(tsf_id, tf.clone());
 
         let (task_state_sender, _task_state_receiver) = oneshot::channel();

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -1206,7 +1206,7 @@ impl Engine for TsKv {
                     }
                 }
 
-                let picker = LevelCompactionPicker::new(self.ctx.options.storage.clone());
+                let picker = LevelCompactionPicker::new();
                 let version = ts_family.read().await.version();
                 if let Some(req) = picker.pick_compaction(version) {
                     match compaction::run_compaction_job(req, self.ctx.global_ctx.clone()).await {

--- a/tskv/src/summary.rs
+++ b/tskv/src/summary.rs
@@ -799,17 +799,17 @@ impl SummaryScheduler {
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
-    use std::fs;
     use std::sync::Arc;
 
+    use config::Config;
     use memory_pool::GreedyMemoryPool;
     use meta::model::meta_admin::AdminMeta;
-    use meta::model::MetaRef;
     use metrics::metric_register::MetricsRegister;
     use models::schema::{make_owner, DatabaseSchema, TenantOptions};
     use tokio::runtime::Runtime;
     use tokio::sync::mpsc;
     use tokio::sync::mpsc::Sender;
+    use tokio::task::JoinHandle;
     use utils::BloomFilter;
 
     use crate::compaction::{CompactTask, FlushReq};
@@ -846,374 +846,394 @@ mod test {
         assert_eq!(ves, ves_2);
     }
 
-    #[test]
-    fn test_summary() {
-        let mut config = config::get_config_for_test();
+    struct SummaryTestHelper {
+        test_case_name: String,
+        base_dir: String,
+        config: Config,
+        options: Arc<Options>,
+        runtime: Arc<Runtime>,
+        summary_task_sender: Sender<SummaryTask>,
+        summary_job: JoinHandle<()>,
+        flush_task_sender: Sender<FlushReq>,
+        flush_job: JoinHandle<()>,
+        compact_task_sender: Sender<CompactTask>,
+        compact_job: JoinHandle<()>,
+    }
 
-        let runtime = Arc::new(
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .worker_threads(4)
-                .build()
-                .unwrap(),
-        );
-
-        // NOTICE: Make sure these channel senders are dropped before test_summary() finished.
-        let (summary_task_sender, mut summary_task_receiver) =
-            mpsc::channel::<SummaryTask>(SUMMARY_REQ_CHANNEL_CAP);
-        let summary_job_mock = runtime.spawn(async move {
-            println!("Mock summary job started (test_summary).");
-            while let Some(t) = summary_task_receiver.recv().await {
-                // Do nothing
-                let _ = t.request.call_back.send(Ok(()));
-            }
-            println!("Mock summary job finished (test_summary).");
-        });
-        let (flush_task_sender, mut flush_task_receiver) =
-            mpsc::channel::<FlushReq>(config.storage.flush_req_channel_cap);
-        let flush_job_mock = runtime.spawn(async move {
-            println!("Mock flush job started (test_summary).");
-            while flush_task_receiver.recv().await.is_some() {
-                // Do nothing
-            }
-            println!("Mock flush job finished (test_summary).");
-        });
-        let (compact_task_sender, mut compact_task_receiver) =
-            mpsc::channel::<CompactTask>(COMPACT_REQ_CHANNEL_CAP);
-        let compact_job_mock = runtime.spawn(async move {
-            println!("Mock compact job started (test_summary).");
-            while compact_task_receiver.recv().await.is_some() {
-                // Do nothing
-            }
-            println!("Mock compact job finished (test_summary).");
-        });
-
-        let (wal_sender, _wal_task_receiver) = mpsc::channel(1024 * 10);
-
-        let runtime_ref = runtime.clone();
-        runtime.block_on(async move {
-            println!("Running test: test_summary_recover");
-            let base_dir = "/tmp/test/summary/test_summary_recover".to_string();
-            let _ = fs::remove_dir_all(&base_dir);
-            fs::create_dir_all(&base_dir).unwrap();
+    impl SummaryTestHelper {
+        fn new(mut config: Config, base_dir: String, test_case_name: String) -> Self {
             config.storage.path = base_dir.clone();
-            test_summary_recover(
-                config.clone(),
-                runtime_ref.clone(),
-                compact_task_sender.clone(),
-            )
-            .await;
+            config.log.path = base_dir.clone();
+            let options = Arc::new(Options::from(&config));
 
-            println!("Running test: test_tsf_num_recover");
-            let base_dir = "/tmp/test/summary/test_tsf_num_recover".to_string();
-            let _ = fs::remove_dir_all(&base_dir);
-            fs::create_dir_all(&base_dir).unwrap();
-            config.storage.path = base_dir.clone();
-            test_tsf_num_recover(
-                config.clone(),
-                runtime_ref.clone(),
-                compact_task_sender.clone(),
-            )
-            .await;
+            let runtime = Arc::new(
+                tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .worker_threads(4)
+                    .build()
+                    .unwrap(),
+            );
 
-            let base_dir = "/tmp/test/summary/test_recover_summary_with_roll".to_string();
-            config.storage.path = base_dir.clone();
-            let meta_manager: MetaRef = AdminMeta::new(config.clone()).await;
-            meta_manager.add_data_node().await.unwrap();
-            let _ = meta_manager
-                .create_tenant("cnosdb".to_string(), TenantOptions::default())
-                .await;
-
-            let options = Arc::new(crate::Options::from(&config));
-            let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
-
-            /***************************************************** */
-            println!("Running test: test_recover_summary_with_roll_0");
-            let _ = fs::remove_dir_all(&base_dir);
-            fs::create_dir_all(&base_dir).unwrap();
-            let summary = Summary::new(
-                options.clone(),
-                runtime_ref.clone(),
-                meta_manager.clone(),
-                memory_pool.clone(),
-                Arc::new(MetricsRegister::default()),
-            )
-            .await
-            .unwrap();
-
-            let ctx = Arc::new(TsKvContext {
-                options: options.clone(),
-                wal_sender: wal_sender.clone(),
-                flush_task_sender: flush_task_sender.clone(),
-                compact_task_sender: compact_task_sender.clone(),
-                summary_task_sender: summary_task_sender.clone(),
-                version_set: summary.version_set(),
-                global_ctx: Arc::new(GlobalContext::new()),
+            // NOTICE: Make sure these channel senders are dropped before test_summary() finished.
+            let (summary_task_sender, mut summary_task_receiver) =
+                mpsc::channel::<SummaryTask>(SUMMARY_REQ_CHANNEL_CAP);
+            let test_case_name_clone = test_case_name.clone();
+            let summary_job = runtime.spawn(async move {
+                println!("Mock summary job started ({test_case_name_clone}).");
+                while let Some(t) = summary_task_receiver.recv().await {
+                    // Do nothing
+                    let _ = t.request.call_back.send(Ok(()));
+                }
+                println!("Mock summary job finished ({test_case_name_clone}).");
+            });
+            let (flush_task_sender, mut flush_task_receiver) =
+                mpsc::channel::<FlushReq>(config.storage.flush_req_channel_cap);
+            let test_case_name_clone = test_case_name.clone();
+            let flush_job = runtime.spawn(async move {
+                println!("Mock flush job started ({test_case_name_clone}).");
+                while flush_task_receiver.recv().await.is_some() {
+                    // Do nothing
+                }
+                println!("Mock flush job finished ({test_case_name_clone}).");
+            });
+            let (compact_task_sender, mut compact_task_receiver) =
+                mpsc::channel::<CompactTask>(COMPACT_REQ_CHANNEL_CAP);
+            let test_case_name_clone = test_case_name.clone();
+            let compact_job = runtime.spawn(async move {
+                println!("Mock compact job started ({test_case_name_clone}).");
+                while compact_task_receiver.recv().await.is_some() {
+                    // Do nothing
+                }
+                println!("Mock compact job finished ({test_case_name_clone}).");
             });
 
-            test_recover_summary_with_roll_0(runtime_ref.clone(), meta_manager.clone(), ctx).await;
-
-            /***************************************************** */
-            println!("Running test: test_recover_summary_with_roll_1");
-            let _ = fs::remove_dir_all(&base_dir);
-            fs::create_dir_all(&base_dir).unwrap();
-            let summary = Summary::new(
-                options.clone(),
-                runtime_ref.clone(),
-                meta_manager.clone(),
-                memory_pool.clone(),
-                Arc::new(MetricsRegister::default()),
-            )
-            .await
-            .unwrap();
-            let ctx = Arc::new(TsKvContext {
+            Self {
+                test_case_name,
+                base_dir,
+                config,
                 options,
-                wal_sender,
-                flush_task_sender,
-                compact_task_sender,
+                runtime,
                 summary_task_sender,
-                version_set: summary.version_set(),
-                global_ctx: Arc::new(GlobalContext::new()),
-            });
-            test_recover_summary_with_roll_1(runtime_ref.clone(), meta_manager.clone(), ctx).await;
+                summary_job,
+                flush_task_sender,
+                flush_job,
+                compact_task_sender,
+                compact_job,
+            }
+        }
 
-            let _ = tokio::join!(summary_job_mock, flush_job_mock, compact_job_mock);
+        fn with_default_config(base_dir: String, test_case_name: String) -> Self {
+            let config = config::get_config_for_test();
+            Self::new(config, base_dir, test_case_name)
+        }
+
+        fn init(
+            &self,
+        ) -> (
+            Arc<AdminMeta>,
+            Arc<GreedyMemoryPool>,
+            Summary,
+            Arc<TsKvContext>,
+        ) {
+            self.runtime.block_on(async {
+                let meta_manager = AdminMeta::new(self.config.clone()).await;
+                meta_manager
+                    .add_data_node()
+                    .await
+                    .map_err(|e| format!("[{}] {e}", &self.test_case_name))
+                    .unwrap();
+                // TODO(zipper): `create_tenant()` add option: ignore already existed tenant.
+                let _ = meta_manager
+                    .create_tenant("cnosdb".to_string(), TenantOptions::default())
+                    .await;
+                let summary_dir = self.options.storage.summary_dir();
+                if !file_manager::try_exists(&summary_dir) {
+                    std::fs::create_dir_all(&summary_dir)
+                        .map_err(|e| format!("[{}] {e}", &self.test_case_name))
+                        .unwrap();
+                }
+                let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
+                let summary = Summary::new(
+                    self.options.clone(),
+                    self.runtime.clone(),
+                    meta_manager.clone(),
+                    memory_pool.clone(),
+                    Arc::new(MetricsRegister::default()),
+                )
+                .await
+                .map_err(|e| format!("[{}] {e}", &self.test_case_name))
+                .unwrap();
+
+                let (wal_task_sender, _wal_task_receiver) = mpsc::channel(1);
+                let tskv_context = Arc::new(TsKvContext {
+                    options: self.options.clone(),
+                    wal_sender: wal_task_sender,
+                    flush_task_sender: self.flush_task_sender.clone(),
+                    compact_task_sender: self.compact_task_sender.clone(),
+                    summary_task_sender: self.summary_task_sender.clone(),
+                    version_set: summary.version_set.clone(),
+                    global_ctx: Arc::new(GlobalContext::new()),
+                });
+
+                (meta_manager, memory_pool, summary, tskv_context)
+            })
+        }
+
+        fn join(self) {
+            let SummaryTestHelper {
+                summary_task_sender,
+                summary_job,
+                flush_task_sender,
+                flush_job,
+                compact_task_sender,
+                compact_job,
+                ..
+            } = self;
+            drop(summary_task_sender);
+            drop(flush_task_sender);
+            drop(compact_task_sender);
+            let _ = self
+                .runtime
+                .block_on(async { tokio::join!(summary_job, flush_job, compact_job,) });
+        }
+    }
+
+    #[test]
+    fn test_summary_recover() {
+        let base_dir = "/tmp/test/summary/test_summary_recover";
+        let _ = std::fs::remove_dir_all(base_dir);
+        std::fs::create_dir_all(base_dir).unwrap();
+        let test_helper = SummaryTestHelper::with_default_config(
+            base_dir.to_string(),
+            "test_summary_recover".to_string(),
+        );
+        let runtime = test_helper.runtime.clone();
+        let options = test_helper.options.clone();
+
+        let (meta_manager, memory_pool, mut summary_1, _ctx) = test_helper.init();
+        #[rustfmt::skip]
+        runtime.block_on(summary_1.apply_version_edit(
+            vec![VersionEdit::new_add_vnode(100, "cnosdb.hello".to_string(), 0)],
+            HashMap::new(),
+            HashMap::new(),
+        )).unwrap();
+
+        let summary_2 = runtime
+            .block_on(Summary::recover(
+                meta_manager,
+                options,
+                runtime.clone(),
+                memory_pool,
+                test_helper.compact_task_sender.clone(),
+                false,
+                Arc::new(MetricsRegister::default()),
+            ))
+            .unwrap();
+
+        // TODO(zipper): compare summary_1 with summary_2
+        drop(summary_1);
+        drop(summary_2);
+        drop(_ctx);
+        test_helper.join();
+    }
+
+    #[test]
+    fn test_tsf_num_recover() {
+        let base_dir = "/tmp/test/summary/test_tsf_num_recover";
+        let _ = std::fs::remove_dir_all(base_dir);
+        std::fs::create_dir_all(base_dir).unwrap();
+        let test_helper = SummaryTestHelper::with_default_config(
+            base_dir.to_string(),
+            "test_tsf_num_recover".to_string(),
+        );
+        let runtime = test_helper.runtime.clone();
+        let runtime_inner = runtime.clone();
+        let options = test_helper.options.clone();
+        let compact_task_sender = test_helper.compact_task_sender.clone();
+
+        let (meta_manager, memory_pool, mut summary_1, _ctx) = test_helper.init();
+
+        let edit = VersionEdit::new_add_vnode(100, "cnosdb.test_tsf_num_recover".to_string(), 0);
+        runtime
+            .block_on(summary_1.apply_version_edit(vec![edit], HashMap::new(), HashMap::new()))
+            .unwrap();
+        drop(summary_1);
+
+        runtime.block_on(async move {
+            let mut summary = Summary::recover(
+                meta_manager.clone(),
+                options.clone(),
+                runtime_inner.clone(),
+                memory_pool.clone(),
+                compact_task_sender.clone(),
+                false,
+                Arc::new(MetricsRegister::default()),
+            )
+            .await
+            .unwrap();
+            assert_eq!(summary.version_set.read().await.tsf_num().await, 1);
+            let edit = VersionEdit::new_del_vnode(100);
+            summary
+                .apply_version_edit(vec![edit], HashMap::new(), HashMap::new())
+                .await
+                .unwrap();
+            drop(summary);
+
+            let summary = Summary::recover(
+                meta_manager,
+                options,
+                runtime_inner,
+                memory_pool,
+                compact_task_sender,
+                false,
+                Arc::new(MetricsRegister::default()),
+            )
+            .await
+            .unwrap();
+            assert_eq!(summary.version_set.read().await.tsf_num().await, 0);
         });
+
+        drop(_ctx);
+        test_helper.join();
     }
 
-    async fn test_summary_recover(
-        config: config::Config,
-        runtime: Arc<Runtime>,
-        compact_task_sender: Sender<CompactTask>,
-    ) {
-        let opt = Arc::new(Options::from(&config));
-        let meta_manager = AdminMeta::new(config.clone()).await;
+    #[test]
+    fn test_recover_summary_with_roll_0() {
+        let base_dir = "/tmp/test/summary/test_recover_summary_with_roll_0";
+        let _ = std::fs::remove_dir_all(base_dir);
+        std::fs::create_dir_all(base_dir).unwrap();
+        let database = "test_recover_summary_with_roll_0";
+        let owned_database = make_owner("cnosdb", database);
+        let mut config = config::get_config_for_test();
+        config.storage.max_summary_size = 128;
+        let test_helper = SummaryTestHelper::new(
+            config,
+            base_dir.to_string(),
+            "test_recover_summary_with_roll_0".to_string(),
+        );
+        let runtime = test_helper.runtime.clone();
+        let runtime_inner = runtime.clone();
+        let options = test_helper.options.clone();
+        let summary_task_sender = test_helper.summary_task_sender.clone();
+        let compact_task_sender = test_helper.compact_task_sender.clone();
 
-        meta_manager.add_data_node().await.unwrap();
+        let (meta_manager, memory_pool, mut summary_1, ctx) = test_helper.init();
 
-        let _ = meta_manager
-            .create_tenant("cnosdb".to_string(), TenantOptions::default())
-            .await;
-        let summary_dir = opt.storage.summary_dir();
-        if !file_manager::try_exists(&summary_dir) {
-            std::fs::create_dir_all(&summary_dir).unwrap();
-        }
-        let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
-        let mut summary = Summary::new(
-            opt.clone(),
-            runtime.clone(),
-            meta_manager.clone(),
-            memory_pool.clone(),
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-        let edit = VersionEdit::new_add_vnode(100, "cnosdb.hello".to_string(), 0);
-        summary
-            .apply_version_edit(vec![edit], HashMap::new(), HashMap::new())
-            .await
-            .unwrap();
-        let _summary = Summary::recover(
-            meta_manager,
-            opt.clone(),
-            runtime.clone(),
-            memory_pool,
-            compact_task_sender,
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-    }
-
-    async fn test_tsf_num_recover(
-        config: config::Config,
-        runtime: Arc<Runtime>,
-        compact_task_sender: Sender<CompactTask>,
-    ) {
-        let opt = Arc::new(Options::from(&config));
-        let meta_manager: MetaRef = AdminMeta::new(config.clone()).await;
-
-        meta_manager.add_data_node().await.unwrap();
-
-        let _ = meta_manager
-            .create_tenant("cnosdb".to_string(), TenantOptions::default())
-            .await;
-        let summary_dir = opt.storage.summary_dir();
-        if !file_manager::try_exists(&summary_dir) {
-            std::fs::create_dir_all(&summary_dir).unwrap();
-        }
-        let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
-        let mut summary = Summary::new(
-            opt.clone(),
-            runtime.clone(),
-            meta_manager.clone(),
-            memory_pool.clone(),
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-
-        let edit = VersionEdit::new_add_vnode(100, "cnosdb.hello".to_string(), 0);
-        summary
-            .apply_version_edit(vec![edit], HashMap::new(), HashMap::new())
-            .await
-            .unwrap();
-        let mut summary = Summary::recover(
-            meta_manager.clone(),
-            opt.clone(),
-            runtime.clone(),
-            memory_pool.clone(),
-            compact_task_sender.clone(),
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-        assert_eq!(summary.version_set.read().await.tsf_num().await, 1);
-        let edit = VersionEdit::new_del_vnode(100);
-        summary
-            .apply_version_edit(vec![edit], HashMap::new(), HashMap::new())
-            .await
-            .unwrap();
-        let summary = Summary::recover(
-            meta_manager,
-            opt.clone(),
-            runtime,
-            memory_pool.clone(),
-            compact_task_sender,
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-        assert_eq!(summary.version_set.read().await.tsf_num().await, 0);
-    }
-
-    // tips : we can use a small max_summary_size
-    #[allow(clippy::too_many_arguments)]
-    async fn test_recover_summary_with_roll_0(
-        runtime: Arc<Runtime>,
-        meta_manager: MetaRef,
-        ctx: Arc<TsKvContext>,
-    ) {
-        let database = "test".to_string();
-        let summary_dir = ctx.options.storage.summary_dir();
-        if !file_manager::try_exists(&summary_dir) {
-            std::fs::create_dir_all(&summary_dir).unwrap();
-        }
-        let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
-
-        let mut summary = Summary::new(
-            ctx.options.clone(),
-            runtime.clone(),
-            meta_manager.clone(),
-            memory_pool.clone(),
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-
-        let mut edits = vec![];
-        let db = summary
-            .version_set
-            .write()
-            .await
-            .create_db(DatabaseSchema::new("cnosdb", &database))
-            .await
-            .unwrap();
-        for i in 0..40 {
-            db.write()
+        runtime.block_on(async {
+            let mut edits = vec![];
+            let db = summary_1
+                .version_set
+                .write()
                 .await
-                .add_tsfamily(i, None, ctx.clone())
+                .create_db(DatabaseSchema::new("cnosdb", database))
                 .await
-                .expect("add tsfamily successfully");
-            let edit = VersionEdit::new_add_vnode(i, make_owner("cnosdb", &database), 0);
-            edits.push(edit.clone());
-        }
-
-        for _ in 0..100 {
+                .unwrap();
+            // Add 20 vnodes
             for i in 0..20 {
                 db.write()
                     .await
-                    .del_tsfamily(i, ctx.summary_task_sender.clone())
-                    .await;
-                edits.push(VersionEdit::new_del_vnode(i));
+                    .add_tsfamily(i, None, ctx.clone())
+                    .await
+                    .expect("add tsfamily successfully");
+                let edit = VersionEdit::new_add_vnode(i, owned_database.to_string(), 0);
+                edits.push(edit.clone());
             }
-        }
-        summary
-            .apply_version_edit(edits, HashMap::new(), HashMap::new())
+            summary_1
+                .apply_version_edit(edits.drain(..).collect(), HashMap::new(), HashMap::new())
+                .await
+                .unwrap();
+            // Do delete vnode for 10 times.
+            for _ in 0..10 {
+                edits.truncate(0);
+                // Delete 10 vnodes
+                for i in 0..10 {
+                    db.write()
+                        .await
+                        .del_tsfamily(i, summary_task_sender.clone())
+                        .await;
+                    edits.push(VersionEdit::new_del_vnode(i));
+                }
+                summary_1
+                    .apply_version_edit(edits.drain(..).collect(), HashMap::new(), HashMap::new())
+                    .await
+                    .unwrap();
+            }
+        });
+
+        runtime.block_on(async move {
+            let summary = Summary::recover(
+                meta_manager,
+                options,
+                runtime_inner,
+                memory_pool,
+                compact_task_sender,
+                false,
+                Arc::new(MetricsRegister::default()),
+            )
             .await
             .unwrap();
+            assert_eq!(summary.version_set.read().await.tsf_num().await, 10);
+        });
 
-        let summary = Summary::recover(
-            meta_manager.clone(),
-            ctx.options.clone(),
-            runtime,
-            memory_pool.clone(),
-            ctx.compact_task_sender.clone(),
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(summary.version_set.read().await.tsf_num().await, 20);
+        drop(summary_task_sender);
+        drop(summary_1);
+        drop(ctx);
+        test_helper.join();
     }
 
-    #[allow(clippy::too_many_arguments)]
-    async fn test_recover_summary_with_roll_1(
-        runtime: Arc<Runtime>,
-        meta_manager: MetaRef,
-        ctx: Arc<TsKvContext>,
-    ) {
-        let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
+    #[test]
+    fn test_recover_summary_with_roll_1() {
+        let base_dir = "/tmp/test/summary/test_recover_summary_with_roll_1";
+        let _ = std::fs::remove_dir_all(base_dir);
+        std::fs::create_dir_all(base_dir).unwrap();
+        let database = "test_recover_summary_with_roll_1";
+        let owned_database = make_owner("cnosdb", database);
+        const VNODE_ID: u32 = 10;
+        let mut config = config::get_config_for_test();
+        config.storage.max_summary_size = 256;
+        let test_helper = SummaryTestHelper::new(
+            config,
+            base_dir.to_string(),
+            "test_recover_summary_with_roll_1".to_string(),
+        );
+        let runtime = test_helper.runtime.clone();
+        let runtime_inner = runtime.clone();
+        let options = test_helper.options.clone();
+        let summary_task_sender = test_helper.summary_task_sender.clone();
+        let compact_task_sender = test_helper.compact_task_sender.clone();
 
-        let database = "test".to_string();
-        let summary_dir = ctx.options.storage.summary_dir();
-        if !file_manager::try_exists(&summary_dir) {
-            std::fs::create_dir_all(&summary_dir).unwrap();
-        }
-        let mut summary = Summary::new(
-            ctx.options.clone(),
-            runtime.clone(),
-            meta_manager.clone(),
-            memory_pool.clone(),
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
+        let (meta_manager, memory_pool, mut summary_1, ctx) = test_helper.init();
 
-        let db = summary
-            .version_set
-            .write()
-            .await
-            .create_db(DatabaseSchema::new("cnosdb", &database))
-            .await
-            .unwrap();
+        // Add vnode[10], delete vnode[0]
+        #[rustfmt::skip]
+        let mut edits = runtime.block_on(async {
+            let db = summary_1.version_set.write().await.create_db(
+                DatabaseSchema::new("cnosdb", database),
+            ).await.unwrap();
+            db.write().await.add_tsfamily(
+                VNODE_ID,
+                None,
+                ctx,
+            ).await.expect("add tsfamily failed");
+            let mut edits = vec![VersionEdit::new_add_vnode(VNODE_ID, owned_database.to_string(), 0)];
+            for _ in 0..10 {
+                db.write()
+                    .await
+                    .del_tsfamily(0, summary_task_sender.clone())
+                    .await;
+                let edit = VersionEdit::new_del_vnode(0);
+                edits.push(edit);
+            }
 
-        db.write()
-            .await
-            .add_tsfamily(10, None, ctx.clone())
-            .await
-            .expect("add tsfamily failed");
+            edits
+        });
 
-        let mut edits = vec![];
-        let edit = VersionEdit::new_add_vnode(10, "cnosdb.hello".to_string(), 0);
-        edits.push(edit);
-
-        for _ in 0..100 {
-            db.write()
-                .await
-                .del_tsfamily(0, ctx.summary_task_sender.clone())
-                .await;
-            let edit = VersionEdit::new_del_vnode(0);
-            edits.push(edit);
-        }
-
-        {
-            let vs = summary.version_set.write().await;
-            let tsf = vs.get_tsfamily_by_tf_id(10).await.unwrap();
+        // Add some files to vnode[10]
+        runtime.block_on(async move {
+            let tsf = {
+                let vs = summary_1.version_set.read().await;
+                vs.get_tsfamily_by_tf_id(VNODE_ID).await.unwrap()
+            };
             let mut version = tsf.read().await.version().copy_apply_version_edits(
                 edits.clone(),
                 &mut HashMap::new(),
@@ -1221,7 +1241,7 @@ mod test {
             );
             let tsm_reader_cache = Arc::downgrade(version.tsm_reader_cache());
 
-            let mut edit = VersionEdit::new(10);
+            let mut edit = VersionEdit::new(VNODE_ID);
             let meta = CompactMeta {
                 file_id: 15,
                 is_delta: false,
@@ -1229,7 +1249,7 @@ mod test {
                 level: 1,
                 min_ts: 1,
                 max_ts: 1,
-                tsf_id: 10,
+                tsf_id: VNODE_ID,
                 high_seq: 1,
                 ..Default::default()
             };
@@ -1241,38 +1261,43 @@ mod test {
             tsf.write().await.new_version(version, None);
             edit.add_file(meta, 1);
             edits.push(edit);
-        }
 
-        summary
-            .apply_version_edit(edits, HashMap::new(), HashMap::new())
+            summary_1
+                .apply_version_edit(edits, HashMap::new(), HashMap::new())
+                .await
+                .unwrap();
+        });
+
+        runtime.block_on(async move {
+            let summary = Summary::recover(
+                meta_manager,
+                options,
+                runtime_inner,
+                memory_pool,
+                compact_task_sender,
+                false,
+                Arc::new(MetricsRegister::default()),
+            )
             .await
             .unwrap();
 
-        let summary = Summary::recover(
-            meta_manager,
-            ctx.options.clone(),
-            runtime,
-            memory_pool.clone(),
-            ctx.compact_task_sender.clone(),
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
+            let vs = summary.version_set.read().await;
+            let tsf = vs.get_tsfamily_by_tf_id(VNODE_ID).await.unwrap();
+            assert_eq!(tsf.read().await.version().last_seq(), 1);
+            assert_eq!(tsf.read().await.version().levels_info()[1].tsf_id, VNODE_ID);
+            assert!(!tsf.read().await.version().levels_info()[1].files[0].is_delta());
+            assert_eq!(
+                tsf.read().await.version().levels_info()[1].files[0].file_id(),
+                15
+            );
+            assert_eq!(
+                tsf.read().await.version().levels_info()[1].files[0].size(),
+                100
+            );
+            assert_eq!(summary.ctx.file_id(), 16);
+        });
 
-        let vs = summary.version_set.read().await;
-        let tsf = vs.get_tsfamily_by_tf_id(10).await.unwrap();
-        assert_eq!(tsf.read().await.version().last_seq(), 1);
-        assert_eq!(tsf.read().await.version().levels_info()[1].tsf_id, 10);
-        assert!(!tsf.read().await.version().levels_info()[1].files[0].is_delta());
-        assert_eq!(
-            tsf.read().await.version().levels_info()[1].files[0].file_id(),
-            15
-        );
-        assert_eq!(
-            tsf.read().await.version().levels_info()[1].files[0].size(),
-            100
-        );
-        assert_eq!(summary.ctx.file_id(), 16);
+        drop(summary_task_sender);
+        test_helper.join();
     }
 }

--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -1052,6 +1052,7 @@ impl TseriesFamily {
     }
 
     pub fn close(&self) {
+        info!("Closing vnode {}", self.tf_id);
         self.cancellation_token.cancel();
     }
 
@@ -1162,7 +1163,10 @@ pub fn schedule_vnode_compaction(
         let cancellation_token = vnode_rlock.cancellation_token.clone();
         drop(vnode_rlock);
 
-        if compact_trigger_cold_duration == Duration::ZERO {} else {
+        if compact_trigger_cold_duration == Duration::ZERO {
+            info!("Schedule vnode compaction for {tsf_id}: compact_trigger_cold_duration is 0 so won't run this job");
+        } else {
+            info!("Schedule vnode compaction for {tsf_id}: checking to compact every 10 seconds.");
             let mut check_interval = tokio::time::interval(Duration::from_secs(10));
             check_interval.tick().await;
 

--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt::Display;
 use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -16,6 +17,7 @@ use models::{FieldId, SeriesId, Timestamp};
 use parking_lot::RwLock;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::RwLock as AsyncRwLock;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use trace::{debug, error, info, warn};
@@ -155,6 +157,25 @@ impl Drop for ColumnFile {
             }
             info!("Removed file {} at '{}", self.file_id, path.display());
         }
+    }
+}
+
+impl Display for ColumnFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{ level:{}, file_id:{}, compacting:{}, time_range:{}-{}, file size:{} }}",
+            self.level,
+            self.file_id,
+            if self.is_compacting() {
+                "True"
+            } else {
+                "False"
+            },
+            self.time_range.min_ts,
+            self.time_range.max_ts,
+            self.size,
+        )
     }
 }
 
@@ -348,6 +369,19 @@ impl LevelInfo {
             .collect::<Vec<Arc<ColumnFile>>>();
         res.sort_by_key(|f| *f.time_range());
         res
+    }
+}
+
+impl Display for LevelInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{ L:{}, files: [ ", self.level)?;
+        for (i, file) in self.files.iter().enumerate() {
+            write!(f, "{}", file.as_ref())?;
+            if i < self.files.len() - 1 {
+                write!(f, ", ")?;
+            }
+        }
+        write!(f, "] }}")
     }
 }
 
@@ -1017,36 +1051,6 @@ impl TseriesFamily {
         }
     }
 
-    pub fn schedule_compaction(&self, runtime: Arc<Runtime>, sender: Sender<CompactTask>) {
-        let tsf_id = self.tf_id;
-        let compact_trigger_cold_duration = self.storage_opt.compact_trigger_cold_duration;
-        let last_modified = self.last_modified.clone();
-        let cancellation_token = self.cancellation_token.clone();
-        let _jh = runtime.spawn(async move {
-            if compact_trigger_cold_duration == Duration::ZERO {} else {
-                let mut cold_check_interval = tokio::time::interval(Duration::from_secs(10));
-                cold_check_interval.tick().await;
-                loop {
-                    tokio::select! {
-                        _ = cold_check_interval.tick() => {
-                            let last_modified = last_modified.read().await;
-                            if let Some(t) = *last_modified {
-                                if t.elapsed() >= compact_trigger_cold_duration {
-                                    if let Err(e) = sender.send(CompactTask::ColdVnode(tsf_id)).await {
-                                        warn!("failed to send compact task({}), {}", tsf_id, e);
-                                    }
-                                }
-                            }
-                        }
-                        _ = cancellation_token.cancelled() => {
-                            break;
-                        }
-                    }
-                }
-            }
-        });
-    }
-
     pub fn close(&self) {
         self.cancellation_token.cancel();
     }
@@ -1138,8 +1142,67 @@ impl TseriesFamily {
 
 impl Drop for TseriesFamily {
     fn drop(&mut self) {
-        self.cancellation_token.cancel();
+        if !self.cancellation_token.is_cancelled() {
+            self.cancellation_token.cancel();
+        }
     }
+}
+
+pub fn schedule_vnode_compaction(
+    runtime: Arc<Runtime>,
+    vnode: Arc<AsyncRwLock<TseriesFamily>>,
+    compact_task_sender: Sender<CompactTask>,
+) {
+    let _jh = runtime.spawn(async move {
+        let vnode_rlock = vnode.read().await;
+        let tsf_id = vnode_rlock.tf_id;
+        let compact_trigger_cold_duration = vnode_rlock.storage_opt.compact_trigger_cold_duration;
+        let last_modified = vnode_rlock.last_modified.clone();
+        let compact_trigger_file_num = vnode_rlock.storage_opt.compact_trigger_file_num as usize;
+        let cancellation_token = vnode_rlock.cancellation_token.clone();
+        drop(vnode_rlock);
+
+        if compact_trigger_cold_duration == Duration::ZERO {} else {
+            let mut check_interval = tokio::time::interval(Duration::from_secs(10));
+            check_interval.tick().await;
+
+            loop {
+                tokio::select! {
+                    _ = check_interval.tick() => {
+                        // Check if vnode is cold.
+                        let ts_rlock = last_modified.read().await;
+                        if let Some(t) = *ts_rlock {
+                            if t.elapsed() >= compact_trigger_cold_duration {
+                                drop(ts_rlock);
+                                let mut ts_wlock = last_modified.write().await;
+                                *ts_wlock = Some(Instant::now());
+                                if let Err(e) = compact_task_sender.send(CompactTask::Cold(tsf_id)).await {
+                                    warn!("failed to send compact task({}), {}", tsf_id, e);
+                                }
+                            }
+                        }
+
+                        // Check if level-0 files is more than DEFAULT_COMPACT_TRIGGER_DETLA_FILE_NUM
+                        let version = vnode.read().await.super_version().version.clone();
+                        let mut level0_files = 0_usize;
+                        for file in version.levels_info()[0].files.iter() {
+                            if !file.is_compacting() {
+                                level0_files += 1;
+                            }
+                        }
+                        if level0_files >= compact_trigger_file_num {
+                            if let Err(e) = compact_task_sender.send(CompactTask::Delta(tsf_id)).await {
+                                warn!("failed to send compact task({}), {}", tsf_id, e);
+                            }
+                        }
+                    }
+                    _ = cancellation_token.cancelled() => {
+                        break;
+                    }
+                }
+            }
+        }
+    });
 }
 
 pub struct ColumnFileToTsmReaderIterator {

--- a/tskv/src/tsm/block.rs
+++ b/tskv/src/tsm/block.rs
@@ -434,6 +434,106 @@ impl DataBlock {
         blk
     }
 
+    pub fn split(self, timestamp: Timestamp) -> (DataBlock, DataBlock) {
+        match &self {
+            DataBlock::U64 { ts, val, .. } => {
+                let i = ts.binary_search(&timestamp).unwrap_or_else(|i| i);
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, PhysicalDType::Unsigned))
+                } else {
+                    (
+                        DataBlock::U64 {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::U64 {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+            DataBlock::I64 { ts, val, .. } => {
+                let i = ts.binary_search(&timestamp).unwrap_or_else(|i| i);
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, PhysicalDType::Integer))
+                } else {
+                    (
+                        DataBlock::I64 {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::I64 {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+            DataBlock::Str { ts, val, .. } => {
+                let i = ts.binary_search(&timestamp).unwrap_or_else(|i| i);
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, PhysicalDType::String))
+                } else {
+                    (
+                        DataBlock::Str {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::Str {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+            DataBlock::F64 { ts, val, .. } => {
+                let i = ts.binary_search(&timestamp).unwrap_or_else(|i| i);
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, PhysicalDType::Float))
+                } else {
+                    (
+                        DataBlock::F64 {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::F64 {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+            DataBlock::Bool { ts, val, .. } => {
+                let i = ts.binary_search(&timestamp).unwrap_or_else(|i| i);
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, PhysicalDType::Boolean))
+                } else {
+                    (
+                        DataBlock::Bool {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::Bool {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+        }
+    }
+
     /// Merges one or many `DataBlock`s into some `DataBlock` with fixed length,
     /// sorted by timestamp, if many (timestamp, value) conflict with the same
     /// timestamp, use the last value.

--- a/tskv/src/tsm/codec/mod.rs
+++ b/tskv/src/tsm/codec/mod.rs
@@ -25,7 +25,7 @@ pub struct DataBlockEncoding {
 }
 
 impl DataBlockEncoding {
-    pub fn new(ts_encoding: Encoding, val_encoding: Encoding) -> Self {
+    pub const fn new(ts_encoding: Encoding, val_encoding: Encoding) -> Self {
         Self {
             ts_encoding,
             val_encoding,

--- a/tskv/src/tsm/reader.rs
+++ b/tskv/src/tsm/reader.rs
@@ -757,7 +757,7 @@ pub mod tsm_reader_tests {
             ]),
         ]);
 
-        write_to_tsm(&tsm_file, &ori_data).await?;
+        write_to_tsm(&tsm_file, &ori_data, false).await?;
         let tombstone = TsmTombstone::with_path(&tombstone_file).await?;
         tombstone
             .add_range(&[1], &TimeRange::new(2, 4), None)

--- a/tskv/src/tsm/writer.rs
+++ b/tskv/src/tsm/writer.rs
@@ -541,13 +541,13 @@ pub mod tsm_writer_tests {
     use crate::file_utils::{self, make_tsm_file};
     use crate::tsm::codec::DataBlockEncoding;
     use crate::tsm::tsm_reader_tests::read_and_check;
-    use crate::tsm::{DataBlock, TsmReader, TsmWriter};
-
-    const TEST_PATH: &str = "/tmp/test/tsm_writer";
+    use crate::tsm::{DataBlock, EncodedDataBlock, TsmReader, TsmWriter, WriteTsmError};
+    use crate::Error;
 
     pub async fn write_to_tsm(
         path: impl AsRef<Path>,
         data: &HashMap<FieldId, Vec<DataBlock>>,
+        encode_data_block: bool,
     ) -> Result<()> {
         let tsm_seq = file_utils::get_tsm_file_id_by_path(&path)?;
         let path = path.as_ref();
@@ -556,12 +556,28 @@ pub mod tsm_writer_tests {
             std::fs::create_dir_all(dir).context(super::WriteIOSnafu)?;
         }
         let mut writer = TsmWriter::open(path, tsm_seq, false, 0).await?;
-        for (fid, blks) in data.iter() {
-            for blk in blks.iter() {
-                writer
-                    .write_block(*fid, blk)
-                    .await
-                    .context(error::WriteTsmSnafu)?;
+        if encode_data_block {
+            for (fid, blks) in data.iter() {
+                for blk in blks.iter() {
+                    let blk_enc = EncodedDataBlock::encode(blk, 0, blk.len()).map_err(|e| {
+                        Error::WriteTsm {
+                            source: WriteTsmError::Encode { source: e },
+                        }
+                    })?;
+                    writer
+                        .write_encoded_block(*fid, &blk_enc)
+                        .await
+                        .context(error::WriteTsmSnafu)?;
+                }
+            }
+        } else {
+            for (fid, blks) in data.iter() {
+                for blk in blks.iter() {
+                    writer
+                        .write_block(*fid, blk)
+                        .await
+                        .context(error::WriteTsmSnafu)?;
+                }
             }
         }
         writer.write_index().await.context(error::WriteTsmSnafu)?;
@@ -576,11 +592,24 @@ pub mod tsm_writer_tests {
             (2, vec![DataBlock::U64 { ts: vec![2, 3, 4], val: vec![101, 102, 103], enc: DataBlockEncoding::default() }]),
         ]);
 
-        let tsm_file = make_tsm_file(TEST_PATH, 0);
-        write_to_tsm(&tsm_file, &data).await.unwrap();
+        let dir = "/tmp/test/tsm_writer/test_tsm_write_fast";
+        let _ = std::fs::remove_dir_all(dir);
+        {
+            // Test write normal data block.
+            let tsm_file = make_tsm_file(dir, 0);
+            write_to_tsm(&tsm_file, &data, false).await.unwrap();
 
-        let reader = TsmReader::open(tsm_file).await.unwrap();
-        read_and_check(&reader, &data).await.unwrap();
+            let reader = TsmReader::open(tsm_file).await.unwrap();
+            read_and_check(&reader, &data).await.unwrap();
+        }
+        {
+            // Test write encoded data block.
+            let tsm_file = make_tsm_file(dir, 1);
+            write_to_tsm(&tsm_file, &data, true).await.unwrap();
+
+            let reader = TsmReader::open(tsm_file).await.unwrap();
+            read_and_check(&reader, &data).await.unwrap();
+        }
     }
 
     #[tokio::test]
@@ -606,10 +635,23 @@ pub mod tsm_writer_tests {
             ]),
         ]);
 
-        let tsm_file = make_tsm_file(TEST_PATH, 1);
-        write_to_tsm(&tsm_file, &data).await.unwrap();
+        let dir = "/tmp/test/tsm_writer/test_tsm_write_1";
+        let _ = std::fs::remove_dir_all(dir);
+        {
+            // Test write normal data block.
+            let tsm_file = make_tsm_file(dir, 0);
+            write_to_tsm(&tsm_file, &data, false).await.unwrap();
 
-        let reader = TsmReader::open(tsm_file).await.unwrap();
-        read_and_check(&reader, &data).await.unwrap();
+            let reader = TsmReader::open(tsm_file).await.unwrap();
+            read_and_check(&reader, &data).await.unwrap();
+        }
+        {
+            // Test write encoded data block.
+            let tsm_file = make_tsm_file(dir, 1);
+            write_to_tsm(&tsm_file, &data, true).await.unwrap();
+
+            let reader = TsmReader::open(tsm_file).await.unwrap();
+            read_and_check(&reader, &data).await.unwrap();
+        }
     }
 }

--- a/tskv/src/version_set.rs
+++ b/tskv/src/version_set.rs
@@ -35,7 +35,13 @@ impl VersionSet {
         memory_pool: MemoryPoolRef,
         metrics_register: Arc<MetricsRegister>,
     ) -> Self {
-        let db_factory = DatabaseFactory::new(meta, memory_pool.clone(), metrics_register, opt);
+        let db_factory = DatabaseFactory::new(
+            meta,
+            memory_pool.clone(),
+            metrics_register,
+            opt,
+            runtime.clone(),
+        );
 
         Self {
             dbs: HashMap::new(),
@@ -51,7 +57,7 @@ impl VersionSet {
         let register = Arc::new(MetricsRegister::default());
         let memory_pool = Arc::new(memory_pool::GreedyMemoryPool::default());
         let meta = Arc::new(AdminMeta::mock());
-        let db_factory = DatabaseFactory::new(meta, memory_pool, register, opt);
+        let db_factory = DatabaseFactory::new(meta, memory_pool, register, opt, runtime.clone());
         Self {
             dbs: HashMap::new(),
             runtime,
@@ -70,7 +76,13 @@ impl VersionSet {
         metrics_register: Arc<MetricsRegister>,
     ) -> Result<Self> {
         let mut dbs = HashMap::new();
-        let db_factory = DatabaseFactory::new(meta.clone(), memory_pool, metrics_register, opt);
+        let db_factory = DatabaseFactory::new(
+            meta.clone(),
+            memory_pool,
+            metrics_register,
+            opt,
+            runtime.clone(),
+        );
 
         for ver in ver_set.into_values() {
             let owner = ver.tenant_database().to_string();


### PR DESCRIPTION
## Related

#1244 

## Conclusion

### Others

1. `DataBlock` - add method `split(timestamp)` and `split_at(index)`.
2. `ColumnFile` and `LevelInfo` now implemnt `std::fmt::Display`.
3. Unit test cases in `summary.rs` can now run in parallel (Now you must check all channel senders in `SummaryTestHelper` are dropped, otherwise the unit test will never finishes).
4. Add command `fix` in makefile which equals to `cargo fix --workspace --allow-dirty --allow-staged`.

### Compaction - flush

1. `FlushReq` now has field `Option<oneshot::Sender<()>>` to notify a flush job completed. It will be `None` when the `TseriesFamily` flushes full immutable `MemCache`s to disk, but it will be `Some` when manually flushing.
2. Add `FlushProcessor` to make flush method simpler.
3. `TsKv::flush_tsfamily()` now wait the flush job completed.

### Compaction - compact

#### Compact strategy

1. Add compact strategy `Delta`, `Sized` and `Split`.
   - Delta - Use `DeltaCompactionPicker`to pick Level-0 files.
   - Sized - Use `SizedCompactionPicker` to pick a level of Level-1~4, then pick files.
   - Split - (todo) Use `SplitCompactionPicker` to pick time range overlapped files.

#### Do compaction

1. Now if a compact is for Level-0 files, it merge data in level-0 files to the destination level, and put back data that timestamp > maximum timestamp of the destination level to Level-0.
2. (todo) Add `CompactionStats` to store metrics of a compaction.

#### Schedule compaction

1. Now `schedule_compaction()` not only check if a vnode is cold but also check num of level-0 files with config `compact_trigger_file_num` or contant `DEFAULT_COMPACT_TRIGGER_DETLA_FILE_NUM` (This change makes unit tests in summary.rs won't stop, so I fixed  it by some changes in unit test cases in summary.rs).
2. `schedule_compaction()` holds a shared reference of `Arc<TseriesFamily`, now we must manually stop it by `TseriesFamily::close()`. Implmentation of `Drop` for `Database` will call that method of all it's vnodes.
3. Now compaction requests are pushed into priority queue `RequestPriorityQueue` first.
   - `RequestPriorityQueue::push()` - Push a task into this queue, the same tasks that already in the queue are ignored.
   - `RequestPriorityQueue::pop()` - Get the head task.

#### Run compaction manually

4. `TsKv::compact()` now use `SizedCompactionPicker` instead of `LevelCompactionPicker`.

## Tasks

Refactored the code for compaction

- [x] Added a delta file compaction method.
- [x] Simplified the level picking process to make the code structure clearer.
- [x] Removed the flush logic from compaction to separate it from flush.
- [ ] Split picker todo.
- [ ] Added compaction statistics functionality.
- [ ] Added a way to trigger compaction through read