### PR TITLE
fix: optimize the error message for direct select the stream table

### DIFF
--- a/query_server/query/src/execution/factory.rs
+++ b/query_server/query/src/execution/factory.rs
@@ -76,34 +76,44 @@ impl QueryExecutionFactory for SqlQueryExecutionFactory {
                 // 获取执行计划中所有涉及到的stream source
                 let stream_providers = extract_stream_providers(&query_plan);
 
-                // 纯批操作
-                // 1. 没有stream source
-                // 2. explain
-                // 3. 非dml
-                if stream_providers.is_empty() || query_plan.is_explain() || !is_dml(&query_plan) {
-                    return Ok(Arc::new(SqlQueryExecution::new(
+                // (含有流表, explain, dml)
+                match (
+                    !stream_providers.is_empty(),
+                    query_plan.is_explain(),
+                    is_dml(&query_plan),
+                ) {
+                    (false, _, _) | (true, true, _) => Ok(Arc::new(SqlQueryExecution::new(
                         state_machine,
                         query_plan,
                         self.optimizer.clone(),
                         self.scheduler.clone(),
-                    )));
+                    ))),
+                    (true, false, true) => {
+                        // 流操作
+                        // stream source + dml + !explain
+                        let options = state_machine.session.inner().config().into();
+                        let exec =
+                            MicroBatchStreamExecutionBuilder::new(MicroBatchStreamExecutionDesc {
+                                plan: Arc::new(query_plan),
+                                options,
+                            })
+                            .with_stream_providers(stream_providers)
+                            .build(
+                                state_machine,
+                                self.scheduler.clone(),
+                                self.trigger_executor_factory.clone(),
+                                self.runtime.clone(),
+                            )?;
+
+                        Ok(Arc::new(exec))
+                    }
+                    (true, false, false) => {
+                        // stream source + !dml + !explain
+                        Err(QueryError::NotImplemented {
+                            err: "Stream table can only be used as source table in insert select statements.".to_string(),
+                        })
+                    }
                 }
-
-                // 流操作
-                let options = state_machine.session.inner().config().into();
-                let exec = MicroBatchStreamExecutionBuilder::new(MicroBatchStreamExecutionDesc {
-                    plan: Arc::new(query_plan),
-                    options,
-                })
-                .with_stream_providers(stream_providers)
-                .build(
-                    state_machine,
-                    self.scheduler.clone(),
-                    self.trigger_executor_factory.clone(),
-                    self.runtime.clone(),
-                )?;
-
-                Ok(Arc::new(exec))
             }
             Plan::DDL(ddl_plan) => Ok(Arc::new(DDLExecution::new(
                 state_machine,

--- a/query_server/sqllogicaltests/cases/stream/unsupport_op.slt
+++ b/query_server/sqllogicaltests/cases/stream/unsupport_op.slt
@@ -89,6 +89,11 @@ insert into readings_agg
   from TskvTable 
   order by time, name;
 
+# select
+statement error Arrow error: Io error: Status \{ code: Internal, message: "Execute logical plan: This feature is not implemented: Stream table can only be used as source table in insert select statements\.", .*
+select *
+  from TskvTable;
+
 # alter
 statement error Arrow error: Io error: Status \{ code: Internal, message: "Build logical plan: This feature is not implemented: only tskv table support alter",.*
 alter table TskvTable add tag ta;


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #1715 .

error message:
```
 {"error_code":"010005","error_message":"This feature is not implemented: Stream table can only be used as source table in insert select statements."}
```

# Rationale for this change

[//]: # (Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.)

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

