### PR TITLE
Fix bugs around compaction

### DIFF
--- a/tskv/src/compaction/compact.rs
+++ b/tskv/src/compaction/compact.rs
@@ -204,49 +204,7 @@ impl CompactingBlockMetaGroup {
             merged_block = head_block;
         }
 
-        self.chunk_merged_block(merged_block, max_block_size)
-    }
-
-    fn chunk_merged_block(
-        &self,
-        data_block: DataBlock,
-        max_block_size: usize,
-    ) -> Result<Vec<CompactingBlock>> {
-        let mut merged_blks = Vec::new();
-        if max_block_size == 0 || data_block.len() < max_block_size {
-            // Data block elements less than max_block_size, do not encode it.
-            // Try to merge with the next CompactingBlockMetaGroup.
-            merged_blks.push(CompactingBlock::decoded(0, self.field_id, data_block));
-        } else {
-            let len = data_block.len();
-            let mut start = 0;
-            let mut end = len.min(max_block_size);
-            while start + end < len {
-                // Encode decoded data blocks into chunks.
-                let encoded_blk =
-                    EncodedDataBlock::encode(&data_block, start, end).map_err(|e| {
-                        Error::WriteTsm {
-                            source: tsm::WriteTsmError::Encode { source: e },
-                        }
-                    })?;
-                merged_blks.push(CompactingBlock::encoded(0, self.field_id, encoded_blk));
-
-                start += end;
-                end = len.min(start + max_block_size);
-            }
-            if start < len {
-                // Encode the remaining decoded data blocks.
-                let encoded_blk =
-                    EncodedDataBlock::encode(&data_block, start, len).map_err(|e| {
-                        Error::WriteTsm {
-                            source: tsm::WriteTsmError::Encode { source: e },
-                        }
-                    })?;
-                merged_blks.push(CompactingBlock::encoded(0, self.field_id, encoded_blk));
-            }
-        }
-
-        Ok(merged_blks)
+        chunk_merged_block(self.field_id, merged_block, max_block_size)
     }
 
     pub fn into_compacting_block_metas(self) -> Vec<CompactingBlockMeta> {
@@ -262,10 +220,41 @@ impl CompactingBlockMetaGroup {
     }
 }
 
+fn chunk_merged_block(
+    field_id: FieldId,
+    data_block: DataBlock,
+    max_block_size: usize,
+) -> Result<Vec<CompactingBlock>> {
+    let mut merged_blks = Vec::new();
+    if max_block_size == 0 || data_block.len() < max_block_size {
+        // Data block elements less than max_block_size, do not encode it.
+        // Try to merge with the next CompactingBlockMetaGroup.
+        merged_blks.push(CompactingBlock::decoded(0, field_id, data_block));
+    } else {
+        let len = data_block.len();
+        let mut start = 0;
+        let mut end = len.min(max_block_size);
+        while start < len {
+            // Encode decoded data blocks into chunks.
+            let encoded_blk =
+                EncodedDataBlock::encode(&data_block, start, end).map_err(|e| Error::WriteTsm {
+                    source: tsm::WriteTsmError::Encode { source: e },
+                })?;
+            merged_blks.push(CompactingBlock::encoded(0, field_id, encoded_blk));
+
+            start = end;
+            end = len.min(start + max_block_size);
+        }
+    }
+
+    Ok(merged_blks)
+}
+
 /// Temporary compacting data block.
 /// - priority: When merging two (timestamp, value) pair with the same
 /// timestamp from two data blocks, pair from data block with lower
 /// priority will be discarded.
