### PR TITLE
[Fix] tskv file system do not use append flag; call WalWriter::close() when a writer roll to old

### DIFF
--- a/tskv/src/file_system/file_manager.rs
+++ b/tskv/src/file_system/file_manager.rs
@@ -88,12 +88,12 @@ impl FileManager {
         self.open_file_with(p, opt).await
     }
 
-    /// Open a file to read or write(append mode), if file does not exists then create it.
+    /// Open a file to read or write, if file does not exists then create it.
     pub async fn open_create_file(&self, path: impl AsRef<Path>) -> Result<AsyncFile> {
         let p = path.as_ref();
         Self::create_dir_if_not_exists(p.parent())?;
         let mut opt = OpenOptions::new();
-        opt.read(true).write(true).create(true).append(true);
+        opt.read(true).write(true).create(true);
         self.open_file_with(path, opt).await
     }
 }
@@ -171,7 +171,7 @@ pub async fn create_file(path: impl AsRef<Path>) -> Result<AsyncFile> {
     get_file_manager().create_file(path).await
 }
 
-/// Open a file to read or write(append mode), if file does not exists then create it.
+/// Open a file to read or write, if file does not exists then create it.
 #[inline(always)]
 pub async fn open_create_file(path: impl AsRef<Path>) -> Result<AsyncFile> {
     get_file_manager().open_create_file(path).await

--- a/tskv/src/wal/writer.rs
+++ b/tskv/src/wal/writer.rs
@@ -311,9 +311,10 @@ impl WalWriter {
 
     pub async fn close(&mut self) -> Result<usize> {
         trace::info!(
-            "Closing wal with sequence: [{}, {})",
+            "Wal '{}' closing with sequence: [{}, {})",
+            self.path.display(),
             self.min_sequence,
-            self.max_sequence
+            self.max_sequence,
         );
         let mut footer = build_footer(self.min_sequence, self.max_sequence);
         let size = self.inner.write_footer(&mut footer).await?;
@@ -354,7 +355,6 @@ impl WalWriter {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-
 pub enum Task {
     Write(WriteTask),
     DeleteVnode(DeleteVnodeTask),
@@ -587,7 +587,7 @@ mod test {
         #[rustfmt::skip]
         let entries = vec![
             Block::Write(WriteBlock::build(
-                1,  "cnosdb", 3, Precision::NS, vec![1, 2, 3],
+                1, "cnosdb", 3, Precision::NS, vec![1, 2, 3],
             )),
             Block::DeleteVnode(DeleteVnodeBlock::build(2, "cnosdb", "public", 6)),
             Block::DeleteTable(DeleteTableBlock::build(3, "cnosdb", "public", "table")),


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

1. file_manager::open_create_file() now don't use append mode, because on Windows11 we can't call file.set_len() on a file which opened with append mode.
2. Now there can be multi opened but finished WAL files in WalManager do not have footer, to fix that, split WalWriter::write_footer() from WalWriter::close(), call wirte_footer() when a WAL file is finished.

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

