### PR TITLE
Fix: function dedup_by_front dropped wrong element

### DIFF
--- a/common/utils/src/dedup.rs
+++ b/common/utils/src/dedup.rs
@@ -102,10 +102,11 @@ where
             let read_ptr = ptr.add(gap.read);
 
             if same_bucket(&mut *prev_ptr, &mut *read_ptr) {
-                // Increase `gap.read` now since the drop may panic.
+                // Increase `gap.prev` now since the drop may panic.
                 gap.read += 1;
+                gap.prev += 1;
                 /* We have found duplicate, drop it in-place */
-                ptr::drop_in_place(read_ptr);
+                ptr::drop_in_place(prev_ptr);
             } else {
                 let read_ptr = ptr.add(gap.read.wrapping_sub(1));
                 let write_ptr = ptr.add(gap.write);
@@ -173,5 +174,6 @@ fn test_dedup_by() {
         }
     });
 
-    assert_eq!(vec, [("foo", 4), ("bar", 8)]);
+    // 1 + 2 + 3, 3 + 4 + 5
+    assert_eq!(vec, [("foo", 6), ("bar", 12)]);
 }

--- a/tskv/tests/test_kvcore_interface.rs
+++ b/tskv/tests/test_kvcore_interface.rs
@@ -277,6 +277,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_kvcore_recover() {
         let dir = PathBuf::from("/tmp/test/kvcore/kvcore_recover");
         let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

Related #1814.

# Rationale for this change

In some systems, it is an error of "attempt to calculate the remainder with a divisor of zero".

In others it may be a "pointer double free" error

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

