### PR TITLE
fix: incorrectly alter non-specified user options

### DIFF
--- a/common/models/src/auth/user.rs
+++ b/common/models/src/auth/user.rs
@@ -124,13 +124,13 @@ impl Identifier<Oid> for UserDesc {
 #[builder(setter(into, strip_option), default)]
 pub struct UserOptions {
     hash_password: Option<String>,
-    #[builder(default = "Some(false)")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     must_change_password: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     rsa_public_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     comment: Option<String>,
-    #[builder(default = "Some(false)")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     granted_admin: Option<bool>,
 }
 

--- a/e2e_test/src/independent/restart_tests.rs
+++ b/e2e_test/src/independent/restart_tests.rs
@@ -437,7 +437,7 @@ pub mod test {
                 .collect::<Vec<_>>(),
             vec![
                 "user_name,is_admin,user_options",
-                r#"tester,false,"{""hash_password"":""*****"",""must_change_password"":false,""granted_admin"":false}""#
+                r#"tester,false,"{""hash_password"":""*****""}""#
             ]
         );
 
@@ -467,7 +467,7 @@ pub mod test {
                 .collect::<Vec<_>>(),
             vec![
                 "user_name,is_admin,user_options",
-                r#"tester,true,"{""hash_password"":""*****"",""must_change_password"":false,""granted_admin"":true}""#
+                r#"tester,true,"{""hash_password"":""*****"",""granted_admin"":true}""#
             ]
         );
 
@@ -497,7 +497,7 @@ pub mod test {
                 .collect::<Vec<_>>(),
             vec![
                 "user_name,is_admin,user_options",
-                r#"tester,false,"{""hash_password"":""*****"",""must_change_password"":false,""granted_admin"":false}""#
+                r#"tester,false,"{""hash_password"":""*****"",""granted_admin"":false}""#
             ]
         );
 
@@ -527,7 +527,7 @@ pub mod test {
                 .collect::<Vec<_>>(),
             vec![
                 "user_name,is_admin,user_options",
-                r#"tester,false,"{""hash_password"":""*****"",""must_change_password"":false,""comment"":""bbb"",""granted_admin"":false}""#
+                r#"tester,false,"{""hash_password"":""*****"",""comment"":""bbb"",""granted_admin"":false}""#
             ]
         );
 

--- a/query_server/sqllogicaltests/cases/ddl/user.slt
+++ b/query_server/sqllogicaltests/cases/ddl/user.slt
@@ -1,4 +1,7 @@
 statement ok
+drop user if exists test_alter_options_u;
+
+statement ok
 create user if not exists test_alter_options_u;
 
 statement ok
@@ -8,7 +11,7 @@ alter user test_alter_options_u set comment = 'xxx ccc';
 query I
 select * from cluster_schema.users where user_name = 'test_alter_options_u';
 ----
-test_alter_options_u false {"hash_password":"*****","must_change_password":false,"comment":"xxx ccc","granted_admin":false}
+test_alter_options_u false {"hash_password":"*****","comment":"xxx ccc"}
 
 statement ok
 alter user test_alter_options_u set comment = 'ooo ooo';
@@ -17,7 +20,7 @@ alter user test_alter_options_u set comment = 'ooo ooo';
 query I
 select * from cluster_schema.users where user_name = 'test_alter_options_u';
 ----
-test_alter_options_u false {"hash_password":"*****","must_change_password":false,"comment":"ooo ooo","granted_admin":false}
+test_alter_options_u false {"hash_password":"*****","comment":"ooo ooo"}
 
 statement ok
 alter user test_alter_options_u set must_change_password = false;
@@ -26,7 +29,7 @@ alter user test_alter_options_u set must_change_password = false;
 query I
 select * from cluster_schema.users where user_name = 'test_alter_options_u';
 ----
-test_alter_options_u false {"hash_password":"*****","must_change_password":false,"comment":"ooo ooo","granted_admin":false}
+test_alter_options_u false {"hash_password":"*****","must_change_password":false,"comment":"ooo ooo"}
 
 statement ok
 alter user test_alter_options_u set must_change_password = true;
@@ -35,7 +38,7 @@ alter user test_alter_options_u set must_change_password = true;
 query I
 select * from cluster_schema.users where user_name = 'test_alter_options_u';
 ----
-test_alter_options_u false {"hash_password":"*****","must_change_password":true,"comment":"ooo ooo","granted_admin":false}
+test_alter_options_u false {"hash_password":"*****","must_change_password":true,"comment":"ooo ooo"}
 
 # table not found
 statement error .*Table not found: \\"a_non_existent_table\\".*

--- a/query_server/test/cases/dcl/alter_user.result
+++ b/query_server/test/cases/dcl/alter_user.result
@@ -41,9 +41,9 @@
 -- AFTER_SORT --
 200 OK
 user_name,is_admin,user_options
-root,true,"{""hash_password"":""*****"",""must_change_password"":true,""comment"":""system admin"",""granted_admin"":false}"
-test_au_u1,false,"{""hash_password"":""*****"",""must_change_password"":false,""granted_admin"":false}"
-test_au_u2,false,"{""hash_password"":""*****"",""must_change_password"":false,""granted_admin"":false}"
+root,true,"{""hash_password"":""*****"",""must_change_password"":true,""comment"":""system admin""}"
+test_au_u1,false,"{""hash_password"":""*****""}"
+test_au_u2,false,"{""hash_password"":""*****""}"
 
 -- EXECUTE SQL: alter user test_au_u1 set granted_admin = true; --
 422 Unprocessable Entity
@@ -58,11 +58,15 @@ test_au_u2,false,"{""hash_password"":""*****"",""must_change_password"":false,""
 -- AFTER_SORT --
 200 OK
 user_name,is_admin,user_options
-root,true,"{""hash_password"":""*****"",""must_change_password"":true,""comment"":""system admin"",""granted_admin"":false}"
-test_au_u1,true,"{""hash_password"":""*****"",""must_change_password"":false,""granted_admin"":true}"
-test_au_u2,false,"{""hash_password"":""*****"",""must_change_password"":false,""granted_admin"":false}"
+root,true,"{""hash_password"":""*****"",""must_change_password"":true,""comment"":""system admin""}"
+test_au_u1,true,"{""hash_password"":""*****"",""granted_admin"":true}"
+test_au_u2,false,"{""hash_password"":""*****""}"
 
 -- EXECUTE SQL: alter user test_au_u2 set granted_admin = true; --
+200 OK
+
+
+-- EXECUTE SQL: alter user test_au_u2 set must_change_password = true; --
 200 OK
 
 
@@ -70,9 +74,9 @@ test_au_u2,false,"{""hash_password"":""*****"",""must_change_password"":false,""
 -- AFTER_SORT --
 200 OK
 user_name,is_admin,user_options
-root,true,"{""hash_password"":""*****"",""must_change_password"":true,""comment"":""system admin"",""granted_admin"":false}"
-test_au_u1,true,"{""hash_password"":""*****"",""must_change_password"":false,""granted_admin"":true}"
-test_au_u2,true,"{""hash_password"":""*****"",""must_change_password"":false,""granted_admin"":true}"
+root,true,"{""hash_password"":""*****"",""must_change_password"":true,""comment"":""system admin""}"
+test_au_u1,true,"{""hash_password"":""*****"",""granted_admin"":true}"
+test_au_u2,true,"{""hash_password"":""*****"",""must_change_password"":true,""granted_admin"":true}"
 
 -- EXECUTE SQL: alter user test_au_u1 set granted_admin = false; --
 200 OK

--- a/query_server/test/cases/dcl/alter_user.sql
+++ b/query_server/test/cases/dcl/alter_user.sql
@@ -34,6 +34,9 @@ select * from cluster_schema.users where user_name in ('root', 'test_au_u1', 'te
 --#SORT=true
 alter user test_au_u2 set granted_admin = true;
 
+--#USER_NAME=test_au_u2
+alter user test_au_u2 set must_change_password = true;
+
 --#TENANT=cnosdb
 --#USER_NAME=root
 --#SORT=true

--- a/query_server/test/cases/sys_table/cluster_schema/users.result
+++ b/query_server/test/cases/sys_table/cluster_schema/users.result
@@ -29,7 +29,7 @@
 -- EXECUTE SQL: select * from cluster_schema.users where user_name = 'test_us_u1'; --
 200 OK
 user_name,is_admin,user_options
-test_us_u1,false,"{""hash_password"":""*****"",""must_change_password"":false,""comment"":""test comment"",""granted_admin"":false}"
+test_us_u1,false,"{""hash_password"":""*****"",""comment"":""test comment""}"
 
 -- EXECUTE SQL: alter tenant cnosdb add user test_us_u1 as owner; --
 200 OK
@@ -51,9 +51,9 @@ test_us_u1,false,"{""hash_password"":""*****"",""must_change_password"":false,""
 -- AFTER_SORT --
 200 OK
 user_name,is_admin,user_options
-root,true,"{""hash_password"":""*****"",""must_change_password"":true,""comment"":""system admin"",""granted_admin"":false}"
-test_us_u1,false,"{""hash_password"":""*****"",""must_change_password"":false,""comment"":""test comment"",""granted_admin"":false}"
-test_us_u2,false,"{""hash_password"":""*****"",""must_change_password"":false,""granted_admin"":false}"
+root,true,"{""hash_password"":""*****"",""must_change_password"":true,""comment"":""system admin""}"
+test_us_u1,false,"{""hash_password"":""*****"",""comment"":""test comment""}"
+test_us_u2,false,"{""hash_password"":""*****""}"
 
 -- EXECUTE SQL: select * from cluster_schema.users where user_name in ('root', 'test_us_u1', 'test_us_u2'); --
 -- AFTER_SORT --


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #1757 .

# Rationale for this change

[//]: # (Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.)

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 The unset user options will no longer be displayed.

