### PR TITLE
Refactor: let the maximum parallel counting task num of cpus

### DIFF
--- a/tskv/src/compute/count.rs
+++ b/tskv/src/compute/count.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use models::predicate::domain::{TimeRange, TimeRanges};
 use models::{utils as model_utils, ColumnId, FieldId, SeriesId, Timestamp};
 use tokio::runtime::Runtime;
+use tokio::sync::Semaphore;
 use trace::trace;
 
 use crate::tseries_family::{ColumnFile, SuperVersion};
@@ -38,6 +39,9 @@ pub async fn count_column_non_null_values(
     let column_files = Arc::new(super_version.column_files(&time_ranges));
     let mut jh_vec = Vec::with_capacity(series_ids.len());
 
+    // Limit the number of concurrent tasks.
+    let max_count_tasks = num_cpus::get().min(series_ids.len());
+    let count_tasks_limit = Arc::new(Semaphore::new(max_count_tasks));
     for series_id in series_ids.iter() {
         let count_object = if let Some(column_id) = column_id {
             let field_id = model_utils::unite_id(column_id, *series_id);
@@ -47,13 +51,15 @@ pub async fn count_column_non_null_values(
         };
         let sv_inner = super_version.clone();
         let cfs_inner = column_files.clone();
+        let trs_inner = time_ranges.clone();
 
-        jh_vec.push(runtime.spawn(count_non_null_values_inner(
-            sv_inner,
-            count_object,
-            cfs_inner,
-            time_ranges.clone(),
-        )));
+        let permit = count_tasks_limit.clone().acquire_owned().await.unwrap();
+        jh_vec.push(runtime.spawn(async move {
+            let ret =
+                count_non_null_values_inner(sv_inner, count_object, cfs_inner, trs_inner).await;
+            drop(permit);
+            ret
+        }));
     }
 
     let mut count_sum = 0_u64;


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

When there are too many series_ids, too many parallel tasks made counting too slow.

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