+#[derive(Debug, PartialEq)]
 pub(crate) enum CompactingBlock {
     Decoded {
         priority: usize,
@@ -429,10 +418,9 @@ pub(crate) struct CompactIterator {
     /// return CompactingBlock::DataBlock rather than CompactingBlock::Raw .
     decode_non_overlap_blocks: bool,
 
-    tmp_tsm_blk_meta_iters: Vec<BlockMetaIterator>,
-    /// Index to mark `Peekable<BlockMetaIterator>` in witch `TsmReader`,
-    /// tmp_tsm_blks[i] is in self.tsm_readers[ tmp_tsm_blk_tsm_reader_idx[i] ]
-    tmp_tsm_blk_tsm_reader_idx: Vec<usize>,
+    /// Temporarily stored index of `TsmReader` in self.tsm_readers,
+    /// and `BlockMetaIterator` of current field_id.
+    tmp_tsm_blk_meta_iters: Vec<(usize, BlockMetaIterator)>,
     /// When a TSM file at index i is ended, finished_idxes[i] is set to true.
     finished_readers: Vec<bool>,
     /// How many finished_idxes is set to true.
@@ -451,7 +439,6 @@ impl Default for CompactIterator {
             max_data_block_size: 0,
             decode_non_overlap_blocks: false,
             tmp_tsm_blk_meta_iters: Default::default(),
-            tmp_tsm_blk_tsm_reader_idx: Default::default(),
             finished_readers: Default::default(),
             finished_reader_cnt: Default::default(),
             curr_fid: Default::default(),
@@ -501,13 +488,14 @@ impl CompactIterator {
             trace!("no file to select, mark finished");
             self.finished_reader_cnt += 1;
         }
+        self.tmp_tsm_blk_meta_iters.clear();
         while let Some(mut f) = self.compacting_files.pop() {
             let loop_field_id = f.field_id;
             let loop_file_i = f.i;
             if self.curr_fid == loop_field_id {
                 if let Some(idx_meta) = f.peek() {
-                    self.tmp_tsm_blk_meta_iters.push(idx_meta.block_iterator());
-                    self.tmp_tsm_blk_tsm_reader_idx.push(loop_file_i);
+                    self.tmp_tsm_blk_meta_iters
+                        .push((loop_file_i, idx_meta.block_iterator()));
                     trace!("merging idx_meta: field_id: {}, field_type: {:?}, block_count: {}, time_range: {:?}",
                         idx_meta.field_id(),
                         idx_meta.field_type(),
@@ -542,12 +530,11 @@ impl CompactIterator {
         let mut blk_metas: Vec<CompactingBlockMeta> =
             Vec::with_capacity(self.tmp_tsm_blk_meta_iters.len());
         // Get all block_meta, and check if it's tsm file has a related tombstone file.
-        for (i, blk_iter) in self.tmp_tsm_blk_meta_iters.iter_mut().enumerate() {
+        for (tsm_reader_idx, blk_iter) in self.tmp_tsm_blk_meta_iters.iter_mut() {
             for blk_meta in blk_iter.by_ref() {
-                let tsm_reader_idx = self.tmp_tsm_blk_tsm_reader_idx[i];
-                let tsm_reader_ptr = self.tsm_readers[tsm_reader_idx].clone();
+                let tsm_reader_ptr = self.tsm_readers[*tsm_reader_idx].clone();
                 blk_metas.push(CompactingBlockMeta::new(
-                    tsm_reader_idx,
+                    *tsm_reader_idx,
                     tsm_reader_ptr,
                     blk_meta,
                 ));
@@ -913,15 +900,102 @@ pub mod test {
     use models::predicate::domain::TimeRange;
     use models::{FieldId, PhysicalDType as ValueType, Timestamp};
 
-    use crate::compaction::{run_compaction_job, CompactReq};
+    use crate::compaction::compact::chunk_merged_block;
+    use crate::compaction::{run_compaction_job, CompactReq, CompactingBlock};
     use crate::context::GlobalContext;
     use crate::file_system::file_manager;
     use crate::kv_option::Options;
     use crate::summary::VersionEdit;
     use crate::tseries_family::{ColumnFile, LevelInfo, Version};
     use crate::tsm::codec::DataBlockEncoding;
-    use crate::tsm::{self, DataBlock, TsmReader, TsmTombstone};
+    use crate::tsm::{self, DataBlock, EncodedDataBlock, TsmReader, TsmTombstone};
     use crate::{file_utils, ColumnFileId};
+
+    #[test]
+    fn test_chunk_merged_block() {
+        let data_block = DataBlock::U64 {
+            ts: vec![0, 1, 2, 10, 11, 12, 100, 101, 102, 1000, 1001, 1002],
+            val: vec![0, 3, 6, 30, 33, 36, 300, 303, 306, 3000, 3003, 3006],
+            enc: DataBlockEncoding::default(),
+        };
+        let field_id = 1;
+        // Trying to chunk with no chunk size
+        {
+            let chunks = chunk_merged_block(field_id, data_block.clone(), 0).unwrap();
+            assert_eq!(chunks.len(), 1);
+            assert_eq!(
+                chunks[0],
+                CompactingBlock::decoded(0, 1, data_block.clone())
+            );
+        }
+        // Trying to chunk with too big chunk size
+        {
+            let chunks = chunk_merged_block(field_id, data_block.clone(), 100).unwrap();
+            assert_eq!(chunks.len(), 1);
+            assert_eq!(
+                chunks[0],
+                CompactingBlock::decoded(0, 1, data_block.clone())
+            );
+        }
+        // Trying to chunk with chunk size that can divide data block exactly
+        {
+            let chunks = chunk_merged_block(field_id, data_block.clone(), 4).unwrap();
+            assert_eq!(chunks.len(), 3);
+            assert_eq!(
+                chunks[0],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 0, 4).unwrap()
+                )
+            );
+            assert_eq!(
+                chunks[1],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 4, 8).unwrap()
+                )
+            );
+            assert_eq!(
+                chunks[2],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 8, 12).unwrap()
+                )
+            );
+        }
+        // Trying to chunk with chunk size that cannot divide data block exactly
+        {
+            let chunks = chunk_merged_block(field_id, data_block.clone(), 5).unwrap();
+            assert_eq!(chunks.len(), 3);
+            assert_eq!(
+                chunks[0],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 0, 5).unwrap()
+                )
+            );
+            assert_eq!(
+                chunks[1],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 5, 10).unwrap()
+                )
+            );
+            assert_eq!(
+                chunks[2],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 10, 12).unwrap()
+                )
+            );
+        }
+    }
 
     pub(crate) async fn write_data_blocks_to_column_file(
         dir: impl AsRef<Path>,

--- a/tskv/src/tsm/block.rs
+++ b/tskv/src/tsm/block.rs
@@ -1044,6 +1044,15 @@ pub struct EncodedDataBlock {
     pub time_range: Option<TimeRange>,
 }
 
+impl PartialEq for EncodedDataBlock {
+    fn eq(&self, other: &Self) -> bool {
+        self.field_type == other.field_type
+            && self.enc == other.enc
+            && self.ts == other.ts
+            && self.val == other.val
+    }
+}
+
 impl Display for EncodedDataBlock {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let time_range = self.time_range.unwrap_or(TimeRange::none());

--- a/tskv/src/tsm/mod.rs
+++ b/tskv/src/tsm/mod.rs
@@ -8,7 +8,7 @@ mod writer;
 pub use block::*;
 pub use index::*;
 pub use reader::*;
-pub use tombstone::{Tombstone, TsmTombstone};
+pub use tombstone::{Tombstone, TsmTombstone, TOMBSTONE_FILE_SUFFIX};
 pub use writer::*;
 
 // MAX_BLOCK_VALUES is the maximum number of values a TSM block can store.

--- a/tskv/src/tsm/tombstone.rs
+++ b/tskv/src/tsm/tombstone.rs
@@ -27,7 +27,7 @@ use crate::file_system::file_manager;
 use crate::record_file::{self, RecordDataType, RecordDataVersion};
 use crate::{byte_utils, file_utils, Error, Result};
 
-const TOMBSTONE_FILE_SUFFIX: &str = ".tombstone";
+pub const TOMBSTONE_FILE_SUFFIX: &str = "tombstone";
 const FOOTER_MAGIC_NUMBER: u32 = u32::from_be_bytes([b'r', b'o', b'm', b'b']);
 const FOOTER_MAGIC_NUMBER_LEN: usize = 4;
 const ENTRY_LEN: usize = 24; // 8 + 8 + 8


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

Related #.

# Rationale for this change

## Fix some bugs:

### 1. Compaction job failed to start;

`CompactJobInner::enable_compaction` is initialized as `true` but the job starts only when it `compare_exchange(false, true) == Ok(false)`.

https://github.com/cnosdb/cnosdb/blob/3112894e0003a9222e1014b2b34af829916a706d/tskv/src/compaction/job.rs#L122-L134

### 2. Errors in compact::chunk_merged_block();

There may be an error when chunking big blocks, this makes data lost.

### 3. Merge two tmp-fields in CompactIterator for better performance;

Merge `tmp_tsm_blk_meta_iters: Vec<BlockMetaIterator>` and `tmp_tsm_blk_tsm_reader_idx: Vec<usize>` into `tmp_tsm_blk_meta_iters: Vec<(usize, BlockMetaIterator)>`.

### 4. Tombstone files not removed when removing TSM file

Tombstone files may be removed when dropping a `ColumnFile`.

# Are there any user-facing changes?


 

