### PR TITLE
feature: support data node sense meta node change

### DIFF
--- a/meta/src/client.rs
+++ b/meta/src/client.rs
@@ -65,10 +65,14 @@ impl MetaHttpClient {
     }
 
     pub async fn watch_meta_membership(&self) -> MetaResult<Vec<String>> {
-        let rsp = self.try_send_to_leader("watch_meta_membership", &String::new()).await?;
+        let rsp = self
+            .try_send_to_leader("watch_meta_membership", &String::new())
+            .await?;
 
-        serde_json::from_str::<MetaResult<Vec<String>>>(&rsp).map_err(|err| MetaError::SerdeMsgInvalid {
-            err: err.to_string(),
+        serde_json::from_str::<MetaResult<Vec<String>>>(&rsp).map_err(|err| {
+            MetaError::SerdeMsgInvalid {
+                err: err.to_string(),
+            }
         })?
     }
 

--- a/meta/src/model/meta_admin.rs
+++ b/meta/src/model/meta_admin.rs
@@ -262,7 +262,7 @@ impl AdminMeta {
                 drop(r_addrs);
                 old_addr.sort();
                 new_addrs.sort();
-                
+
                 if !old_addr.eq(&new_addrs) {
                     admin.client.change_meta_membership(new_addrs.clone());
                     let w_tenants = admin.tenants.write();
@@ -270,7 +270,6 @@ impl AdminMeta {
                         tenant_meta.client.change_meta_membership(new_addrs.clone());
                     });
                 }
-
             } else {
                 info!("watch meta node change wrong {:?}", res);
             }

--- a/meta/src/model/meta_tenant.rs
+++ b/meta/src/model/meta_tenant.rs
@@ -30,7 +30,7 @@ pub struct TenantMeta {
     meta_url: String,
 
     data: RwLock<TenantMetaData>,
-    client: MetaHttpClient,
+    pub client: MetaHttpClient,
 }
 
 impl TenantMeta {


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [x] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #1633 .

# Rationale for this change

[//]: # (Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.)
1. raft do not appear tow leader(split-brain), the new leader will be elected when old leader isolated ,so leader`s data aways right, we just need watch leader.
2. when a meta node failed(like: process exit), raft membership do not change until manual request `change-membership`, I think data node no need to specifically remove this failed node, can continue use the membership.


# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

