### PR TITLE
[Feature] Restore feature `vnode checksum <group_id>`

### DIFF
--- a/tskv/src/compaction/compact.rs
+++ b/tskv/src/compaction/compact.rs
@@ -249,6 +249,10 @@ impl CompactingBlockMetaGroup {
         Ok(merged_blks)
     }
 
+    pub fn into_compacting_block_metas(self) -> Vec<CompactingBlockMeta> {
+        self.blk_metas
+    }
+
     pub fn is_empty(&self) -> bool {
         self.blk_metas.is_empty()
     }
@@ -636,6 +640,10 @@ impl CompactIterator {
             return Some(g);
         }
         None
+    }
+
+    pub fn curr_fid(&self) -> Option<FieldId> {
+        self.curr_fid
     }
 }
 

--- a/tskv/tests/test_kvcore_interface.rs
+++ b/tskv/tests/test_kvcore_interface.rs
@@ -337,14 +337,14 @@ mod tests {
 
     #[test]
     fn test_kvcore_snapshot_create_apply_delete() {
-        let dir = PathBuf::from("/tmp/test/kvcore/test_kvcore_snapshot_create_apply_delete");
+        let dir = PathBuf::from("/tmp/test/kvcore/kvcore_snapshot_create_apply_delete");
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
 
         init_default_global_tracing(dir.join("log"), "tskv.log", "debug");
         let tenant = "cnosdb";
-        let database = "test_db";
-        let table = "test_tab";
+        let database = "db_test_snapshot";
+        let table = "tab_test_snapshot";
         let vnode_id = 11;
 
         let (runtime, tskv) = get_tskv(&dir, None);


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label. - No
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

#1641 

# Rationale for this change

1. Restore commented code to get vnode checksum, and fit the new compaction iterator.
2. Improve implements of `std::fmt::Display` of each hash tree structs, the prints now use JSON format.

# Are there any user-facing changes?

Change 
