### PR TITLE
Feature: add compaction task for delta files

### DIFF
--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -206,7 +206,7 @@ pub static COMPACTION_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
         .namespace(NAMESPACE)
         .subsystem(TSKV_SUBSYSTEM)
         .buckets(linear_buckets(0.0, 300.0, 2400).unwrap()),
-        &["db", "ts_family", "level"],
+        &["db", "ts_family", "in_level", "out_level"],
     )
     .expect("tskv metric cannot be created")
 });
@@ -231,9 +231,15 @@ pub fn incr_compaction_failed() {
     COMPACTION_FAILED.inc();
 }
 
-pub fn sample_tskv_compaction_duration(db: &str, ts_family: &str, level: &str, delta: f64) {
+pub fn sample_tskv_compaction_duration(
+    db: &str,
+    ts_family: &str,
+    in_level: &str,
+    out_level: &str,
+    delta: f64,
+) {
     COMPACTION_DURATION
-        .with_label_values(&[db, ts_family, level])
+        .with_label_values(&[db, ts_family, in_level, out_level])
         .observe(delta)
 }
 

--- a/common/models/src/predicate/domain.rs
+++ b/common/models/src/predicate/domain.rs
@@ -145,6 +145,35 @@ impl TimeRange {
         };
         (left, right)
     }
+
+    pub fn compact(time_ranges: &mut Vec<TimeRange>) {
+        if time_ranges.is_empty() {
+            return;
+        }
+
+        // Start compact with sorted ascending time ranges
+        time_ranges.sort();
+
+        fn can_compact(a: &TimeRange, b: &TimeRange) -> bool {
+            (a.min_ts <= b.max_ts && a.max_ts >= b.min_ts)
+                || (a.max_ts.checked_add(1).is_some_and(|t| t == b.min_ts))
+                || (b.max_ts.checked_add(1).is_some_and(|t| t == a.min_ts))
+        }
+
+        let mut i = 0;
+        while i < time_ranges.len() - 1 {
+            if can_compact(&time_ranges[i], &time_ranges[i + 1]) {
+                let mut j = i + 1;
+                while j < time_ranges.len() && can_compact(&time_ranges[i], &time_ranges[j]) {
+                    time_ranges[i].max_ts = time_ranges[i].max_ts.max(time_ranges[j].max_ts);
+                    j += 1;
+                }
+                time_ranges.drain(i + 1..j);
+            } else {
+                i += 1;
+            }
+        }
+    }
 }
 
 impl From<(Timestamp, Timestamp)> for TimeRange {
@@ -1802,6 +1831,7 @@ mod tests {
         assert!(tr.overlaps(&TimeRange::new(4, 7)));
         assert!(tr.overlaps(&TimeRange::new(1, 5)));
         assert!(tr.overlaps(&TimeRange::new(2, 4)));
+        assert!(tr.overlaps(&TimeRange::new(5, 6)));
         assert!(!tr.overlaps(&TimeRange::new(-3, -1)));
         assert!(!tr.overlaps(&TimeRange::new(-1, 0)));
         assert!(!tr.overlaps(&TimeRange::new(6, 7)));
@@ -1997,6 +2027,89 @@ mod tests {
         let exclude_ranges =
             trs.exclude_time_ranges(&[&TimeRange::new(3, 4), &TimeRange::new(5, 8)]);
         assert_eq!(expected, exclude_ranges);
+    }
+    #[test]
+    fn test_time_range_sort() {
+        let mut time_range_vec: Vec<TimeRange> = vec![
+            (1, 1).into(),
+            (1, 2).into(),
+            (1, 0).into(),
+            (3, 4).into(),
+            (2, 3).into(),
+            (2, 1).into(),
+        ];
+        time_range_vec.sort();
+        assert_eq!(
+            time_range_vec,
+            vec![
+                (1, 0).into(),
+                (1, 1).into(),
+                (1, 2).into(),
+                (2, 1).into(),
+                (2, 3).into(),
+                (3, 4).into(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_time_range_compact() {
+        {
+            let mut time_range_vec: Vec<TimeRange> = vec![];
+            TimeRange::compact(&mut time_range_vec);
+            assert_eq!(time_range_vec, vec![]);
+        }
+        {
+            let mut time_range_vec: Vec<TimeRange> = vec![(1, 2).into()];
+            TimeRange::compact(&mut time_range_vec);
+            assert_eq!(time_range_vec, vec![(1, 2).into()]);
+        }
+        {
+            let mut time_range_vec: Vec<TimeRange> =
+                vec![(Timestamp::MIN, 999).into(), (1_000, Timestamp::MAX).into()];
+            TimeRange::compact(&mut time_range_vec);
+            assert_eq!(
+                time_range_vec,
+                vec![(Timestamp::MIN, Timestamp::MAX).into()]
+            );
+        }
+        {
+            let mut time_range_vec: Vec<TimeRange> =
+                vec![(Timestamp::MIN, Timestamp::MAX).into(), (999, 1_000).into()];
+            TimeRange::compact(&mut time_range_vec);
+            assert_eq!(
+                time_range_vec,
+                vec![(Timestamp::MIN, Timestamp::MAX).into()]
+            );
+        }
+        {
+            let mut time_range_vec: Vec<TimeRange> =
+                vec![(Timestamp::MIN, 998).into(), (1_000, Timestamp::MAX).into()];
+            TimeRange::compact(&mut time_range_vec);
+            assert_eq!(
+                time_range_vec,
+                vec![(Timestamp::MIN, 998).into(), (1_000, Timestamp::MAX).into()]
+            );
+        }
+        {
+            let mut time_range_vec: Vec<TimeRange> =
+                vec![(1, 2).into(), (3, 4).into(), (9, 10).into()];
+            TimeRange::compact(&mut time_range_vec);
+            assert_eq!(time_range_vec, vec![(1, 4).into(), (9, 10).into()]);
+        }
+        {
+            let mut time_range_vec: Vec<TimeRange> = vec![
+                (5, 5).into(),
+                (1, 10).into(),
+                (0, 5).into(),
+                (3, 6).into(),
+                (5, 9).into(),
+                (20, 30).into(),
+                (21, 29).into(),
+            ];
+            TimeRange::compact(&mut time_range_vec);
+            assert_eq!(time_range_vec, vec![(0, 10).into(), (20, 30).into()]);
+        }
     }
 
     #[test]

--- a/tskv/src/compaction/check.rs
+++ b/tskv/src/compaction/check.rs
@@ -13,8 +13,7 @@ use models::predicate::domain::TimeRange;
 use models::{utils as model_utils, ColumnId, FieldId, SeriesId, Timestamp};
 use tokio::sync::RwLock;
 
-use super::CompactingBlockMeta;
-use crate::compaction::CompactIterator;
+use super::compact::{CompactIterator, CompactingBlockMeta};
 use crate::error::{Error, Result};
 use crate::tseries_family::TseriesFamily;
 use crate::tsm::{DataBlock, TsmReader};

--- a/tskv/src/compaction/compact.rs
+++ b/tskv/src/compaction/compact.rs
@@ -1,6 +1,5 @@
 use std::collections::{BinaryHeap, HashMap, VecDeque};
 use std::fmt::{Display, Formatter};
-use std::pin::Pin;
 use std::sync::Arc;
 
 use models::predicate::domain::TimeRange;
@@ -21,12 +20,13 @@ use crate::tsm::{
 };
 use crate::{ColumnFileId, Error, LevelId, TseriesFamilyId};
 
-/// Temporary compacting data block meta
+/// Temporary compacting data block meta, holding the priority of reader,
+/// the reader and the meta of data block.
 #[derive(Clone)]
 pub(crate) struct CompactingBlockMeta {
-    reader_idx: usize,
-    reader: Arc<TsmReader>,
-    meta: BlockMeta,
+    pub reader_idx: usize,
+    pub reader: Arc<TsmReader>,
+    pub meta: BlockMeta,
 }
 
 impl PartialEq for CompactingBlockMeta {
@@ -83,6 +83,11 @@ impl CompactingBlockMeta {
         self.meta.min_ts() <= time_range.max_ts && self.meta.max_ts() >= time_range.min_ts
     }
 
+    pub fn included_in_time_range(&self, time_range: &TimeRange) -> bool {
+        self.meta.min_ts() >= time_range.min_ts && self.meta.max_ts() <= time_range.max_ts
+    }
+
+    /// Read data block of block meta from reader.
     pub async fn get_data_block(&self) -> Result<DataBlock> {
         self.reader
             .get_data_block(&self.meta)
@@ -90,6 +95,18 @@ impl CompactingBlockMeta {
             .context(error::ReadTsmSnafu)
     }
 
+    /// Read data block of block meta from reader.
+    pub async fn get_data_block_opt(&self, time_range: &TimeRange) -> Result<Option<DataBlock>> {
+        // It's impossible that the reader got None by meta,
+        // or blk.intersection(time_range) returned None.
+        self.reader
+            .get_data_block(&self.meta)
+            .await
+            .map(|blk| blk.intersection(time_range))
+            .context(error::ReadTsmSnafu)
+    }
+
+    /// Read raw data of block meta from reader.
     pub async fn get_raw_data(&self, dst: &mut Vec<u8>) -> Result<usize> {
         self.reader
             .get_raw_data(&self.meta, dst)
@@ -108,6 +125,7 @@ pub(crate) struct CompactingBlockMetaGroup {
     blk_metas: Vec<CompactingBlockMeta>,
     time_range: TimeRange,
 }
+
 impl CompactingBlockMetaGroup {
     pub fn new(field_id: FieldId, blk_meta: CompactingBlockMeta) -> Self {
         let time_range = blk_meta.time_range();
@@ -141,7 +159,7 @@ impl CompactingBlockMetaGroup {
         let merged_block;
         if self.blk_metas.len() == 1 && !self.blk_metas[0].has_tombstone() {
             // Only one compacting block and has no tombstone, write as raw block.
-            trace!("only one compacting block, write as raw block");
+            trace!("only one compacting block without tombstone, handled as raw block");
             let meta_0 = &self.blk_metas[0].meta;
             let mut buf_0 = Vec::with_capacity(meta_0.size() as usize);
             let data_len_0 = self.blk_metas[0].get_raw_data(&mut buf_0).await?;
@@ -174,7 +192,6 @@ impl CompactingBlockMetaGroup {
                 merged_block = data_block;
             } else {
                 // Raw block is not full, but nothing to merge with, directly return.
-
                 return Ok(vec![CompactingBlock::raw(
                     self.blk_metas[0].reader_idx,
                     meta_0.clone(),
@@ -220,6 +237,34 @@ impl CompactingBlockMetaGroup {
     }
 }
 
+impl Display for CompactingBlockMetaGroup {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{field_id: {}, blk_metas: [", self.field_id)?;
+        if !self.blk_metas.is_empty() {
+            write!(f, "{}", &self.blk_metas[0])?;
+            for b in self.blk_metas.iter().skip(1) {
+                write!(f, ", {}", b)?;
+            }
+        }
+        write!(f, "]}}")
+    }
+}
+
+struct CompactingBlockMetaGroupsVecDeque<'a>(&'a VecDeque<CompactingBlockMetaGroup>);
+
+impl<'a> Display for CompactingBlockMetaGroupsVecDeque<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut iter = self.0.iter();
+        if let Some(d) = iter.next() {
+            write!(f, "{}", d)?;
+            for d in iter {
+                write!(f, ", {d}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
 fn chunk_merged_block(
     field_id: FieldId,
     data_block: DataBlock,
@@ -231,6 +276,7 @@ fn chunk_merged_block(
         // Try to merge with the next CompactingBlockMetaGroup.
         merged_blks.push(CompactingBlock::decoded(0, field_id, data_block));
     } else {
+        // Data block is so big that split into multi CompactingBlock
         let len = data_block.len();
         let mut start = 0;
         let mut end = len.min(max_block_size);
@@ -290,15 +336,20 @@ impl Display for CompactingBlock {
             } => {
                 write!(f, "p: {priority}, f: {field_id}, block: {data_block}")
             }
-            CompactingBlock::Raw { priority, meta, .. } => {
+            CompactingBlock::Raw {
+                priority,
+                meta,
+                raw,
+            } => {
                 write!(
                     f,
-                    "p: {priority}, f: {}, block: {}: {{ len: {}, min_ts: {}, max_ts: {} }}",
+                    "p: {priority}, f: {}, block: {}: {{ len: {}, min_ts: {}, max_ts: {}, raw_len: {} }}",
                     meta.field_id(),
                     meta.field_type(),
                     meta.count(),
                     meta.min_ts(),
-                    meta.max_ts()
+                    meta.max_ts(),
+                    raw.len(),
                 )
             }
         }
@@ -347,6 +398,28 @@ impl CompactingBlock {
         }
     }
 
+    /// Decode data block and return the intersected segment with out_time_range.
+    pub fn decode_opt(self, out_time_range: &TimeRange) -> Result<Option<DataBlock>> {
+        let data_block = match self {
+            CompactingBlock::Decoded { data_block, .. } => data_block,
+            CompactingBlock::Encoded { data_block, .. } => {
+                data_block.decode().context(error::DecodeSnafu)?
+            }
+            CompactingBlock::Raw { raw, meta, .. } => {
+                tsm::decode_data_block(&raw, meta.field_type(), meta.val_off() - meta.offset())
+                    .context(error::ReadTsmSnafu)?
+            }
+        };
+        if data_block
+            .time_range()
+            .is_some_and(|(min_ts, _max_ts)| min_ts < out_time_range.max_ts)
+        {
+            Ok(data_block.intersection(out_time_range))
+        } else {
+            Ok(None)
+        }
+    }
+
     pub fn len(&self) -> usize {
         match self {
             CompactingBlock::Decoded { data_block, .. } => data_block.len(),
@@ -356,32 +429,38 @@ impl CompactingBlock {
     }
 }
 
-struct CompactingFile {
-    i: usize,
-    tsm_reader: Arc<TsmReader>,
-    index_iter: BufferedIterator<IndexIterator>,
-    field_id: Option<FieldId>,
+pub(crate) struct CompactingFile {
+    pub i: usize,
+    pub tsm_reader: Arc<TsmReader>,
+    pub index_iter: BufferedIterator<IndexIterator>,
+    pub field_id: FieldId,
 }
 
 impl CompactingFile {
-    fn new(i: usize, tsm_reader: Arc<TsmReader>) -> Self {
+    pub(crate) fn new(i: usize, tsm_reader: Arc<TsmReader>) -> Option<Self> {
         let mut index_iter = BufferedIterator::new(tsm_reader.index_iterator());
-        let first_field_id = index_iter.peek().map(|i| i.field_id());
-        Self {
-            i,
-            tsm_reader,
-            index_iter,
-            field_id: first_field_id,
+        index_iter
+            .peek()
+            .map(|idx_meta| idx_meta.field_id())
+            .map(|field_id| Self {
+                i,
+                tsm_reader,
+                index_iter,
+                field_id,
+            })
+    }
+
+    /// Fetch the next index meta of tsm-file, field_id may be changed.
+    pub(crate) fn next(&mut self) -> Option<&IndexMeta> {
+        if let Some(idx_meta) = self.index_iter.next() {
+            self.field_id = idx_meta.field_id();
+            Some(idx_meta)
+        } else {
+            None
         }
     }
 
-    fn next(&mut self) -> Option<&IndexMeta> {
-        let idx_meta = self.index_iter.next();
-        idx_meta.map(|i| self.field_id.replace(i.field_id()));
-        idx_meta
-    }
-
-    fn peek(&mut self) -> Option<&IndexMeta> {
+    pub(crate) fn peek(&mut self) -> Option<&IndexMeta> {
         self.index_iter.peek()
     }
 }
@@ -408,17 +487,15 @@ impl PartialOrd for CompactingFile {
 
 pub(crate) struct CompactIterator {
     tsm_readers: Vec<Arc<TsmReader>>,
-    compacting_files: BinaryHeap<Pin<Box<CompactingFile>>>,
+    compacting_files: BinaryHeap<CompactingFile>,
     /// Maximum values in generated CompactingBlock
     max_data_block_size: usize,
-    // /// The time range of data to be merged of level-0 data blocks.
-    // /// The level-0 data that out of the thime range will write back to level-0.
-    // level_time_range: TimeRange,
     /// Decode a data block even though it doesn't need to merge with others,
     /// return CompactingBlock::DataBlock rather than CompactingBlock::Raw .
     decode_non_overlap_blocks: bool,
 
     /// Temporarily stored index of `TsmReader` in self.tsm_readers,
+    /// and if `TsmReader` is a delta file,
     /// and `BlockMetaIterator` of current field_id.
     tmp_tsm_blk_meta_iters: Vec<(usize, BlockMetaIterator)>,
     /// When a TSM file at index i is ended, finished_idxes[i] is set to true.
@@ -453,25 +530,31 @@ impl CompactIterator {
         max_data_block_size: usize,
         decode_non_overlap_blocks: bool,
     ) -> Self {
-        let compacting_files: BinaryHeap<Pin<Box<CompactingFile>>> = tsm_readers
-            .iter()
-            .enumerate()
-            .map(|(i, r)| Box::pin(CompactingFile::new(i, r.clone())))
-            .collect();
-        let compacting_files_cnt = compacting_files.len();
+        let mut compacting_tsm_readers = Vec::with_capacity(tsm_readers.len());
+        let mut compacting_files = BinaryHeap::with_capacity(tsm_readers.len());
+        let mut compacting_tsm_file_idx = 0_usize;
+        for tsm_reader in tsm_readers {
+            if let Some(cf) = CompactingFile::new(compacting_tsm_file_idx, tsm_reader.clone()) {
+                compacting_tsm_readers.push(tsm_reader);
+                compacting_files.push(cf);
+                compacting_tsm_file_idx += 1;
+            }
+        }
 
         Self {
-            tsm_readers,
+            tsm_readers: compacting_tsm_readers,
             compacting_files,
             max_data_block_size,
             decode_non_overlap_blocks,
-            finished_readers: vec![false; compacting_files_cnt],
+            tmp_tsm_blk_meta_iters: Vec::with_capacity(compacting_tsm_file_idx),
+            finished_readers: vec![false; compacting_tsm_file_idx],
             ..Default::default()
         }
     }
 
     /// Update tmp_tsm_blks and tmp_tsm_blk_tsm_reader_idx for field id in next iteration.
     fn next_field_id(&mut self) {
+        trace!("===============================");
         self.curr_fid = None;
 
         if let Some(f) = self.compacting_files.peek() {
@@ -481,7 +564,7 @@ impl CompactIterator {
                     f.field_id,
                     f.tsm_reader.file_id()
                 );
-                self.curr_fid = f.field_id
+                self.curr_fid = Some(f.field_id);
             }
         } else {
             // TODO finished
@@ -489,14 +572,15 @@ impl CompactIterator {
             self.finished_reader_cnt += 1;
         }
         self.tmp_tsm_blk_meta_iters.clear();
+        let mut loop_file_i;
         while let Some(mut f) = self.compacting_files.pop() {
-            let loop_field_id = f.field_id;
-            let loop_file_i = f.i;
-            if self.curr_fid == loop_field_id {
+            loop_file_i = f.i;
+            if self.curr_fid.is_some_and(|fid| fid == f.field_id) {
                 if let Some(idx_meta) = f.peek() {
                     self.tmp_tsm_blk_meta_iters
                         .push((loop_file_i, idx_meta.block_iterator()));
-                    trace!("merging idx_meta: field_id: {}, field_type: {:?}, block_count: {}, time_range: {:?}",
+                    trace!("merging idx_meta({}): field_id: {}, field_type: {:?}, block_count: {}, time_range: {:?}",
+                        self.tmp_tsm_blk_meta_iters.len(),
                         idx_meta.field_id(),
                         idx_meta.field_type(),
                         idx_meta.block_count(),
@@ -505,12 +589,13 @@ impl CompactIterator {
                     f.next();
                     self.compacting_files.push(f);
                 } else {
-                    // This tsm-file has been finished
-                    trace!("file {} is finished.", loop_file_i);
+                    // This tsm-file has been finished, do not push it back.
+                    trace!("file {loop_file_i} is finished.");
                     self.finished_readers[loop_file_i] = true;
                     self.finished_reader_cnt += 1;
                 }
             } else {
+                // This tsm-file do not need to compact at this time, push it back.
                 self.compacting_files.push(f);
                 break;
             }
@@ -518,7 +603,7 @@ impl CompactIterator {
     }
 
     /// Collect merging `DataBlock`s.
-    async fn fetch_merging_block_meta_groups(&mut self) -> bool {
+    fn fetch_merging_block_meta_groups(&mut self) -> bool {
         if self.tmp_tsm_blk_meta_iters.is_empty() {
             return false;
         }
@@ -579,20 +664,10 @@ impl CompactIterator {
             .into_iter()
             .filter(|l| !l.is_empty())
             .collect();
+
         trace!(
             "selected merging meta groups: {}",
-            blk_meta_groups
-                .iter()
-                .map(|g| format!(
-                    "[{}]",
-                    g.blk_metas
-                        .iter()
-                        .map(|b| format!("{}", b))
-                        .collect::<Vec<String>>()
-                        .join(", ")
-                ))
-                .collect::<Vec<String>>()
-                .join(", ")
+            CompactingBlockMetaGroupsVecDeque(&blk_meta_groups),
         );
 
         self.merging_blk_meta_groups = blk_meta_groups;
@@ -621,7 +696,7 @@ impl CompactIterator {
         }
 
         // Get all of block_metas of this field id, and merge these blocks
-        self.fetch_merging_block_meta_groups().await;
+        self.fetch_merging_block_meta_groups();
 
         if let Some(g) = self.merging_blk_meta_groups.pop_front() {
             return Some(g);
@@ -643,24 +718,7 @@ pub async fn run_compaction_job(
     request: CompactReq,
     kernel: Arc<GlobalContext>,
 ) -> Result<Option<(VersionEdit, HashMap<ColumnFileId, Arc<BloomFilter>>)>> {
-    info!(
-        "Compaction: Running compaction job on ts_family: {} and files: [ {} ]",
-        request.ts_family_id,
-        request
-            .files
-            .iter()
-            .map(|f| {
-                format!(
-                    "{{ Level-{}, file_id: {}, time_range: {}-{} }}",
-                    f.level(),
-                    f.file_id(),
-                    f.time_range().min_ts,
-                    f.time_range().max_ts
-                )
-            })
-            .collect::<Vec<String>>()
-            .join(", ")
-    );
+    info!("Compaction: Running compaction job on {request}");
 
     if request.files.is_empty() {
         // Nothing to compact
@@ -677,7 +735,9 @@ pub async fn run_compaction_job(
 
     let max_block_size = TseriesFamily::MAX_DATA_BLOCK_SIZE as usize;
     let mut iter = CompactIterator::new(tsm_readers, max_block_size, false);
-    let tsm_dir = request.storage_opt.tsm_dir(&request.database, tsf_id);
+    let tsm_dir = request
+        .storage_opt
+        .tsm_dir(&request.tenant_database, tsf_id);
     let mut tsm_writer = tsm::new_tsm_writer(&tsm_dir, kernel.file_id_next(), false, 0).await?;
     info!(
         "Compaction: File: {} been created (level: {}).",
@@ -897,11 +957,11 @@ pub mod test {
 
     use cache::ShardedAsyncCache;
     use minivec::MiniVec;
+    use models::codec::Encoding;
     use models::predicate::domain::TimeRange;
     use models::{FieldId, PhysicalDType as ValueType, Timestamp};
 
-    use crate::compaction::compact::chunk_merged_block;
-    use crate::compaction::{run_compaction_job, CompactReq, CompactingBlock};
+    use super::{chunk_merged_block, run_compaction_job, CompactReq, CompactingBlock};
     use crate::context::GlobalContext;
     use crate::file_system::file_manager;
     use crate::kv_option::Options;
@@ -909,7 +969,7 @@ pub mod test {
     use crate::tseries_family::{ColumnFile, LevelInfo, Version};
     use crate::tsm::codec::DataBlockEncoding;
     use crate::tsm::{self, DataBlock, EncodedDataBlock, TsmReader, TsmTombstone};
-    use crate::{file_utils, ColumnFileId};
+    use crate::{file_utils, ColumnFileId, LevelId};
 
     #[test]
     fn test_chunk_merged_block() {
@@ -997,7 +1057,7 @@ pub mod test {
         }
     }
 
-    pub(crate) async fn write_data_blocks_to_column_file(
+    pub async fn write_data_blocks_to_column_file(
         dir: impl AsRef<Path>,
         data: Vec<HashMap<FieldId, Vec<DataBlock>>>,
     ) -> (u64, Vec<Arc<ColumnFile>>) {
@@ -1024,13 +1084,13 @@ pub mod test {
                 false,
                 writer.path(),
             );
-            cf.set_field_id_filter(Arc::new(writer.bloom_filter_cloned()));
+            cf.set_field_id_filter(Arc::new(writer.into_bloom_filter()));
             cfs.push(Arc::new(cf));
         }
         (file_seq + 1, cfs)
     }
 
-    async fn read_data_blocks_from_column_file(
+    pub async fn read_data_blocks_from_column_file(
         path: impl AsRef<Path>,
     ) -> HashMap<FieldId, Vec<DataBlock>> {
         let tsm_reader = TsmReader::open(path).await.unwrap();
@@ -1045,27 +1105,41 @@ pub mod test {
         data
     }
 
-    fn get_result_file_path(dir: impl AsRef<Path>, version_edit: VersionEdit) -> PathBuf {
+    fn get_result_file_path(
+        dir: impl AsRef<Path>,
+        version_edit: VersionEdit,
+        level: LevelId,
+    ) -> PathBuf {
         if version_edit.has_file_id && !version_edit.add_files.is_empty() {
-            let file_id = version_edit.add_files.first().unwrap().file_id;
-            return file_utils::make_tsm_file(dir, file_id);
+            if let Some(f) = version_edit
+                .add_files
+                .into_iter()
+                .find(|f| f.level == level)
+            {
+                if level == 0 {
+                    return file_utils::make_delta_file(dir, f.file_id);
+                } else {
+                    return file_utils::make_tsm_file(dir, f.file_id);
+                }
+            }
+            panic!("VersionEdit::add_files doesn't contain any file matches level-{level}.");
         }
-
-        panic!("VersionEdit doesn't contain any add_files.");
+        panic!("VersionEdit::add_files is empty, no file to read.");
     }
 
     /// Compare DataBlocks in path with the expected_Data using assert_eq.
-    async fn check_column_file(
+    pub async fn check_column_file(
         dir: impl AsRef<Path>,
         version_edit: VersionEdit,
         expected_data: HashMap<FieldId, Vec<DataBlock>>,
+        expected_data_level: LevelId,
     ) {
-        let path = get_result_file_path(dir, version_edit);
+        let path = get_result_file_path(dir, version_edit, expected_data_level);
         let data = read_data_blocks_from_column_file(path).await;
         let mut data_field_ids = data.keys().copied().collect::<Vec<_>>();
-        data_field_ids.sort_unstable();
+        data_field_ids.sort();
         let mut expected_data_field_ids = expected_data.keys().copied().collect::<Vec<_>>();
-        expected_data_field_ids.sort_unstable();
+        expected_data_field_ids.sort();
         assert_eq!(data_field_ids, expected_data_field_ids);
 
         for (k, v) in expected_data.iter() {
@@ -1073,7 +1147,7 @@ pub mod test {
             if v.len() != data_blks.len() {
                 let v_str = format_data_blocks(v.as_slice());
                 let data_blks_str = format_data_blocks(data_blks.as_slice());
-                panic!("fid={k}, v.len != data_blks.len: v={v_str}, data_blks={data_blks_str}")
+                panic!("fid={k}, v.len != data_blks.len:\n          v={v_str}\n  data_blks={data_blks_str}")
             }
             assert_eq!(v.len(), data_blks.len());
             for (v_idx, v_blk) in v.iter().enumerate() {
@@ -1082,40 +1156,43 @@ pub mod test {
         }
     }
 
-    pub(crate) fn create_options(base_dir: String) -> Arc<Options> {
+    pub fn create_options(base_dir: String) -> Arc<Options> {
         let mut config = config::get_config_for_test();
-        config.storage.path = base_dir;
-        let opt = Options::from(&config);
-        Arc::new(opt)
+        config.storage.path = base_dir.clone();
+        config.log.path = base_dir;
+        Arc::new(Options::from(&config))
     }
 
-    fn prepare_compact_req_and_kernel(
-        database: Arc<String>,
+    pub fn prepare_compaction(
+        tenant_database: Arc<String>,
         opt: Arc<Options>,
-        next_file_id: u64,
+        next_file_id: ColumnFileId,
         files: Vec<Arc<ColumnFile>>,
+        max_level_ts: Timestamp,
     ) -> (CompactReq, Arc<GlobalContext>) {
         let version = Arc::new(Version::new(
             1,
-            database.clone(),
+            tenant_database.clone(),
             opt.storage.clone(),
             1,
-            LevelInfo::init_levels(database.clone(), 0, opt.storage.clone()),
-            1000,
+            LevelInfo::init_levels(tenant_database.clone(), 0, opt.storage.clone()),
+            max_level_ts,
             Arc::new(ShardedAsyncCache::create_lru_sharded_cache(1)),
         ));
         let compact_req = CompactReq {
             ts_family_id: 1,
-            database,
+            tenant_database,
             storage_opt: opt.storage.clone(),
             files,
             version,
+            in_level: 1,
             out_level: 2,
+            max_ts: Timestamp::MAX,
         };
-        let kernel = Arc::new(GlobalContext::new());
-        kernel.set_file_id(next_file_id);
+        let context = Arc::new(GlobalContext::new());
+        context.set_file_id(next_file_id);
 
-        (compact_req, kernel)
+        (compact_req, context)
     }
 
     fn format_data_blocks(data_blocks: &[DataBlock]) -> String {
@@ -1129,6 +1206,7 @@ pub mod test {
         )
     }
 
+    /// Test compaction with ordered data.
     #[tokio::test]
     async fn test_compaction_fast() {
         #[rustfmt::skip]
@@ -1156,104 +1234,117 @@ pub mod test {
             (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
         ]);
 
-        let dir = "/tmp/test/compaction";
-        let database = Arc::new("dba".to_string());
+        let dir = "/tmp/test/compaction/0";
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
+        let max_level_ts = 9;
 
         let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, files);
+            prepare_compaction(tenant_database, opt, next_file_id, files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
+
+    const INT_BLOCK_ENCODING: DataBlockEncoding =
+        DataBlockEncoding::new(Encoding::Delta, Encoding::Delta);
 
     #[tokio::test]
     async fn test_compaction_1() {
         #[rustfmt::skip]
         let data = vec![
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
             ]),
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
             ]),
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
             ]),
         ];
         #[rustfmt::skip]
         let expected_data = HashMap::from([
-            (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (2, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
+            (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (2, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
         ]);
 
         let dir = "/tmp/test/compaction/1";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
+        let max_level_ts = 9;
 
         let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, files);
+            prepare_compaction(tenant_database, opt, next_file_id, files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
+    /// Test compact with duplicate timestamp.
     #[tokio::test]
     async fn test_compaction_2() {
         #[rustfmt::skip]
         let data = vec![
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4], val: vec![1, 2, 3, 5], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4], val: vec![1, 2, 3, 5], enc: DataBlockEncoding::default() }]),
-                (4, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4], val: vec![1, 2, 3, 5], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4], val: vec![1, 2, 3, 5], enc: INT_BLOCK_ENCODING }]),
+                (4, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
             ]),
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![4, 5, 6, 7], val: vec![4, 5, 6, 8], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![4, 5, 6, 7], val: vec![4, 5, 6, 8], enc: INT_BLOCK_ENCODING }]),
             ]),
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
             ]),
         ];
         #[rustfmt::skip]
         let expected_data = HashMap::from([
-            (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (2, vec![DataBlock::I64 { ts: vec![4, 5, 6, 7, 8, 9], val: vec![4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (4, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
+            (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (2, vec![DataBlock::I64 { ts: vec![4, 5, 6, 7, 8, 9], val: vec![4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (4, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
         ]);
 
         let dir = "/tmp/test/compaction/2";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
+        let max_level_ts = 9;
 
         let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, files);
+            prepare_compaction(tenant_database, opt, next_file_id, files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
     /// Returns a generated `DataBlock` with default value and specified size, `DataBlock::ts`
@@ -1266,7 +1357,10 @@ pub mod test {
     /// - Float: 1.0
     /// - Boolean: true
     /// - Unknown: will create a panic
-    fn generate_data_block(value_type: ValueType, data_descriptors: Vec<(i64, i64)>) -> DataBlock {
+    pub fn generate_data_block(
+        value_type: ValueType,
+        data_descriptors: Vec<(i64, i64)>,
+    ) -> DataBlock {
         match value_type {
             ValueType::Unsigned => {
                 let mut ts_vec: Vec<Timestamp> = Vec::with_capacity(1000);
@@ -1280,7 +1374,7 @@ pub mod test {
                 DataBlock::U64 {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::Delta),
                 }
             }
             ValueType::Integer => {
@@ -1295,11 +1389,11 @@ pub mod test {
                 DataBlock::I64 {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::Delta),
                 }
             }
             ValueType::String => {
-                let word = MiniVec::from(&b"1"[..]);
+                let word = MiniVec::from(&b"hello_world"[..]);
                 let mut ts_vec: Vec<Timestamp> = Vec::with_capacity(10000);
                 let mut val_vec: Vec<MiniVec<u8>> = Vec::with_capacity(10000);
                 for (min_ts, max_ts) in data_descriptors {
@@ -1311,7 +1405,7 @@ pub mod test {
                 DataBlock::Str {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::Snappy),
                 }
             }
             ValueType::Float => {
@@ -1326,7 +1420,7 @@ pub mod test {
                 DataBlock::F64 {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::Gorilla),
                 }
             }
             ValueType::Boolean => {
@@ -1341,7 +1435,7 @@ pub mod test {
                 DataBlock::Bool {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::BitPack),
                 }
             }
             ValueType::Unknown => {
@@ -1350,10 +1444,56 @@ pub mod test {
         }
     }
 
+    pub type TsmSchema = (
+        ColumnFileId,                                    // tsm file id
+        Vec<(ValueType, FieldId, Timestamp, Timestamp)>, // Data block definitions
+        Vec<(FieldId, Timestamp, Timestamp)>,            // Tombstone definitions
+    );
+
+    pub async fn write_data_block_desc(
+        dir: impl AsRef<Path>,
+        data_desc: &[TsmSchema],
+    ) -> Vec<Arc<ColumnFile>> {
+        let mut column_files = Vec::new();
+        for (tsm_sequence, tsm_desc, tombstone_desc) in data_desc.iter() {
+            let mut tsm_writer = tsm::new_tsm_writer(&dir, *tsm_sequence, false, 0)
+                .await
+                .unwrap();
+            for &(val_type, fid, min_ts, max_ts) in tsm_desc.iter() {
+                tsm_writer
+                    .write_block(fid, &generate_data_block(val_type, vec![(min_ts, max_ts)]))
+                    .await
+                    .unwrap();
+            }
+            tsm_writer.write_index().await.unwrap();
+            tsm_writer.finish().await.unwrap();
+            let tsm_tombstone = TsmTombstone::open(&dir, *tsm_sequence).await.unwrap();
+            for (fid, min_ts, max_ts) in tombstone_desc.iter() {
+                tsm_tombstone
+                    .add_range(&[*fid][..], &TimeRange::new(*min_ts, *max_ts), None)
+                    .await
+                    .unwrap();
+            }
+
+            tsm_tombstone.flush().await.unwrap();
+            column_files.push(Arc::new(ColumnFile::new(
+                *tsm_sequence,
+                2,
+                TimeRange::new(tsm_writer.min_ts(), tsm_writer.max_ts()),
+                tsm_writer.size(),
+                false,
+                tsm_writer.path(),
+            )));
+        }
+
+        column_files
+    }
+
+    /// Test compaction without tombstones.
     #[tokio::test]
     async fn test_compaction_3() {
         #[rustfmt::skip]
-        let data_desc = [
+        let data_desc: [TsmSchema; 3] = [
             // [( tsm_sequence, vec![ (ValueType, FieldId, Timestamp_Begin, Timestamp_end) ] )]
             (1_u64, vec![
                 // 1, 1~2500
@@ -1366,7 +1506,7 @@ pub mod test {
                 // 3, 1~1500
                 (ValueType::Boolean, 3, 1, 1000),
                 (ValueType::Boolean, 3, 1001, 1500),
-            ]),
+            ], vec![]),
             (2, vec![
                 // 1, 2001~4500
                 (ValueType::Unsigned, 1, 2001, 3000),
@@ -1381,7 +1521,7 @@ pub mod test {
                 // 4, 1~1500
                 (ValueType::Float, 4, 1, 1000),
                 (ValueType::Float, 4, 1001, 1500),
-            ]),
+            ], vec![]),
             (3, vec![
                 // 1, 4001~6500
                 (ValueType::Unsigned, 1, 4001, 5000),
@@ -1396,7 +1536,7 @@ pub mod test {
                 // 4. 1001~2500
                 (ValueType::Float, 4, 1001, 2000),
                 (ValueType::Float, 4, 2001, 2500),
-            ]),
+            ], vec![]),
         ];
         #[rustfmt::skip]
         let expected_data: HashMap<FieldId, Vec<DataBlock>> = HashMap::from(
@@ -1436,102 +1576,46 @@ pub mod test {
         );
 
         let dir = "/tmp/test/compaction/3";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
+        let max_level_ts = 6500;
 
-        let mut column_files = Vec::new();
-        for (tsm_sequence, args) in data_desc.iter() {
-            let mut tsm_writer = tsm::new_tsm_writer(&dir, *tsm_sequence, false, 0)
-                .await
-                .unwrap();
-            for arg in args.iter() {
-                tsm_writer
-                    .write_block(arg.1, &generate_data_block(arg.0, vec![(arg.2, arg.3)]))
-                    .await
-                    .unwrap();
-            }
-            tsm_writer.write_index().await.unwrap();
-            tsm_writer.finish().await.unwrap();
-            column_files.push(Arc::new(ColumnFile::new(
-                *tsm_sequence,
-                2,
-                TimeRange::new(tsm_writer.min_ts(), tsm_writer.max_ts()),
-                tsm_writer.size(),
-                false,
-                tsm_writer.path(),
-            )));
-        }
-
+        let column_files = write_data_block_desc(&dir, &data_desc).await;
         let next_file_id = 4_u64;
 
-        let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
-
+        let (compact_req, kernel) = prepare_compaction(
+            tenant_database,
+            opt,
+            next_file_id,
+            column_files,
+            max_level_ts,
+        );
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
 
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
-    #[allow(clippy::type_complexity)]
-    async fn write_data_block_desc(
-        dir: impl AsRef<Path>,
-        data_desc: &[(
-            ColumnFileId,
-            Vec<(ValueType, FieldId, Timestamp, Timestamp)>,
-            Vec<(FieldId, Timestamp, Timestamp)>,
-        )],
-    ) -> Vec<Arc<ColumnFile>> {
-        let mut column_files = Vec::new();
-        for (tsm_sequence, tsm_desc, tombstone_desc) in data_desc.iter() {
-            let mut tsm_writer = tsm::new_tsm_writer(&dir, *tsm_sequence, false, 0)
-                .await
-                .unwrap();
-            for &(val_type, fid, min_ts, max_ts) in tsm_desc.iter() {
-                tsm_writer
-                    .write_block(fid, &generate_data_block(val_type, vec![(min_ts, max_ts)]))
-                    .await
-                    .unwrap();
-            }
-            tsm_writer.write_index().await.unwrap();
-            tsm_writer.finish().await.unwrap();
-            let tsm_tombstone = TsmTombstone::open(&dir, *tsm_sequence).await.unwrap();
-            for (fid, min_ts, max_ts) in tombstone_desc.iter() {
-                tsm_tombstone
-                    .add_range(&[*fid][..], &TimeRange::new(*min_ts, *max_ts), None)
-                    .await
-                    .unwrap();
-            }
-
-            tsm_tombstone.flush().await.unwrap();
-            column_files.push(Arc::new(ColumnFile::new(
-                *tsm_sequence,
-                2,
-                TimeRange::new(tsm_writer.min_ts(), tsm_writer.max_ts()),
-                tsm_writer.size(),
-                false,
-                tsm_writer.path(),
-            )));
-        }
-
-        column_files
-    }
-
+    /// Test compaction with tombstones
     #[tokio::test]
     async fn test_compaction_4() {
         #[rustfmt::skip]
-        let data_desc = [
-            // [( tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)], vec![Option<(FieldId, MinTimestamp, MaxTimestamp)>] )]
-            (1_u64, vec![
+        let data_desc: [TsmSchema; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
                 // 1, 1~2500
-                (ValueType::Unsigned, 1_u64, 1_i64, 1000_i64), (ValueType::Unsigned, 1, 1001, 2000), (ValueType::Unsigned, 1, 2001, 2500),
-            ], vec![(1_u64, 1_i64, 2_i64), (1, 2001, 2100)]),
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000), (ValueType::Unsigned, 1, 2001, 2500),
+            ], vec![(1, 1, 2), (1, 2001, 2100)]),
             (2, vec![
                 // 1, 2001~4500
                 // 2101~3100, 3101~4100, 4101~4499
@@ -1560,40 +1644,50 @@ pub mod test {
         );
 
         let dir = "/tmp/test/compaction/4";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
+        let max_level_ts = 6500;
 
         let column_files = write_data_block_desc(&dir, &data_desc).await;
         let next_file_id = 4_u64;
-        let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
-
+        let (compact_req, kernel) = prepare_compaction(
+            tenant_database,
+            opt,
+            next_file_id,
+            column_files,
+            max_level_ts,
+        );
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
 
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
+    /// Test compaction with multi-field and tombstones.
     #[tokio::test]
     async fn test_compaction_5() {
         #[rustfmt::skip]
-        let data_desc = [
-            // [( tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)], vec![Option<(FieldId, MinTimestamp, MaxTimestamp)>] )]
-            (1_u64, vec![
+        let data_desc: [TsmSchema; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
                 // 1, 1~2500
-                (ValueType::Unsigned, 1_u64, 1_i64, 1000_i64), (ValueType::Unsigned, 1, 1001, 2000),  (ValueType::Unsigned, 1, 2001, 2500),
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000),  (ValueType::Unsigned, 1, 2001, 2500),
                 // 2, 1~1500
                 (ValueType::Integer, 2, 1, 1000), (ValueType::Integer, 2, 1001, 1500),
                 // 3, 1~1500
                 (ValueType::Boolean, 3, 1, 1000), (ValueType::Boolean, 3, 1001, 1500),
             ], vec![
-                (1_u64, 1_i64, 2_i64), (1, 2001, 2100),
+                (1, 1, 2), (1, 2001, 2100),
                 (2, 1001, 1002),
                 (3, 1499, 1500),
             ]),
@@ -1663,23 +1757,30 @@ pub mod test {
         );
 
         let dir = "/tmp/test/compaction/5";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
+        let max_level_ts = 6500;
 
         let column_files = write_data_block_desc(&dir, &data_desc).await;
         let next_file_id = 4_u64;
-        let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
-
+        let (compact_req, kernel) = prepare_compaction(
+            tenant_database,
+            opt,
+            next_file_id,
+            column_files,
+            max_level_ts,
+        );
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
 
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 }

--- a/tskv/src/compaction/delta_compact.rs
+++ b/tskv/src/compaction/delta_compact.rs
@@ -1,0 +1,1119 @@
+use std::collections::{BinaryHeap, HashMap};
+use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use models::predicate::domain::{TimeRange, TimeRanges};
+use models::FieldId;
+use snafu::ResultExt;
+use utils::BloomFilter;
+
+use crate::compaction::compact::{CompactingBlock, CompactingBlockMeta, CompactingFile};
+use crate::compaction::CompactReq;
+use crate::context::GlobalContext;
+use crate::error::{self, Result};
+use crate::summary::{CompactMeta, VersionEdit};
+use crate::tseries_family::TseriesFamily;
+use crate::tsm::{
+    self, BlockMetaIterator, DataBlock, EncodedDataBlock, TsmReader, TsmWriter, WriteTsmError,
+    WriteTsmResult,
+};
+use crate::{ColumnFileId, Error, LevelId, TseriesFamilyId};
+
+pub async fn run_compaction_job(
+    request: CompactReq,
+    kernel: Arc<GlobalContext>,
+) -> Result<Option<(VersionEdit, HashMap<ColumnFileId, Arc<BloomFilter>>)>> {
+    let out_time_range = TimeRange::new(0, request.max_ts);
+    trace::info!("Compaction(delta): Running compaction job on {request}");
+
+    if request.files.is_empty() {
+        // Nothing to compact
+        return Ok(None);
+    }
+
+    // Buffers all tsm-files and it's indexes for this compaction
+    let mut tsm_readers = Vec::new();
+    for col_file in request.files.iter() {
+        let tsm_reader = request.version.get_tsm_reader(col_file.file_path()).await?;
+        tsm_reader
+            .add_tombstone_and_compact_to_tmp(&out_time_range)
+            .await?;
+        tsm_readers.push(tsm_reader);
+    }
+
+    let max_block_size = TseriesFamily::MAX_DATA_BLOCK_SIZE as usize;
+    let mut state = CompactState::new(tsm_readers, out_time_range, max_block_size);
+    let mut writer_wrapper = WriterWrapper::new(&request, kernel.clone());
+
+    let mut previous_merged_block = Option::<CompactingBlock>::None;
+    let mut merging_blk_meta_groups = Vec::with_capacity(32);
+    let mut merged_blks = Vec::with_capacity(32);
+
+    let mut curr_fid: Option<FieldId> = None;
+    while let Some(fid) = state.next(&mut merging_blk_meta_groups).await {
+        for blk_meta_group in merging_blk_meta_groups.drain(..) {
+            trace::trace!("merging meta group: {blk_meta_group}");
+            if curr_fid.is_some_and(|c_fid| c_fid != fid) {
+                // Iteration of next field id, write previous merged block.
+                if let Some(blk) = previous_merged_block.take() {
+                    // Write the small previous merged block.
+                    trace::trace!("write the previous compacting block (fid={curr_fid:?}): {blk}");
+                    writer_wrapper.write(blk).await?;
+                }
+            }
+            curr_fid = Some(fid);
+
+            blk_meta_group
+                .merge_with_previous_block(
+                    previous_merged_block.take(),
+                    max_block_size,
+                    &out_time_range,
+                    &mut merged_blks,
+                )
+                .await?;
+            if merged_blks.is_empty() {
+                continue;
+            }
+            if merged_blks.len() == 1 && merged_blks[0].len() < max_block_size {
+                // The only one data block too small, try to extend the next compacting blocks.
+                previous_merged_block = Some(merged_blks.remove(0));
+                continue;
+            }
+
+            let last_blk_idx = merged_blks.len() - 1;
+            for (i, blk) in merged_blks.drain(..).enumerate() {
+                if i == last_blk_idx && blk.len() < max_block_size {
+                    // The last data block too small, try to extend to
+                    // the next compacting blocks (current field id).
+                    trace::trace!("compacting block (fid={fid}) {blk} is too small, try to merge with the next compacting blocks");
+                    previous_merged_block = Some(blk);
+                    break;
+                }
+                trace::trace!("write compacting block(fid={fid}): {blk}");
+                writer_wrapper.write(blk).await?;
+            }
+        }
+    }
+    if let Some(blk) = previous_merged_block {
+        trace::trace!("write the final compacting block(fid={curr_fid:?}): {blk}");
+        writer_wrapper.write(blk).await?;
+    }
+
+    let (mut version_edit, file_metas) = writer_wrapper.close().await?;
+    for file in request.files {
+        if file.time_range().max_ts <= out_time_range.max_ts {
+            // All files merged into target level.
+            version_edit.del_file(file.level(), file.file_id(), file.is_delta());
+        } else {
+            // Only part of the tsm file merged into target level.
+            version_edit.del_file_part(
+                file.level(),
+                file.file_id(),
+                file.is_delta(),
+                out_time_range.min_ts,
+                out_time_range.max_ts,
+            );
+            if let Some(time_range) = file.time_range().intersect(&out_time_range) {
+                // Re-add file but with the intersected time range if file has something.
+                version_edit.add_file(
+                    CompactMeta {
+                        file_id: file.file_id(),
+                        file_size: file.size(),
+                        tsf_id: request.ts_family_id,
+                        level: file.level(),
+                        min_ts: time_range.min_ts,
+                        max_ts: time_range.max_ts,
+                        high_seq: 0,
+                        low_seq: 0,
+                        is_delta: file.is_delta(),
+                    },
+                    out_time_range.max_ts,
+                )
+            } else {
+                // Seems file has nothing merged into target level, it is impossible.
+            }
+        }
+    }
+
+    trace::info!(
+        "Compaction(delta): Compact finished, version edits: {:?}",
+        version_edit
+    );
+    Ok(Some((version_edit, file_metas)))
+}
+
+pub(crate) struct CompactState {
+    tsm_readers: Vec<Arc<TsmReader>>,
+    /// The TimeRange for delta files to partly compact with other files.
+    out_time_range: TimeRange,
+    /// The TimeRanges for delta files to partly compact with other files.
+    out_time_ranges: Arc<TimeRanges>,
+    /// Maximum values in generated CompactingBlock
+    max_data_block_size: usize,
+
+    compacting_files: BinaryHeap<CompactingFile>,
+    /// Temporarily stored index of `TsmReader` in self.tsm_readers,
+    /// and `BlockMetaIterator` of current field_id.
+    tmp_tsm_blk_meta_iters: Vec<(usize, BlockMetaIterator)>,
+}
+
+impl CompactState {
+    pub fn new(
+        tsm_readers: Vec<Arc<TsmReader>>,
+        out_time_range: TimeRange,
+        max_data_block_size: usize,
+    ) -> Self {
+        let mut compacting_tsm_readers = Vec::with_capacity(tsm_readers.len());
+        let mut compacting_files = BinaryHeap::with_capacity(tsm_readers.len());
+        let mut compacting_tsm_file_idx = 0_usize;
+        for tsm_reader in tsm_readers {
+            if let Some(cf) = CompactingFile::new(compacting_tsm_file_idx, tsm_reader.clone()) {
+                compacting_tsm_readers.push(tsm_reader);
+                compacting_files.push(cf);
+                compacting_tsm_file_idx += 1;
+            }
+        }
+
+        Self {
+            tsm_readers: compacting_tsm_readers,
+            compacting_files,
+            out_time_range,
+            out_time_ranges: Arc::new(TimeRanges::new(vec![out_time_range])),
+            max_data_block_size,
+            tmp_tsm_blk_meta_iters: Vec::with_capacity(compacting_tsm_file_idx),
+        }
+    }
+
+    pub async fn next(
+        &mut self,
+        compacting_blk_meta_groups: &mut Vec<CompactingBlockMetaGroup>,
+    ) -> Option<FieldId> {
+        // For each tsm-file, get next index reader for current iteration field id
+        if let Some(field_id) = self.next_field() {
+            // Get all of block_metas of this field id, and group these block_metas.
+            self.fill_compacting_block_meta_groups(field_id, compacting_blk_meta_groups);
+
+            Some(field_id)
+        } else {
+            None
+        }
+    }
+}
+
+impl CompactState {
+    /// Update tmp_tsm_blk_meta_iters for field id in next iteration.
+    fn next_field(&mut self) -> Option<FieldId> {
+        trace::trace!("===============================");
+
+        self.tmp_tsm_blk_meta_iters.clear();
+        let mut curr_fid: FieldId;
+
+        loop {
+            if let Some(f) = self.compacting_files.peek() {
+                trace::trace!(
+                    "selected new field {:?} from file {} as current field id",
+                    f.field_id,
+                    f.tsm_reader.file_id()
+                );
+                curr_fid = f.field_id
+            } else {
+                trace::trace!("no file to select, mark finished");
+                return None;
+            }
+
+            let mut loop_file_i;
+            while let Some(mut f) = self.compacting_files.pop() {
+                loop_file_i = f.i;
+                if curr_fid == f.field_id {
+                    if let Some(idx_meta) = f.peek() {
+                        trace::trace!(
+                            "for delta file @{loop_file_i}, put block iterator with time_range {:?}",
+                            &self.out_time_range
+                        );
+                        self.tmp_tsm_blk_meta_iters.push((
+                            loop_file_i,
+                            idx_meta.block_iterator_opt(self.out_time_ranges.clone()),
+                        ));
+
+                        trace::trace!("merging idx_meta({}): field_id: {}, field_type: {:?}, block_count: {}, time_range: {:?}",
+                            self.tmp_tsm_blk_meta_iters.len(),
+                            idx_meta.field_id(),
+                            idx_meta.field_type(),
+                            idx_meta.block_count(),
+                            idx_meta.time_range(),
+                        );
+                        f.next();
+                        self.compacting_files.push(f);
+                    } else {
+                        // This tsm-file has been finished, do not push it back.
+                        trace::trace!("file {loop_file_i} is finished.");
+                    }
+                } else {
+                    // This tsm-file do not need to compact at this time, push it back.
+                    self.compacting_files.push(f);
+                    break;
+                }
+            }
+
+            if !self.tmp_tsm_blk_meta_iters.is_empty() {
+                trace::trace!(
+                    "selected {} blocks meta iterators",
+                    self.tmp_tsm_blk_meta_iters.len()
+                );
+                break;
+            } else {
+                trace::trace!("iteration field_id {curr_fid} is finished, trying next field.");
+                continue;
+            }
+        }
+
+        Some(curr_fid)
+    }
+
+    /// Clear buffer vector and collect compacting `DataBlock`s into the buffer vector.
+    fn fill_compacting_block_meta_groups(
+        &mut self,
+        field_id: FieldId,
+        compacting_blk_meta_groups: &mut Vec<CompactingBlockMetaGroup>,
+    ) -> bool {
+        if self.tmp_tsm_blk_meta_iters.is_empty() {
+            return false;
+        }
+
+        let mut blk_metas: Vec<CompactingBlockMeta> =
+            Vec::with_capacity(self.tmp_tsm_blk_meta_iters.len());
+        // Get all block_meta, and check if it's tsm file has a related tombstone file.
+        for (tsm_reader_idx, blk_iter) in self.tmp_tsm_blk_meta_iters.iter_mut() {
+            for blk_meta in blk_iter.by_ref() {
+                let tsm_reader_ptr = self.tsm_readers[*tsm_reader_idx].clone();
+                blk_metas.push(CompactingBlockMeta::new(
+                    *tsm_reader_idx,
+                    tsm_reader_ptr,
+                    blk_meta,
+                ));
+            }
+        }
+        // Sort by field_id, min_ts and max_ts.
+        blk_metas.sort();
+
+        let mut blk_meta_groups: Vec<CompactingBlockMetaGroup> =
+            Vec::with_capacity(blk_metas.len());
+        for blk_meta in blk_metas {
+            blk_meta_groups.push(CompactingBlockMetaGroup::new(field_id, blk_meta));
+        }
+        // Compact blk_meta_groups.
+        let mut i = 0;
+        loop {
+            let mut head_idx = i;
+            // Find the first non-empty as head.
+            for (off, bmg) in blk_meta_groups[i..].iter().enumerate() {
+                if !bmg.is_empty() {
+                    head_idx += off;
+                    break;
+                }
+            }
+            if head_idx >= blk_meta_groups.len() - 1 {
+                // There no other blk_meta_group to merge with the last one.
+                break;
+            }
+            let mut head = blk_meta_groups[head_idx].clone();
+            i = head_idx + 1;
+            for bmg in blk_meta_groups[i..].iter_mut() {
+                if bmg.is_empty() {
+                    continue;
+                }
+                if head.overlaps(bmg) {
+                    head.append(bmg);
+                }
+            }
+            blk_meta_groups[head_idx] = head;
+        }
+
+        compacting_blk_meta_groups.clear();
+        for cbm_group in blk_meta_groups {
+            if !cbm_group.is_empty() {
+                compacting_blk_meta_groups.push(cbm_group);
+            }
+        }
+        trace::trace!(
+            "selected merging meta groups: {}",
+            CompactingBlockMetaGroups(compacting_blk_meta_groups),
+        );
+        true
+    }
+}
+
+///
+#[derive(Clone)]
+pub(crate) struct CompactingBlockMetaGroup {
+    field_id: FieldId,
+    blk_metas: Vec<CompactingBlockMeta>,
+    time_range: TimeRange,
+}
+
+impl CompactingBlockMetaGroup {
+    pub fn new(field_id: FieldId, blk_meta: CompactingBlockMeta) -> Self {
+        let time_range = blk_meta.time_range();
+        Self {
+            field_id,
+            blk_metas: vec![blk_meta],
+            time_range,
+        }
+    }
+
+    pub fn overlaps(&self, other: &Self) -> bool {
+        self.time_range.overlaps(&other.time_range)
+    }
+
+    pub fn append(&mut self, other: &mut CompactingBlockMetaGroup) {
+        self.blk_metas.append(&mut other.blk_metas);
+        self.time_range.merge(&other.time_range);
+    }
+
+    pub async fn merge_with_previous_block(
+        mut self,
+        previous_block: Option<CompactingBlock>,
+        max_block_size: usize,
+        time_range: &TimeRange,
+        compacting_blocks: &mut Vec<CompactingBlock>,
+    ) -> Result<()> {
+        compacting_blocks.clear();
+        if self.blk_metas.is_empty() {
+            return Ok(());
+        }
+        self.blk_metas
+            .sort_by(|a, b| a.reader_idx.cmp(&b.reader_idx).reverse());
+
+        let mut merged_block = Option::<DataBlock>::None;
+        if self.blk_metas.len() == 1
+            && !self.blk_metas[0].has_tombstone()
+            && self.blk_metas[0].included_in_time_range(time_range)
+        {
+            // Only one compacting block and has no tombstone, write as raw block.
+            trace::trace!("only one compacting block without tombstone and time_range is entirely included by target level, handled as raw block");
+            let head_meta = &self.blk_metas[0].meta;
+            let mut buf = Vec::with_capacity(head_meta.size() as usize);
+            let data_len = self.blk_metas[0].get_raw_data(&mut buf).await?;
+            buf.truncate(data_len);
+
+            if head_meta.size() >= max_block_size as u64 {
+                // Raw data block is full, so do not merge with the previous, directly return.
+                if let Some(prev_compacting_block) = previous_block {
+                    compacting_blocks.push(prev_compacting_block);
+                }
+                compacting_blocks.push(CompactingBlock::raw(
+                    self.blk_metas[0].reader_idx,
+                    head_meta.clone(),
+                    buf,
+                ));
+
+                return Ok(());
+            } else if let Some(prev_compacting_block) = previous_block {
+                // Raw block is not full, so decode and merge with compacting_block.
+                let decoded_raw_block = tsm::decode_data_block(
+                    &buf,
+                    head_meta.field_type(),
+                    head_meta.val_off() - head_meta.offset(),
+                )
+                .context(error::ReadTsmSnafu)?;
+                if let Some(mut data_block) = prev_compacting_block.decode_opt(time_range)? {
+                    data_block.extend(decoded_raw_block);
+                    merged_block = Some(data_block);
+                }
+            } else {
+                // Raw block is not full, but nothing to merge with, directly return.
+                compacting_blocks.push(CompactingBlock::raw(
+                    self.blk_metas[0].reader_idx,
+                    head_meta.clone(),
+                    buf,
+                ));
+                return Ok(());
+            }
+        } else {
+            // One block with tombstone or multi compacting blocks, decode and merge these data block.
+            trace::trace!(
+                "there are {} compacting blocks, need to decode and merge",
+                self.blk_metas.len()
+            );
+
+            let (mut head_block, mut head_i) = (Option::<DataBlock>::None, 0_usize);
+            for (i, meta) in self.blk_metas.iter().enumerate() {
+                if let Some(blk) = meta.get_data_block_opt(time_range).await? {
+                    head_block = Some(blk);
+                    head_i = i;
+                    break;
+                }
+            }
+            if let Some(mut head_blk) = head_block.take() {
+                if let Some(prev_compacting_block) = previous_block {
+                    if let Some(mut data_block) = prev_compacting_block.decode_opt(time_range)? {
+                        data_block.extend(head_blk);
+                        head_blk = data_block;
+                    }
+                }
+                for blk_meta in self.blk_metas.iter_mut().skip(head_i + 1) {
+                    // Merge decoded data block.
+                    if let Some(blk) = blk_meta.get_data_block_opt(time_range).await? {
+                        head_blk = head_blk.merge(blk);
+                    }
+                }
+                head_block = Some(head_blk);
+            }
+
+            merged_block = head_block;
+        }
+        if let Some(blk) = merged_block {
+            chunk_data_block_into_compacting_blocks(
+                self.field_id,
+                blk,
+                max_block_size,
+                compacting_blocks,
+            )
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn into_compacting_block_metas(self) -> Vec<CompactingBlockMeta> {
+        self.blk_metas
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.blk_metas.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.blk_metas.len()
+    }
+}
+
+impl Display for CompactingBlockMetaGroup {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{field_id: {}, blk_metas: [", self.field_id)?;
+        if !self.blk_metas.is_empty() {
+            write!(f, "{}", &self.blk_metas[0])?;
+            for b in self.blk_metas.iter().skip(1) {
+                write!(f, ", {}", b)?;
+            }
+        }
+        write!(f, "]}}")
+    }
+}
+
+struct CompactingBlockMetaGroups<'a>(&'a [CompactingBlockMetaGroup]);
+
+impl<'a> Display for CompactingBlockMetaGroups<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut iter = self.0.iter();
+        if let Some(d) = iter.next() {
+            write!(f, "{}", d)?;
+            for d in iter {
+                write!(f, ", {d}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn chunk_data_block_into_compacting_blocks(
+    field_id: FieldId,
+    data_block: DataBlock,
+    max_block_size: usize,
+    compacting_blocks: &mut Vec<CompactingBlock>,
+) -> Result<()> {
+    compacting_blocks.clear();
+    if max_block_size == 0 || data_block.len() < max_block_size {
+        // Data block elements less than max_block_size, do not encode it.
+        // Try to merge with the next CompactingBlockMetaGroup.
+        compacting_blocks.push(CompactingBlock::decoded(0, field_id, data_block));
+    } else {
+        // Data block is so big that split into multi CompactingBlock
+        let len = data_block.len();
+        let mut start = 0;
+        let mut end = len.min(max_block_size);
+        while start < len {
+            // Encode decoded data blocks into chunks.
+            let encoded_blk =
+                EncodedDataBlock::encode(&data_block, start, end).map_err(|e| Error::WriteTsm {
+                    source: WriteTsmError::Encode { source: e },
+                })?;
+            compacting_blocks.push(CompactingBlock::encoded(0, field_id, encoded_blk));
+
+            start = end;
+            end = len.min(start + max_block_size);
+        }
+    }
+
+    Ok(())
+}
+
+struct WriterWrapper {
+    // Init values.
+    ts_family_id: TseriesFamilyId,
+    out_level: LevelId,
+    max_file_size: u64,
+    tsm_dir: PathBuf,
+    context: Arc<GlobalContext>,
+
+    // Temporary values.
+    tsm_writer_full: bool,
+    tsm_writer: Option<TsmWriter>,
+
+    // Result values.
+    version_edit: VersionEdit,
+    file_metas: HashMap<ColumnFileId, Arc<BloomFilter>>,
+}
+
+impl WriterWrapper {
+    pub fn new(request: &CompactReq, context: Arc<GlobalContext>) -> Self {
+        Self {
+            ts_family_id: request.ts_family_id,
+            out_level: request.out_level,
+            max_file_size: request
+                .version
+                .storage_opt()
+                .level_max_file_size(request.out_level),
+            tsm_dir: request
+                .storage_opt
+                .tsm_dir(&request.tenant_database, request.ts_family_id),
+            context,
+
+            tsm_writer_full: false,
+            tsm_writer: None,
+
+            version_edit: VersionEdit::new(request.ts_family_id),
+            file_metas: HashMap::new(),
+        }
+    }
+
+    pub async fn close(mut self) -> Result<(VersionEdit, HashMap<ColumnFileId, Arc<BloomFilter>>)> {
+        self.close_writer_and_append_compact_meta().await?;
+        Ok((self.version_edit, self.file_metas))
+    }
+
+    /// Write CompactingBlock to TsmWriter, fill file_metas and version_edit.
+    pub async fn write(&mut self, blk: CompactingBlock) -> Result<usize> {
+        let write_result: WriteTsmResult<usize> = match blk {
+            CompactingBlock::Decoded {
+                field_id,
+                data_block,
+                ..
+            } => {
+                self.tsm_writer_mut()
+                    .await?
+                    .write_block(field_id, &data_block)
+                    .await
+            }
+            CompactingBlock::Encoded {
+                field_id,
+                data_block,
+                ..
+            } => {
+                self.tsm_writer_mut()
+                    .await?
+                    .write_encoded_block(field_id, &data_block)
+                    .await
+            }
+            CompactingBlock::Raw { meta, raw, .. } => {
+                self.tsm_writer_mut().await?.write_raw(&meta, &raw).await
+            }
+        };
+        match write_result {
+            Ok(size) => Ok(size),
+            Err(WriteTsmError::WriteIO { source }) => {
+                // TODO try re-run compaction on other time.
+                trace::error!("Failed compaction: IO error when write tsm: {:?}", source);
+                Err(Error::IO { source })
+            }
+            Err(WriteTsmError::Encode { source }) => {
+                // TODO try re-run compaction on other time.
+                trace::error!(
+                    "Failed compaction: encoding error when write tsm: {:?}",
+                    source
+                );
+                Err(Error::Encode { source })
+            }
+            Err(WriteTsmError::Finished { path }) => {
+                trace::error!(
+                    "Failed compaction: Trying write already finished tsm file: '{}'",
+                    path.display()
+                );
+                Err(Error::WriteTsm {
+                    source: WriteTsmError::Finished { path },
+                })
+            }
+            Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) => {
+                self.tsm_writer_full = true;
+                Ok(write_size)
+            }
+        }
+    }
+
+    async fn tsm_writer_mut(&mut self) -> Result<&mut TsmWriter> {
+        if self.tsm_writer_full {
+            self.close_writer_and_append_compact_meta().await?;
+            self.new_writer_mut().await
+        } else {
+            match self.tsm_writer {
+                Some(ref mut w) => Ok(w),
+                None => self.new_writer_mut().await,
+            }
+        }
+    }
+
+    async fn new_writer_mut(&mut self) -> Result<&mut TsmWriter> {
+        let writer = tsm::new_tsm_writer(
+            &self.tsm_dir,
+            self.context.file_id_next(),
+            false,
+            self.max_file_size,
+        )
+        .await?;
+        trace::info!(
+            "Compaction(delta): File: {} been created (level: {}).",
+            writer.sequence(),
+            self.out_level,
+        );
+
+        self.tsm_writer_full = false;
+        Ok(self.tsm_writer.insert(writer))
+    }
+
+    async fn close_writer_and_append_compact_meta(&mut self) -> Result<()> {
+        if let Some(mut tsm_writer) = self.tsm_writer.take() {
+            tsm_writer
+                .write_index()
+                .await
+                .context(error::WriteTsmSnafu)?;
+            tsm_writer.finish().await.context(error::WriteTsmSnafu)?;
+
+            trace::info!(
+                "Compaction(delta): File: {} write finished (level: {}, {} B).",
+                tsm_writer.sequence(),
+                self.out_level,
+                tsm_writer.size()
+            );
+
+            let file_id = tsm_writer.sequence();
+            let cm = CompactMeta {
+                file_id,
+                file_size: tsm_writer.size(),
+                tsf_id: self.ts_family_id,
+                level: self.out_level,
+                min_ts: tsm_writer.min_ts(),
+                max_ts: tsm_writer.max_ts(),
+                high_seq: 0,
+                low_seq: 0,
+                is_delta: false,
+            };
+            self.version_edit.add_file(cm, tsm_writer.max_ts());
+            let bloom_filter = tsm_writer.into_bloom_filter();
+            self.file_metas.insert(file_id, Arc::new(bloom_filter));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use cache::ShardedAsyncCache;
+    use models::{FieldId, PhysicalDType as ValueType, Timestamp};
+
+    use super::*;
+    use crate::compaction::test::{
+        check_column_file, create_options, generate_data_block, write_data_block_desc, TsmSchema,
+    };
+    use crate::file_system::file_manager;
+    use crate::tseries_family::{ColumnFile, LevelInfo, Version};
+    use crate::tsm::codec::DataBlockEncoding;
+    use crate::Options;
+
+    #[test]
+    fn test_chunk_merged_block() {
+        let data_block = DataBlock::U64 {
+            ts: vec![0, 1, 2, 10, 11, 12, 100, 101, 102, 1000, 1001, 1002],
+            val: vec![0, 3, 6, 30, 33, 36, 300, 303, 306, 3000, 3003, 3006],
+            enc: DataBlockEncoding::default(),
+        };
+        let field_id = 1;
+        // Trying to chunk with no chunk size
+        {
+            let mut chunks = Vec::new();
+            chunk_data_block_into_compacting_blocks(field_id, data_block.clone(), 0, &mut chunks)
+                .unwrap();
+            assert_eq!(chunks.len(), 1);
+            assert_eq!(
+                chunks[0],
+                CompactingBlock::decoded(0, 1, data_block.clone())
+            );
+        }
+        // Trying to chunk with too big chunk size
+        {
+            let mut chunks: Vec<_> = Vec::new();
+            chunk_data_block_into_compacting_blocks(field_id, data_block.clone(), 100, &mut chunks)
+                .unwrap();
+            assert_eq!(chunks.len(), 1);
+            assert_eq!(
+                chunks[0],
+                CompactingBlock::decoded(0, 1, data_block.clone())
+            );
+        }
+        // Trying to chunk with chunk size that can divide data block exactly
+        {
+            let mut chunks = Vec::new();
+            chunk_data_block_into_compacting_blocks(field_id, data_block.clone(), 4, &mut chunks)
+                .unwrap();
+            assert_eq!(chunks.len(), 3);
+            assert_eq!(
+                chunks[0],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 0, 4).unwrap()
+                )
+            );
+            assert_eq!(
+                chunks[1],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 4, 8).unwrap()
+                )
+            );
+            assert_eq!(
+                chunks[2],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 8, 12).unwrap()
+                )
+            );
+        }
+        // Trying to chunk with chunk size that cannot divide data block exactly
+        {
+            let mut chunks = Vec::new();
+            chunk_data_block_into_compacting_blocks(field_id, data_block.clone(), 5, &mut chunks)
+                .unwrap();
+            assert_eq!(chunks.len(), 3);
+            assert_eq!(
+                chunks[0],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 0, 5).unwrap()
+                )
+            );
+            assert_eq!(
+                chunks[1],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 5, 10).unwrap()
+                )
+            );
+            assert_eq!(
+                chunks[2],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 10, 12).unwrap()
+                )
+            );
+        }
+    }
+
+    pub fn prepare_delta_compaction(
+        tenant_database: Arc<String>,
+        opt: Arc<Options>,
+        next_file_id: ColumnFileId,
+        files: Vec<Arc<ColumnFile>>,
+        out_level_max_ts: Timestamp,
+    ) -> (CompactReq, Arc<GlobalContext>) {
+        let version = Arc::new(Version::new(
+            1,
+            tenant_database.clone(),
+            opt.storage.clone(),
+            1,
+            LevelInfo::init_levels(tenant_database.clone(), 0, opt.storage.clone()),
+            out_level_max_ts,
+            Arc::new(ShardedAsyncCache::create_lru_sharded_cache(1)),
+        ));
+        let compact_req = CompactReq {
+            ts_family_id: 1,
+            tenant_database,
+            storage_opt: opt.storage.clone(),
+            files,
+            version,
+            in_level: 1,
+            out_level: 2,
+            max_ts: out_level_max_ts,
+        };
+        let context = Arc::new(GlobalContext::new());
+        context.set_file_id(next_file_id);
+
+        (compact_req, context)
+    }
+
+    async fn test_delta_compaction(
+        dir: &str,
+        source_data_desc: &[TsmSchema],
+        max_ts: Timestamp,
+        expected_data_desc: HashMap<FieldId, Vec<DataBlock>>,
+        expected_data_level: LevelId,
+    ) {
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
+        let opt = create_options(dir.to_string());
+        let tsm_dir = opt.storage.tsm_dir(&tenant_database, 1);
+        if !file_manager::try_exists(&tsm_dir) {
+            std::fs::create_dir_all(&tsm_dir).unwrap();
+        }
+        let delta_dir = opt.storage.delta_dir(&tenant_database, 1);
+        if !file_manager::try_exists(&delta_dir) {
+            std::fs::create_dir_all(&delta_dir).unwrap();
+        }
+
+        let column_files = write_data_block_desc(&delta_dir, source_data_desc).await;
+        let next_file_id = source_data_desc
+            .iter()
+            .map(|(_file_id, blk_desc, _tomb_desc)| {
+                blk_desc
+                    .iter()
+                    .map(|(_vtype, field_id, _min_ts, _max_ts)| *field_id)
+                    .max()
+                    .unwrap_or(1)
+            })
+            .max()
+            .unwrap_or(1)
+            + 1;
+        let (mut compact_req, kernel) =
+            prepare_delta_compaction(tenant_database, opt, next_file_id, column_files, max_ts);
+        compact_req.in_level = 0;
+        compact_req.out_level = expected_data_level;
+
+        let (version_edit, _) = run_compaction_job(compact_req, kernel)
+            .await
+            .unwrap()
+            .unwrap();
+
+        check_column_file(
+            tsm_dir,
+            version_edit,
+            expected_data_desc,
+            expected_data_level,
+        )
+        .await;
+    }
+
+    /// Test compaction on level-0 (delta compaction) with multi-field.
+    #[tokio::test]
+    async fn test_delta_compaction_1() {
+        #[rustfmt::skip]
+        let data_desc: [TsmSchema; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
+                // 1, 1~2500
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000),  (ValueType::Unsigned, 1, 2001, 2500),
+                // 2, 1~1500
+                (ValueType::Integer, 2, 1, 1000), (ValueType::Integer, 2, 1001, 1500),
+                // 3, 1~1500
+                (ValueType::Boolean, 3, 1, 1000), (ValueType::Boolean, 3, 1001, 1500),
+            ], vec![]),
+            (2, vec![
+                // 1, 2001~4500
+                (ValueType::Unsigned, 1, 2001, 3000), (ValueType::Unsigned, 1, 3001, 4000), (ValueType::Unsigned, 1, 4001, 4500),
+                // 2, 1001~3000
+                (ValueType::Integer, 2, 1001, 2000), (ValueType::Integer, 2, 2001, 3000),
+                // 3, 1001~2500
+                (ValueType::Boolean, 3, 1001, 2000), (ValueType::Boolean, 3, 2001, 2500),
+                // 4, 1~1500
+                (ValueType::Float, 4, 1, 1000), (ValueType::Float, 4, 1001, 1500),
+            ], vec![]),
+            (3, vec![
+                // 1, 4001~6500
+                (ValueType::Unsigned, 1, 4001, 5000), (ValueType::Unsigned, 1, 5001, 6000), (ValueType::Unsigned, 1, 6001, 6500),
+                // 2, 3001~5000
+                (ValueType::Integer, 2, 3001, 4000), (ValueType::Integer, 2, 4001, 5000),
+                // 3, 2001~3500
+                (ValueType::Boolean, 3, 2001, 3000), (ValueType::Boolean, 3, 3001, 3500),
+                // 4. 1001~2500
+                (ValueType::Float, 4, 1001, 2000), (ValueType::Float, 4, 2001, 2500),
+            ], vec![]),
+        ];
+        let max_ts = 3000;
+        let expected_data_target_level: HashMap<FieldId, Vec<DataBlock>> = HashMap::from([
+            (
+                // 1, 1~6500
+                1,
+                vec![
+                    generate_data_block(ValueType::Unsigned, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(2001, 3000)]),
+                ],
+            ),
+            (
+                // 2, 1~5000
+                2,
+                vec![
+                    generate_data_block(ValueType::Integer, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Integer, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Integer, vec![(2001, 3000)]),
+                ],
+            ),
+            (
+                // 3, 1~3500
+                3,
+                vec![
+                    generate_data_block(ValueType::Boolean, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Boolean, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Boolean, vec![(2001, 3000)]),
+                ],
+            ),
+            (
+                // 4, 1~2500
+                4,
+                vec![
+                    generate_data_block(ValueType::Float, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Float, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Float, vec![(2001, 2500)]),
+                ],
+            ),
+        ]);
+
+        test_delta_compaction(
+            "/tmp/test/delta_compaction/1",
+            &data_desc,
+            max_ts,
+            expected_data_target_level,
+            2,
+        )
+        .await;
+    }
+
+    /// Test compaction on level-0 (delta compaction) with samll blocks.
+    #[tokio::test]
+    async fn test_delta_compaction_2() {
+        #[rustfmt::skip]
+        let data_desc: [TsmSchema; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
+                // 1, 1~4000
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000), (ValueType::Unsigned, 1, 2001, 2500),
+                (ValueType::Unsigned, 1, 2501, 3100), (ValueType::Unsigned, 1, 3101, 3500), (ValueType::Unsigned, 1, 3501, 4000),
+                // 2, 2~2501
+                (ValueType::Integer, 2, 2, 1001), (ValueType::Integer, 2, 1002, 1501), (ValueType::Integer, 2, 1502, 2501),
+                // 3, 3~1002, 2003~2502, 3003~4002
+                (ValueType::Boolean, 3, 3, 1002), (ValueType::Boolean, 3, 2003, 2502), (ValueType::Boolean, 3, 3003, 4002),
+                // 5, 5~1504, 2005~2504
+                (ValueType::String, 5, 5, 1004), (ValueType::String, 5, 1005, 1504), (ValueType::String, 5, 2005, 2504),
+            ], vec![]),
+            (2, vec![
+                // 1, 3501~3700, 3801~4500
+                (ValueType::Unsigned, 1, 3501, 3700), (ValueType::Unsigned, 1, 3801, 4000), (ValueType::Unsigned, 1, 4001, 4500),
+                // 2, 1002~2001, 2502~3001, 3502~4001
+                (ValueType::Integer, 2, 1002, 2001), (ValueType::Integer, 2, 2502, 3001), (ValueType::Integer, 2, 3502, 4001),
+                // 3, 1003~3002, 3503~4502, 5003~7002
+                (ValueType::Boolean, 3, 1003, 2002), (ValueType::Boolean, 3, 2003, 2502), (ValueType::Boolean, 3, 2503, 3002),
+                (ValueType::Boolean, 3, 3503, 4502), (ValueType::Boolean, 3, 5003, 6002), (ValueType::Boolean, 3, 6003, 7002),
+                // 4, 4~1503, 2004~2503
+                (ValueType::Float, 4, 4, 1003), (ValueType::Float, 4, 1004, 1503), (ValueType::Float, 4, 2004, 2503),
+                // 5, 2505~3004. 4005~5004, 6005~7004
+                (ValueType::String, 5, 2505, 3004), (ValueType::String, 5, 4005, 5004), (ValueType::String, 5, 6005, 7004),
+            ], vec![]),
+            (3, vec![
+                // 1, 4001~6500
+                (ValueType::Unsigned, 1, 4001, 5000), (ValueType::Unsigned, 1, 5001, 6000), (ValueType::Unsigned, 1, 6001, 6500),
+                // 2, 3002~6501, 6602~6801, 6802~7001
+                (ValueType::Integer, 2, 3002, 4001), (ValueType::Integer, 2, 4002, 5001), (ValueType::Integer, 2, 5002, 6001),
+                (ValueType::Integer, 2, 6002, 6501), (ValueType::Integer, 2, 6602, 6801), (ValueType::Integer, 2, 6802, 7001),
+                // 3, 2003~3502
+                (ValueType::Boolean, 3, 2003, 3002), (ValueType::Boolean, 3, 3003, 3502),
+                // 4. 1004~2503
+                (ValueType::Float, 4, 1004, 2003), (ValueType::Float, 4, 2004, 2503),
+            ], vec![]),
+        ];
+        let max_ts = 5000;
+        let expected_data_target_level: HashMap<FieldId, Vec<DataBlock>> = HashMap::from([
+            (
+                // 1
+                // 1~4000
+                // 3501~3700, 3801~4500
+                // 4001~6500
+                1,
+                vec![
+                    generate_data_block(ValueType::Unsigned, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(2001, 3000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(3001, 4000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(4001, 5000)]),
+                ],
+            ),
+            (
+                // 2
+                // 2~2501
+                // 1002~2001, 2502~3001, 3502~4001
+                // 3002~6501, 6602~6801, 6802~7001
+                2,
+                vec![
+                    generate_data_block(ValueType::Integer, vec![(2, 1001)]),
+                    generate_data_block(ValueType::Integer, vec![(1002, 2001)]),
+                    generate_data_block(ValueType::Integer, vec![(2002, 3001)]),
+                    generate_data_block(ValueType::Integer, vec![(3002, 4001)]),
+                    generate_data_block(ValueType::Integer, vec![(4002, 5000)]),
+                ],
+            ),
+            (
+                // 3
+                // 3~1002, 2003~2502, 3003~4002
+                // 1003~3002, 3503~4502, 5003~7002
+                // 2003~3502
+                3,
+                vec![
+                    generate_data_block(ValueType::Boolean, vec![(3, 1002)]),
+                    generate_data_block(ValueType::Boolean, vec![(1003, 2002)]),
+                    generate_data_block(ValueType::Boolean, vec![(2003, 3002)]),
+                    generate_data_block(ValueType::Boolean, vec![(3003, 4002)]),
+                    generate_data_block(ValueType::Boolean, vec![(4003, 4502)]),
+                ],
+            ),
+            (
+                // 4
+                // 4~1503, 2004~2503
+                // 1004~2503
+                4,
+                vec![
+                    generate_data_block(ValueType::Float, vec![(4, 1003)]),
+                    generate_data_block(ValueType::Float, vec![(1004, 2003)]),
+                    generate_data_block(ValueType::Float, vec![(2004, 2503)]),
+                ],
+            ),
+            (
+                // 5
+                // 5~1504, 2005~2504
+                // 2505~3004. 4005~5004, 6005~7004
+                5,
+                vec![
+                    generate_data_block(ValueType::String, vec![(5, 1004)]),
+                    generate_data_block(ValueType::String, vec![(1005, 1504), (2005, 2504)]),
+                    generate_data_block(ValueType::String, vec![(2505, 3004), (4005, 4504)]),
+                    generate_data_block(ValueType::String, vec![(4505, 5000)]),
+                ],
+            ),
+        ]);
+
+        test_delta_compaction(
+            "/tmp/test/delta_compaction/2",
+            &data_desc,
+            max_ts,
+            expected_data_target_level,
+            2,
+        )
+        .await;
+    }
+}

--- a/tskv/src/compaction/job.rs
+++ b/tskv/src/compaction/job.rs
@@ -9,33 +9,49 @@ use tokio::sync::mpsc::Receiver;
 use tokio::sync::{oneshot, RwLock, RwLockWriteGuard, Semaphore};
 use trace::{error, info};
 
-use crate::compaction::{flush, CompactTask, FlushReq, LevelCompactionPicker, Picker};
+use crate::compaction::{flush, picker, CompactTask, FlushReq};
 use crate::summary::SummaryTask;
 use crate::{TsKvContext, TseriesFamilyId};
 
 const COMPACT_BATCH_CHECKING_SECONDS: u64 = 1;
 
 struct CompactProcessor {
-    vnode_ids: HashMap<TseriesFamilyId, bool>,
+    /// Maps (vnode_id, is_delta_compaction) to should_flush_vnode.
+    compact_task_keys: HashMap<CompactTaskKey, bool>,
 }
 
 impl CompactProcessor {
-    fn insert(&mut self, vnode_id: TseriesFamilyId, should_flush: bool) {
-        let old_should_flush = self.vnode_ids.entry(vnode_id).or_insert(should_flush);
+    fn insert(&mut self, key: CompactTaskKey, should_flush: bool) {
+        let old_should_flush = self.compact_task_keys.entry(key).or_insert(should_flush);
         if should_flush && !*old_should_flush {
             *old_should_flush = should_flush
         }
     }
 
-    fn take(&mut self) -> HashMap<TseriesFamilyId, bool> {
-        std::mem::replace(&mut self.vnode_ids, HashMap::with_capacity(32))
+    fn take(&mut self) -> HashMap<CompactTaskKey, bool> {
+        std::mem::replace(&mut self.compact_task_keys, HashMap::with_capacity(32))
     }
 }
 
 impl Default for CompactProcessor {
     fn default() -> Self {
         Self {
-            vnode_ids: HashMap::with_capacity(32),
+            compact_task_keys: HashMap::with_capacity(32),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+struct CompactTaskKey {
+    vnode_id: TseriesFamilyId,
+    delta_compaction: bool,
+}
+
+impl CompactTaskKey {
+    pub fn new(vnode_id: TseriesFamilyId, delta_compaction: bool) -> Self {
+        Self {
+            vnode_id,
+            delta_compaction,
         }
     }
 }
@@ -102,18 +118,36 @@ impl CompactJobInner {
     fn start_merge_compact_task_job(&self, mut compact_task_receiver: Receiver<CompactTask>) {
         info!("Compaction: start merge compact task job");
         let compact_processor = self.compact_processor.clone();
+        let enable_compaction = self.enable_compaction.clone();
         self.runtime.spawn(async move {
             while let Some(compact_task) = compact_task_receiver.recv().await {
-                // Vnode id to compact & whether vnode be flushed before compact
-                let (vnode_id, flush_vnode) = match compact_task {
-                    CompactTask::Vnode(id) => (id, false),
-                    CompactTask::ColdVnode(id) => (id, true),
-                };
-                compact_processor
-                    .write()
-                    .await
-                    .insert(vnode_id, flush_vnode);
+                let mut compact_processor_wlock = compact_processor.write().await;
+                match compact_task {
+                    CompactTask::Normal(id) => compact_processor_wlock.insert(
+                        CompactTaskKey {
+                            vnode_id: id,
+                            delta_compaction: false,
+                        },
+                        false,
+                    ),
+                    CompactTask::Cold(id) => compact_processor_wlock.insert(
+                        CompactTaskKey {
+                            vnode_id: id,
+                            delta_compaction: false,
+                        },
+                        true,
+                    ),
+                    CompactTask::Delta(id) => compact_processor_wlock.insert(
+                        CompactTaskKey {
+                            vnode_id: id,
+                            delta_compaction: true,
+                        },
+                        false,
+                    ),
+                }
             }
+
+            enable_compaction.store(false, atomic::Ordering::SeqCst);
         });
     }
 
@@ -152,33 +186,41 @@ impl CompactJobInner {
                 if !enable_compaction.load(atomic::Ordering::SeqCst) {
                     break;
                 }
-                if compact_processor.read().await.vnode_ids.is_empty() {
+                if compact_processor.read().await.compact_task_keys.is_empty() {
                     continue;
                 }
-                let vnode_ids = compact_processor.write().await.take();
-                let vnode_ids_for_debug = vnode_ids.clone();
-                let now = Instant::now();
-                info!("Compacting on vnode(job start): {:?}", &vnode_ids_for_debug);
-                for (vnode_id, flush_vnode) in vnode_ids {
+                // TODO: This concurrent model may leave one big compaction runing alone before next iteration.
+                let compact_tasks = compact_processor.write().await.take();
+                for (compact_task_key, should_flush) in compact_tasks {
                     let ts_family = ctx
                         .version_set
                         .read()
                         .await
-                        .get_tsfamily_by_tf_id(vnode_id)
+                        .get_tsfamily_by_tf_id(compact_task_key.vnode_id)
                         .await;
                     if let Some(tsf) = ts_family {
-                        info!("Starting compaction on ts_family {}", vnode_id);
+                        info!(
+                            "Starting compaction on ts_family {}",
+                            compact_task_key.vnode_id
+                        );
                         let start = Instant::now();
                         if !tsf.read().await.can_compaction() {
-                            info!("forbidden compaction on moving vnode {}", vnode_id);
+                            info!(
+                                "forbidden compaction on moving vnode {}",
+                                compact_task_key.vnode_id
+                            );
                             return;
                         }
-                        let picker = LevelCompactionPicker::new(ctx.options.storage.clone());
                         let version = tsf.read().await.version();
-                        let compact_req = picker.pick_compaction(version);
+                        let compact_req = if compact_task_key.delta_compaction {
+                            picker::pick_delta_compaction(version)
+                        } else {
+                            picker::pick_level_compaction(version)
+                        };
                         if let Some(req) = compact_req {
-                            let database = req.database.clone();
+                            let tenant_database = req.tenant_database.clone();
                             let compact_ts_family = req.ts_family_id;
+                            let in_level = req.in_level;
                             let out_level = req.out_level;
 
                             // Method acquire_owned() will return AcquireError if the semaphore has been closed.
@@ -192,13 +234,13 @@ impl CompactJobInner {
                                 if !enable_compaction.load(atomic::Ordering::SeqCst) {
                                     return;
                                 }
-                                // Edit running_compation
+                                // Edit running_compaction
                                 running_compaction.fetch_add(1, atomic::Ordering::SeqCst);
                                 let _sub_running_compaction_guard = DeferGuard(Some(|| {
                                     running_compaction.fetch_sub(1, atomic::Ordering::SeqCst);
                                 }));
 
-                                if flush_vnode {
+                                if should_flush {
                                     let mut tsf_wlock = tsf.write().await;
                                     tsf_wlock.switch_to_immutable();
                                     let flush_req = tsf_wlock.build_flush_req(true);
@@ -208,7 +250,10 @@ impl CompactJobInner {
                                             flush::run_flush_memtable_job(req, ctx.clone(), false)
                                                 .await
                                         {
-                                            error!("Failed to flush vnode {}: {:?}", vnode_id, e);
+                                            error!(
+                                                "Failed to flush vnode {}: {:?}",
+                                                compact_task_key.vnode_id, e
+                                            );
                                         }
                                     }
                                 }
@@ -228,8 +273,9 @@ impl CompactJobInner {
                                             .await;
 
                                         metrics::sample_tskv_compaction_duration(
-                                            database.as_str(),
+                                            tenant_database.as_str(),
                                             compact_ts_family.to_string().as_str(),
+                                            in_level.to_string().as_str(),
                                             out_level.to_string().as_str(),
                                             start.elapsed().as_secs_f64(),
                                         )
@@ -248,11 +294,6 @@ impl CompactJobInner {
                         }
                     }
                 }
-                info!(
-                    "Compacting on vnode(job start): {:?} costs {} sec",
-                    vnode_ids_for_debug,
-                    now.elapsed().as_secs()
-                );
             }
         });
     }
@@ -333,33 +374,80 @@ impl std::fmt::Debug for FlushJob {
 
 #[cfg(test)]
 mod test {
-    use std::sync::atomic::{self, AtomicI32};
-    use std::sync::Arc;
+    use std::sync::atomic::AtomicI32;
+    use std::sync::{atomic, Arc};
 
     use super::DeferGuard;
-    use crate::compaction::job::CompactProcessor;
-    use crate::TseriesFamilyId;
+    use crate::compaction::job::{CompactProcessor, CompactTaskKey};
 
     #[test]
     fn test_build_compact_batch() {
         let mut compact_batch_builder = CompactProcessor::default();
-        compact_batch_builder.insert(1, false);
-        compact_batch_builder.insert(2, false);
-        compact_batch_builder.insert(1, true);
-        compact_batch_builder.insert(3, true);
-        assert_eq!(compact_batch_builder.vnode_ids.len(), 3);
-        let mut keys: Vec<TseriesFamilyId> =
-            compact_batch_builder.vnode_ids.keys().cloned().collect();
+        compact_batch_builder.insert(CompactTaskKey::new(1, false), false);
+        compact_batch_builder.insert(CompactTaskKey::new(2, false), false);
+        compact_batch_builder.insert(CompactTaskKey::new(1, true), true);
+        compact_batch_builder.insert(CompactTaskKey::new(3, false), true);
+        compact_batch_builder.insert(CompactTaskKey::new(1, false), true);
+        assert_eq!(compact_batch_builder.compact_task_keys.len(), 4);
+        let mut keys: Vec<CompactTaskKey> = compact_batch_builder
+            .compact_task_keys
+            .keys()
+            .cloned()
+            .collect();
         keys.sort();
-        assert_eq!(keys, vec![1, 2, 3]);
-        assert_eq!(compact_batch_builder.vnode_ids.get(&1), Some(&true));
-        assert_eq!(compact_batch_builder.vnode_ids.get(&2), Some(&false));
-        assert_eq!(compact_batch_builder.vnode_ids.get(&3), Some(&true));
-        let vnode_ids = compact_batch_builder.take();
-        assert_eq!(vnode_ids.len(), 3);
-        assert_eq!(vnode_ids.get(&1), Some(&true));
-        assert_eq!(vnode_ids.get(&2), Some(&false));
-        assert_eq!(vnode_ids.get(&3), Some(&true));
+        assert_eq!(
+            keys,
+            vec![
+                CompactTaskKey::new(1, false),
+                CompactTaskKey::new(1, true),
+                CompactTaskKey::new(2, false),
+                CompactTaskKey::new(3, false),
+            ],
+        );
+        assert_eq!(
+            compact_batch_builder
+                .compact_task_keys
+                .get(&CompactTaskKey::new(1, false)),
+            Some(&true)
+        );
+        assert_eq!(
+            compact_batch_builder
+                .compact_task_keys
+                .get(&CompactTaskKey::new(1, true)),
+            Some(&true)
+        );
+        assert_eq!(
+            compact_batch_builder
+                .compact_task_keys
+                .get(&CompactTaskKey::new(2, false)),
+            Some(&false)
+        );
+        assert_eq!(
+            compact_batch_builder
+                .compact_task_keys
+                .get(&CompactTaskKey::new(3, false)),
+            Some(&true)
+        );
+        let compact_tasks = compact_batch_builder.take();
+        assert_eq!(compact_tasks.len(), 4);
+        assert_eq!(
+            compact_tasks.get(&CompactTaskKey::new(1, true)),
+            Some(&true)
+        );
+        assert_eq!(
+            compact_tasks.get(&CompactTaskKey::new(1, false)),
+            Some(&true)
+        );
+        assert_eq!(
+            compact_tasks.get(&CompactTaskKey::new(2, false)),
+            Some(&false)
+        );
+        assert_eq!(
+            compact_tasks.get(&CompactTaskKey::new(3, false)),
+            Some(&true)
+        );
+        let compact_tasks = compact_batch_builder.take();
+        assert!(compact_tasks.is_empty());
     }
 
     #[test]

--- a/tskv/src/compaction/mod.rs
+++ b/tskv/src/compaction/mod.rs
@@ -1,37 +1,93 @@
 pub mod check;
 mod compact;
+mod delta_compact;
 mod flush;
 mod iterator;
 pub mod job;
 mod picker;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
-pub use compact::*;
-pub use flush::*;
+use chrono::Utc;
+pub use flush::run_flush_memtable_job;
+use models::Timestamp;
 use parking_lot::RwLock;
-pub use picker::*;
+pub use picker::{pick_delta_compaction, pick_level_compaction};
+use utils::BloomFilter;
 
+use crate::context::GlobalContext;
 use crate::kv_option::StorageOptions;
 use crate::memcache::MemCache;
 use crate::tseries_family::{ColumnFile, Version};
-use crate::{LevelId, TseriesFamilyId};
+use crate::{ColumnFileId, LevelId, TseriesFamilyId, VersionEdit};
 
-pub enum CompactTask {
-    Vnode(TseriesFamilyId),
-    ColdVnode(TseriesFamilyId),
+#[cfg(test)]
+pub mod test {
+    pub use super::compact::test::{
+        check_column_file, create_options, generate_data_block, prepare_compaction,
+        read_data_blocks_from_column_file, write_data_block_desc, write_data_blocks_to_column_file,
+        TsmSchema,
+    };
+    pub use super::flush::flush_tests::default_table_schema;
 }
 
+pub enum CompactTask {
+    /// Compact the files in the in_level into the out_level.
+    Normal(TseriesFamilyId),
+    /// Flush memcaches and then compact the files in the in_level into the out_level.
+    Cold(TseriesFamilyId),
+    /// Compact the files in level-0 into the out_level.
+    Delta(TseriesFamilyId),
+}
+
+#[derive(Debug, Clone)]
 pub struct CompactReq {
-    pub ts_family_id: TseriesFamilyId,
-    pub database: Arc<String>,
+    ts_family_id: TseriesFamilyId,
+    tenant_database: Arc<String>,
     storage_opt: Arc<StorageOptions>,
 
     files: Vec<Arc<ColumnFile>>,
     version: Arc<Version>,
-    pub out_level: LevelId,
+    in_level: LevelId,
+    out_level: LevelId,
+    /// The maximum timestamp of the data from the in_level to be compacted
+    /// into the out_level, only used in delta compaction.
+    max_ts: Timestamp,
 }
 
+impl std::fmt::Display for CompactReq {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "tenant_database: {}, ts_family: {}, max_ts: {}, files: [",
+            self.tenant_database, self.ts_family_id, self.max_ts,
+        )?;
+        if !self.files.is_empty() {
+            write!(
+                f,
+                "{{ Level-{}, file_id: {}, time_range: {}-{} }}",
+                self.files[0].level(),
+                self.files[0].file_id(),
+                self.files[0].time_range().min_ts,
+                self.files[0].time_range().max_ts
+            )?;
+            for file in self.files.iter().skip(1) {
+                write!(
+                    f,
+                    ", {{ Level-{}, file_id: {}, time_range: {}-{} }}",
+                    file.level(),
+                    file.file_id(),
+                    file.time_range().min_ts,
+                    file.time_range().max_ts
+                )?;
+            }
+        }
+        write!(f, "]")
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct FlushReq {
     pub ts_family_id: TseriesFamilyId,
     pub mems: Vec<Arc<RwLock<MemCache>>>,
@@ -51,5 +107,24 @@ impl std::fmt::Display for FlushReq {
             self.mems.len(),
             self.force_flush,
         )
+    }
+}
+
+const PICKER_CONTEXT_DATETIME_FORMAT: &str = "%d%m%Y_%H%M%S_%3f";
+
+fn context_datetime() -> String {
+    Utc::now()
+        .format(PICKER_CONTEXT_DATETIME_FORMAT)
+        .to_string()
+}
+
+pub async fn run_compaction_job(
+    request: CompactReq,
+    kernel: Arc<GlobalContext>,
+) -> crate::Result<Option<(VersionEdit, HashMap<ColumnFileId, Arc<BloomFilter>>)>> {
+    if request.in_level == 0 {
+        delta_compact::run_compaction_job(request, kernel).await
+    } else {
+        compact::run_compaction_job(request, kernel).await
     }
 }

--- a/tskv/src/compaction/picker.rs
+++ b/tskv/src/compaction/picker.rs
@@ -1,76 +1,59 @@
 use std::fmt::Debug;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use models::predicate::domain::TimeRange;
 use trace::{debug, info};
 
-use crate::compaction::CompactReq;
-use crate::kv_option::StorageOptions;
-use crate::tseries_family::{ColumnFile, LevelInfo, Version};
+use crate::compaction::{context_datetime, CompactReq};
+use crate::tseries_family::{ColumnFile, ColumnFiles, LevelInfo, LevelInfos, Version};
 use crate::LevelId;
 
-pub trait Picker: Send + Sync + Debug {
-    fn pick_compaction(&self, version: Arc<Version>) -> Option<CompactReq>;
+pub fn pick_level_compaction(version: Arc<Version>) -> Option<CompactReq> {
+    LevelCompactionPicker::new().pick_compaction(version)
 }
 
-/// Compaction picker for picking files in level
+pub fn pick_delta_compaction(version: Arc<Version>) -> Option<CompactReq> {
+    DeltaCompactionPicker::new().pick_compaction(version)
+}
+
+/// Compaction picker for picking a level from level-1 to level-4, and then
+/// pick inner files of the level.
 #[derive(Debug)]
-pub struct LevelCompactionPicker {
-    picking: AtomicBool,
-    storage: Arc<StorageOptions>,
+struct LevelCompactionPicker {
+    /// Datetime when this picker created.
+    datetime: String,
 }
 
-impl Picker for LevelCompactionPicker {
+impl LevelCompactionPicker {
+    fn new() -> LevelCompactionPicker {
+        Self {
+            datetime: context_datetime(),
+        }
+    }
+
     fn pick_compaction(&self, version: Arc<Version>) -> Option<CompactReq> {
         //! 1. Get TseriesFamily's newest **version**(`Arc<Version>`)
         //! 2. Get all level's score, pick LevelInfo with the max score.
         //! 3. Get files(`Vec<Arc<ColumnFile>>`) from the picked level, sorted by min_ts(ascending)
         //!    and size(ascending), pick ColumnFile until picking_files_size reaches
         //!    max_compact_size, remove away the last picked files with overlapped time_range.
-        //! 4. Get files(`Vec<Arc<ColumnFile>>`) from level-0, sorted by min_ts(ascending)
-        //!    and size(ascending), pick ColumnFile until picking_files_size reaches
-        //!    max_compact_size.
+        //! 4. (Deprecated and skipped): Pick files from level-0.
         //! 5. Build CompactReq using **version**, picked level and picked files.
 
         debug!(
-            "Picker: Version info: [ {} ]",
-            version
-                .levels_info()
-                .iter()
-                .enumerate()
-                .map(|(i, lvl)| {
-                    format!(
-                        "Level-{}: files: [ {} ]",
-                        i,
-                        lvl.files
-                            .iter()
-                            .map(|f| format!(
-                                "{}(C:{}, {}-{}, {} B)",
-                                f.file_id(),
-                                if f.is_compacting() { "Y" } else { "N" },
-                                f.time_range().min_ts,
-                                f.time_range().max_ts,
-                                f.size()
-                            ))
-                            .collect::<Vec<String>>()
-                            .join(", ")
-                    )
-                })
-                .collect::<Vec<String>>()
-                .join(", ")
+            "Picker(level): version: [ {} ]",
+            LevelInfos(version.levels_info())
         );
 
         let storage_opt = version.storage_opt();
         let level_infos = version.levels_info();
 
-        // Pick a level to compact with level 0
+        // Pick a level to compact
         let level_start: &LevelInfo;
+        let in_level;
         let out_level;
-
         if let Some((start_lvl, out_lvl)) = self.pick_level(level_infos) {
-            info!("Picker: picked level: {} to {}", start_lvl, out_lvl);
             level_start = &level_infos[start_lvl as usize];
+            in_level = start_lvl;
             out_level = out_lvl;
 
             // If start_lvl is L1, compare the number of L1 files
@@ -80,87 +63,45 @@ impl Picker for LevelCompactionPicker {
                 && (level_infos[1].files.len() as u32) < storage_opt.compact_trigger_file_num
             {
                 info!(
-                    "Picker: picked L1 files({}) does not reach trigger({}), return None",
+                    "Picker(level): picked L1 files({}) does not reach trigger({}), return None",
                     level_infos[1].files.len(),
                     storage_opt.compact_trigger_file_num
                 );
                 return None;
             }
         } else {
-            info!("Picker: picked no level");
+            info!("Picker(level): picked no level");
             return None;
         }
 
         // Pick selected level files.
-        let mut picking_files: Vec<Arc<ColumnFile>> = Vec::new();
-        let (mut picking_files_size, picking_time_range) = if level_start.files.is_empty() {
-            info!("Picker: picked no files from level {}", level_start.level);
+        if level_start.files.is_empty() {
             return None;
-        } else {
-            let mut files = level_start.files.clone();
-            files.sort_by(Self::compare_column_file);
-            Self::pick_files(files, storage_opt.max_compact_size, &mut picking_files)
-        };
-
-        // Pick level 0 files.
-        let mut files = level_infos[0].files.clone();
-        files.sort_by(Self::compare_column_file);
-        for file in files.iter() {
-            if file.time_range().min_ts > picking_time_range.max_ts {
-                break;
-            }
-            if file.is_compacting() || !file.time_range().overlaps(&picking_time_range) {
-                continue;
-            }
-            if !file.mark_compacting() {
-                // If file already compacting, continue to next file.
-                continue;
-            }
-            picking_files.push(file.clone());
-            picking_files_size += file.size();
-
-            if picking_files_size > storage_opt.max_compact_size {
-                // Picked file size >= max_compact_size, try break picking files.
-                break;
-            }
         }
 
-        // Even if picked only 1 file, send it to the next level.
-
+        let mut files = level_start.files.clone();
+        files.sort_by(Self::compare_column_file);
+        let picking_files: Vec<Arc<ColumnFile>> =
+            Self::pick_files(files, storage_opt.max_compact_size);
         info!(
-            "Picker: Picked files: [ {} ]",
-            picking_files
-                .iter()
-                .map(|f| {
-                    format!(
-                        "{{ Level-{}, file_id: {}, time_range: {}-{} }}",
-                        f.level(),
-                        f.file_id(),
-                        f.time_range().min_ts,
-                        f.time_range().max_ts
-                    )
-                })
-                .collect::<Vec<String>>()
-                .join(", ")
+            "Picker(level): Picked files: [ {} ]",
+            ColumnFiles(&picking_files)
         );
+        if picking_files.is_empty() {
+            return None;
+        }
 
+        // Run compaction and send them to the next level, even if picked only 1 file,.
         Some(CompactReq {
             ts_family_id: version.tf_id(),
-            database: version.tenant_database(),
+            tenant_database: version.tenant_database(),
             storage_opt: version.storage_opt(),
             files: picking_files,
             version: version.clone(),
+            in_level,
             out_level,
+            max_ts: level_infos[out_level as usize].time_range.max_ts,
         })
-    }
-}
-
-impl LevelCompactionPicker {
-    pub fn new(storage_opt: Arc<StorageOptions>) -> LevelCompactionPicker {
-        Self {
-            picking: AtomicBool::new(false),
-            storage: storage_opt,
-        }
     }
 
     /// Weight of file number of a level to be picked.
@@ -247,8 +188,8 @@ impl LevelCompactionPicker {
             score_a.partial_cmp(score_b).expect("a NaN score").reverse()
         });
 
-        info!(
-            "Picker: Calculate level scores: [ {} ]",
+        debug!(
+            "Picker(level), level scores: [ {} ]",
             level_scores
                 .iter()
                 .map(|lc| format!("{{ Level-{}: {} }}", lc.0, lc.4))
@@ -265,30 +206,140 @@ impl LevelCompactionPicker {
         })
     }
 
-    fn pick_files(
-        src_files: Vec<Arc<ColumnFile>>,
-        max_compact_size: u64,
-        dst_files: &mut Vec<Arc<ColumnFile>>,
-    ) -> (u64, TimeRange) {
+    fn pick_files(src_files: Vec<Arc<ColumnFile>>, max_compact_size: u64) -> Vec<Arc<ColumnFile>> {
+        let mut dst_files = Vec::with_capacity(src_files.len());
+
         let mut picking_file_size = 0_u64;
-        let mut picking_time_range = TimeRange::none();
         for file in src_files.iter() {
             if file.is_compacting() || !file.mark_compacting() {
                 // If file already compacting, continue to next file.
                 continue;
             }
             picking_file_size += file.size();
-            picking_time_range.merge(file.time_range());
             dst_files.push(file.clone());
 
             if picking_file_size >= max_compact_size {
                 // Picked file size >= max_compact_size, try break picking files.
-                picking_file_size -= file.size();
                 break;
             }
         }
 
-        (picking_file_size, picking_time_range)
+        dst_files
+    }
+}
+
+/// Compaction picker for picking files in level-0 (delta files)
+/// and the output level (one of 1 to 4)
+#[derive(Debug)]
+struct DeltaCompactionPicker {
+    /// Datetime when this picker created.
+    datetime: String,
+}
+
+impl DeltaCompactionPicker {
+    fn new() -> Self {
+        Self {
+            datetime: context_datetime(),
+        }
+    }
+
+    fn pick_compaction(&self, version: Arc<Version>) -> Option<CompactReq> {
+        debug!(
+            "Picker(delta): version: [ {} ]",
+            LevelInfos(version.levels_info())
+        );
+
+        let levels = version.levels_info();
+        if levels[0].files.is_empty() {
+            return None;
+        }
+
+        let mut level_overlapped_files: [Vec<Arc<ColumnFile>>; 5] =
+            [vec![], Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+        let mut file_picked: bool;
+        let mut level_picking: usize;
+        for file in levels[0].files.iter() {
+            if file.is_compacting() {
+                continue;
+            }
+            file_picked = false;
+            level_picking = 4;
+            // Form level-4 to level-1, collect the overlapped level-0 files.
+            for level in levels.iter().skip(1).rev() {
+                if file.time_range().min_ts < level.time_range.max_ts {
+                    level_overlapped_files[level_picking].push(file.clone());
+                    file_picked = true;
+                    break;
+                }
+                level_picking -= 1;
+            }
+            // If time_range of a level-0 file is too old than level-4, put to level-4 files.
+            // TODO(zipper): remove this because it's impossible when a level-0 file is newer than level-1 to level-4
+            if !file_picked {
+                // impossible: level-0 files is newer than level-4 to level-1
+                level_overlapped_files[4].push(file.clone());
+            }
+        }
+        debug!(
+            "Picker(delta): level overlapped files: [ {} ]",
+            level_overlapped_files
+                .iter()
+                .enumerate()
+                .map(|(i, files)| format!("{{ Level-{}: {} }}", i, files.len()))
+                .collect::<Vec<String>>()
+                .join(", ")
+        );
+
+        // Find the level with maximum overlapped level-0 files.
+        let mut out_level = 0;
+        let mut max_files = 0_usize;
+        for (i, files) in level_overlapped_files.iter().enumerate() {
+            if files.len() > max_files {
+                out_level = i;
+                max_files = files.len();
+            }
+        }
+        if out_level == 0 || max_files == 0 {
+            info!("Picker(delta): picked out-level is 0 or picked no files",);
+            return None;
+        }
+
+        // Pick files from level-0 files overlapped with that level.
+        let max_compact_size = version.storage_opt().max_compact_size;
+        let mut picking_files = Vec::with_capacity(level_overlapped_files.len());
+        let mut picking_file_size = 0_u64;
+        for file in level_overlapped_files[out_level].iter() {
+            if file.is_compacting() || !file.mark_compacting() {
+                // If file already compacting, continue to next file.
+                continue;
+            }
+            picking_file_size += file.size();
+            picking_files.push(file.clone());
+
+            if picking_file_size >= max_compact_size {
+                // Picked file size >= max_compact_size
+                break;
+            }
+        }
+        info!(
+            "Picker(delta): Picked files: [ {} ]",
+            ColumnFiles(&picking_files)
+        );
+        if picking_files.is_empty() {
+            return None;
+        }
+
+        // Run compaction and send them to the target level, even if picked only 1 file,.
+        Some(CompactReq {
+            ts_family_id: version.tf_id(),
+            tenant_database: version.tenant_database(),
+            storage_opt: version.storage_opt(),
+            files: picking_files,
+            version: version.clone(),
+            in_level: 0,
+            out_level: out_level as u32,
+            max_ts: levels[out_level].time_range.max_ts,
+        })
     }
 }
 
@@ -301,8 +352,7 @@ mod test {
     use metrics::metric_register::MetricsRegister;
     use models::predicate::domain::TimeRange;
 
-    use crate::compaction::test::create_options;
-    use crate::compaction::{LevelCompactionPicker, Picker};
+    use crate::compaction::compact::test::create_options;
     use crate::file_utils::make_tsm_file;
     use crate::kv_option::Options;
     use crate::memcache::MemCache;
@@ -388,11 +438,11 @@ mod test {
     }
 
     #[test]
-    fn test_pick_1() {
+    fn test_pick_level_files_1() {
         //! There are Level 0-4, and Level 1 is now in compaction.
         //! In this case, Level 2, and serial files in Level 0 will be picked,
         //! and compact to Level 3.
-        let dir = "/tmp/test/pick/1";
+        let dir = "/tmp/test/pick/level_files_1";
         let opt = create_options(dir.to_string());
 
         #[rustfmt::skip]
@@ -422,11 +472,56 @@ mod test {
             ]), // 0.00001
         ];
 
-        let storage_opt = opt.storage.clone();
         let tsf = create_tseries_family(Arc::new("dba".to_string()), opt, levels_sketch);
-        let picker = LevelCompactionPicker::new(storage_opt);
-        let compact_req = picker.pick_compaction(tsf.version()).unwrap();
+        let compact_req = super::pick_level_compaction(tsf.version()).unwrap();
         assert_eq!(compact_req.out_level, 2);
         assert_eq!(compact_req.files.len(), 2);
+    }
+
+    #[test]
+    fn test_pick_delta_files_1() {
+        //! There are Level 0-4, and Level 0 is now in compaction.
+        //! In this case, Level 2, and serial files in Level 0 will be picked,
+        //! and compact to Level 3.
+        let dir = "/tmp/test/pick/delta_files_1";
+        let opt = create_options(dir.to_string());
+
+        #[rustfmt::skip]
+        let levels_sketch: LevelsSketch = vec![
+            // vec![( level, Timestamp_Begin, Timestamp_end, vec![(file_id, Timestamp_Begin, Timestamp_end, size, being_compact)] )]
+            (0_u32, 1_i64, 370_i64, vec![
+                (11_u64, 1_i64, 5_i64, 10_u64, false), // 4
+                (12, 10, 20, 10, true),                // 4
+                (12, 30, 40, 10, false),               // 4
+                (12, 110, 120, 10, false),             // 4
+                (12, 230, 240, 10, false),             // 3
+                (12, 300, 350, 10, false),             // 3
+                (12, 340, 350, 10, false),             // 2
+                (12, 360, 370, 10, false),             // 1
+            ]),
+            (1, 341, 380, vec![
+                (7, 341, 350, 1000, false),
+                (8, 351, 360, 1000, false),
+                (9, 361, 370, 1000, true),
+                (10, 371, 380, 1000, true),
+            ]), // 1
+            (2, 301, 340, vec![
+                (5, 301, 320, 2000, false),
+                (6, 321, 340, 2000, false),
+            ]), // 1
+            (3, 201, 300, vec![
+                (3, 201, 250, 5000, false),
+                (4, 251, 300, 5000, false),
+            ]), // 2
+            (4, 1, 200, vec![
+                (1, 10, 100, 10000, false),
+                (2, 101, 200, 10000, false),
+            ]), // 3
+        ];
+
+        let tsf = create_tseries_family(Arc::new("dba".to_string()), opt, levels_sketch);
+        let compact_req = super::pick_delta_compaction(tsf.version()).unwrap();
+        assert_eq!(compact_req.out_level, 4);
+        assert_eq!(compact_req.files.len(), 3);
     }
 }

--- a/tskv/src/compute/count.rs
+++ b/tskv/src/compute/count.rs
@@ -355,8 +355,7 @@ mod test {
     use parking_lot::RwLock;
     use tokio::runtime::Runtime;
 
-    use crate::compaction::flush_tests::default_table_schema;
-    use crate::compaction::test::write_data_blocks_to_column_file;
+    use crate::compaction::test::{default_table_schema, write_data_blocks_to_column_file};
     use crate::compute::count::count_column_non_null_values;
     use crate::memcache::test::put_rows_to_cache;
     use crate::memcache::MemCache;

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -25,17 +25,19 @@ use crate::kv_option::{Options, INDEX_PATH};
 use crate::memcache::{RowData, RowGroup};
 use crate::schema::schemas::DBschemas;
 use crate::summary::{SummaryTask, VersionEdit};
-use crate::tseries_family::{LevelInfo, TseriesFamily, TsfFactory, Version};
-use crate::Error::{self};
-use crate::{file_utils, ColumnFileId, TsKvContext, TseriesFamilyId};
+use crate::tseries_family::{
+    schedule_vnode_compaction, LevelInfo, TseriesFamily, TsfFactory, Version,
+};
+use crate::{file_utils, ColumnFileId, Error, TsKvContext, TseriesFamilyId};
 
 pub type FlatBufferTable<'a> = flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Table<'a>>>;
 
 #[derive(Debug)]
 pub struct Database {
+    opt: Arc<Options>,
+    runtime: Arc<Runtime>,
     //tenant_name.database_name => owner
     owner: Arc<String>,
-    opt: Arc<Options>,
     db_name: Arc<String>,
 
     schemas: Arc<DBschemas>,
@@ -50,6 +52,7 @@ pub struct DatabaseFactory {
     memory_pool: MemoryPoolRef,
     metrics_register: Arc<MetricsRegister>,
     opt: Arc<Options>,
+    runtime: Arc<Runtime>,
 }
 
 impl DatabaseFactory {
@@ -58,12 +61,14 @@ impl DatabaseFactory {
         memory_pool: MemoryPoolRef,
         metrics_register: Arc<MetricsRegister>,
         opt: Arc<Options>,
+        runtime: Arc<Runtime>,
     ) -> Self {
         Self {
             meta,
             memory_pool,
             metrics_register,
             opt,
+            runtime,
         }
     }
 
@@ -71,6 +76,7 @@ impl DatabaseFactory {
         Database::new(
             schema,
             self.opt.clone(),
+            self.runtime.clone(),
             self.meta.clone(),
             self.memory_pool.clone(),
             self.metrics_register.clone(),
@@ -83,6 +89,7 @@ impl Database {
     pub async fn new(
         schema: DatabaseSchema,
         opt: Arc<Options>,
+        runtime: Arc<Runtime>,
         meta: MetaRef,
         memory_pool: MemoryPoolRef,
         metrics_register: Arc<MetricsRegister>,
@@ -97,6 +104,7 @@ impl Database {
 
         let db = Self {
             opt,
+            runtime,
 
             owner: Arc::new(schema.owner()),
             db_name: Arc::new(schema.database_name().to_owned()),
@@ -117,9 +125,11 @@ impl Database {
     ) {
         let tf_id = ver.tf_id();
         let tf = self.tsf_factory.create_tsf(tf_id, ver.clone());
-        tf.schedule_compaction(runtime, compact_task_sender);
-        self.ts_families
-            .insert(ver.tf_id(), Arc::new(RwLock::new(tf)));
+
+        let tf_ref = Arc::new(RwLock::new(tf));
+        schedule_vnode_compaction(runtime, tf_ref.clone(), compact_task_sender);
+
+        self.ts_families.insert(ver.tf_id(), tf_ref);
     }
 
     // todo: Maybe TseriesFamily::new() should be refactored.
@@ -193,6 +203,11 @@ impl Database {
         if let Some(tsf) = self.ts_families.get(&tsf_id) {
             return Ok(tsf.clone());
         }
+        schedule_vnode_compaction(
+            ctx.runtime.clone(),
+            tf.clone(),
+            ctx.compact_task_sender.clone(),
+        );
         self.ts_families.insert(tsf_id, tf.clone());
 
         let (task_state_sender, _task_state_receiver) = oneshot::channel();
@@ -485,6 +500,17 @@ impl Database {
 impl Database {
     pub fn tsf_num(&self) -> usize {
         self.ts_families.len()
+    }
+}
+
+impl Drop for Database {
+    fn drop(&mut self) {
+        let vnodes: Vec<Arc<RwLock<TseriesFamily>>> = self.ts_families.values().cloned().collect();
+        self.runtime.spawn(async move {
+            for vnode in vnodes {
+                vnode.write().await.close();
+            }
+        });
     }
 }
 

--- a/tskv/src/lib.rs
+++ b/tskv/src/lib.rs
@@ -18,6 +18,7 @@ use models::{SeriesId, SeriesKey, TagKey, TagValue, Timestamp};
 use protos::kv_service::{WritePointsRequest, WritePointsResponse};
 use serde::{Deserialize, Serialize};
 use summary::SummaryTask;
+use tokio::runtime::Runtime;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::RwLock;
 use trace::SpanContext;
@@ -256,6 +257,7 @@ pub trait Engine: Send + Sync + Debug {
 #[derive(Debug, Clone)]
 pub struct TsKvContext {
     pub options: Arc<Options>,
+    pub runtime: Arc<Runtime>,
     pub global_ctx: Arc<GlobalContext>,
     pub version_set: Arc<RwLock<VersionSet>>,
 

--- a/tskv/src/summary.rs
+++ b/tskv/src/summary.rs
@@ -164,6 +164,11 @@ pub struct VersionEdit {
     pub max_level_ts: Timestamp,
     pub add_files: Vec<CompactMeta>,
     pub del_files: Vec<CompactMeta>,
+    /// Partly deleted files, only for delta-compaction.
+    /// Field min_ts and max_ts are the partly deleted time_range.
+    /// This field won't serialize and write into summary file.
+    #[serde(skip)]
+    pub partly_del_files: Vec<CompactMeta>,
 
     pub del_tsf: bool,
     pub add_tsf: bool,
@@ -181,6 +186,7 @@ impl Default for VersionEdit {
             max_level_ts: i64::MIN,
             add_files: vec![],
             del_files: vec![],
+            partly_del_files: vec![],
             del_tsf: false,
             add_tsf: false,
             tsf_id: 0,
@@ -277,6 +283,24 @@ impl VersionEdit {
             file_id,
             level,
             is_delta,
+            ..Default::default()
+        });
+    }
+
+    pub fn del_file_part(
+        &mut self,
+        level: LevelId,
+        file_id: u64,
+        is_delta: bool,
+        min_ts: Timestamp,
+        max_ts: Timestamp,
+    ) {
+        self.partly_del_files.push(CompactMeta {
+            file_id,
+            level,
+            is_delta,
+            min_ts,
+            max_ts,
             ..Default::default()
         });
     }
@@ -564,16 +588,69 @@ impl Summary {
 
         // For each TsereiesFamily - VersionEdits，generate a new Version and then apply it.
         let version_set = self.version_set.read().await;
+        let mut partly_deleted_file_pathes = Vec::new();
         for (tsf_id, edits) in tsf_version_edits {
             let min_seq = tsf_min_seq.get(&tsf_id);
             if let Some(tsf) = version_set.get_tsfamily_by_tf_id(tsf_id).await {
-                trace::info!("Applying new version for ts_family {}.", tsf_id);
+                // Store tsm pathes.
+                let tenant_database = &tsf.read().await.tenant_database().clone();
+                partly_deleted_file_pathes.clear();
+                for version_edit in edits.iter() {
+                    for compact_meta in version_edit.partly_del_files.iter() {
+                        partly_deleted_file_pathes.push(compact_meta.file_path(
+                            &self.opt.storage,
+                            tenant_database.as_str(),
+                            tsf_id,
+                        ));
+                    }
+                }
+
+                // Generate new version by version edits.
                 let new_version = tsf.read().await.version().copy_apply_version_edits(
                     edits,
                     &mut file_metas,
                     min_seq.copied(),
                 );
+
+                // Try to replace tombstones with compact_tmp.
+                let mut replace_tombstone_compact_tmp_tasks =
+                    Vec::with_capacity(partly_deleted_file_pathes.len());
+                for tsm_path in partly_deleted_file_pathes.iter() {
+                    match new_version.get_tsm_reader(tsm_path).await {
+                        Ok(tsm_reader) => {
+                            replace_tombstone_compact_tmp_tasks.push(
+                                self.runtime.spawn(async move {
+                                    tsm_reader.replace_with_compact_tmp().await
+                                }),
+                            );
+                        }
+                        Err(e) => {
+                            trace::error!(
+                                "Failed to get tsm_reader for file '{}' when trying to replace tombstones generated in delta-compaction: {e}",
+                                tsm_path.display(),
+                            )
+                        }
+                    }
+                }
+                for jh in replace_tombstone_compact_tmp_tasks {
+                    match jh.await {
+                        Ok(Ok(_)) => {
+                            trace::info!("Succefssfully replaced tombstone with compact_tmp");
+                        }
+                        Ok(Err(e)) => {
+                            // TODO: This delta-compaction should be failed.
+                            trace::error!("Failed to replace tombstone with compact_tmp: {e}");
+                        }
+                        Err(e) => {
+                            trace::error!(
+                                "Maybe paniced replacing tombstone with compact_tmp: {e}"
+                            );
+                        }
+                    }
+                }
+
                 let flushed_mem_cahces = mem_caches.get(&tsf_id);
+                trace::info!("Applying new version for ts_family {}.", tsf_id);
                 tsf.write()
                     .await
                     .new_version(new_version, flushed_mem_cahces);
@@ -684,6 +761,17 @@ pub async fn print_summary_statistics(path: impl AsRef<Path>) {
                             buffer.truncate(buffer.len() - 2);
                         }
                         println!("  Delete file:[ {} ]", buffer);
+                    }
+                    if !ve.partly_del_files.is_empty() {
+                        let mut buffer = String::new();
+                        ve.del_files.iter().for_each(|f| {
+                            buffer
+                                .push_str(format!("{} (level: {}), ", f.file_id, f.level).as_str())
+                        });
+                        if !buffer.is_empty() {
+                            buffer.truncate(buffer.len() - 2);
+                        }
+                        println!("  Partly Delete file:[ {} ]", buffer);
                     }
                 }
             }
@@ -935,6 +1023,7 @@ mod test {
             Summary,
             Arc<TsKvContext>,
         ) {
+            let runtime_ref = self.runtime.clone();
             self.runtime.block_on(async {
                 let meta_manager = AdminMeta::new(self.config.clone()).await;
                 meta_manager
@@ -967,6 +1056,7 @@ mod test {
                 let (wal_task_sender, _wal_task_receiver) = mpsc::channel(1);
                 let tskv_context = Arc::new(TsKvContext {
                     options: self.options.clone(),
+                    runtime: runtime_ref,
                     wal_sender: wal_task_sender,
                     flush_task_sender: self.flush_task_sender.clone(),
                     compact_task_sender: self.compact_task_sender.clone(),

--- a/tskv/src/tsm/block.rs
+++ b/tskv/src/tsm/block.rs
@@ -217,23 +217,23 @@ impl DataBlock {
         }
         let end = self.len();
         match self {
-            DataBlock::U64 { ts, .. } => Some((ts[0].to_owned(), ts[end - 1].to_owned())),
-            DataBlock::I64 { ts, .. } => Some((ts[0].to_owned(), ts[end - 1].to_owned())),
-            DataBlock::Str { ts, .. } => Some((ts[0].to_owned(), ts[end - 1].to_owned())),
-            DataBlock::F64 { ts, .. } => Some((ts[0].to_owned(), ts[end - 1].to_owned())),
-            DataBlock::Bool { ts, .. } => Some((ts[0].to_owned(), ts[end - 1].to_owned())),
+            DataBlock::U64 { ts, .. } => Some((ts[0], ts[end - 1])),
+            DataBlock::I64 { ts, .. } => Some((ts[0], ts[end - 1])),
+            DataBlock::Str { ts, .. } => Some((ts[0], ts[end - 1])),
+            DataBlock::F64 { ts, .. } => Some((ts[0], ts[end - 1])),
+            DataBlock::Bool { ts, .. } => Some((ts[0], ts[end - 1])),
         }
     }
 
     /// Returns (`timestamp[start]`, `timestamp[end]`) from this `DataBlock` at the specified
     /// indexes.
-    pub fn time_range_by_range(&self, start: usize, end: usize) -> (i64, i64) {
+    pub fn time_range_by_range(&self, start: usize, end: usize) -> (Timestamp, Timestamp) {
         match self {
-            DataBlock::U64 { ts, .. } => (ts[start].to_owned(), ts[end - 1].to_owned()),
-            DataBlock::I64 { ts, .. } => (ts[start].to_owned(), ts[end - 1].to_owned()),
-            DataBlock::Str { ts, .. } => (ts[start].to_owned(), ts[end - 1].to_owned()),
-            DataBlock::F64 { ts, .. } => (ts[start].to_owned(), ts[end - 1].to_owned()),
-            DataBlock::Bool { ts, .. } => (ts[start].to_owned(), ts[end - 1].to_owned()),
+            DataBlock::U64 { ts, .. } => (ts[start], ts[end - 1]),
+            DataBlock::I64 { ts, .. } => (ts[start], ts[end - 1]),
+            DataBlock::Str { ts, .. } => (ts[start], ts[end - 1]),
+            DataBlock::F64 { ts, .. } => (ts[start], ts[end - 1]),
+            DataBlock::Bool { ts, .. } => (ts[start], ts[end - 1]),
         }
     }
 
@@ -432,6 +432,102 @@ impl DataBlock {
         }
 
         blk
+    }
+
+    /// Split data block at index `i`, returns (block[..i]. block[i..])
+    pub fn split_at(self, i: usize) -> (DataBlock, DataBlock) {
+        match &self {
+            DataBlock::U64 { ts, val, .. } => {
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, PhysicalDType::Unsigned))
+                } else {
+                    (
+                        DataBlock::U64 {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::U64 {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+            DataBlock::I64 { ts, val, .. } => {
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, PhysicalDType::Integer))
+                } else {
+                    (
+                        DataBlock::I64 {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::I64 {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+            DataBlock::Str { ts, val, .. } => {
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, PhysicalDType::String))
+                } else {
+                    (
+                        DataBlock::Str {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::Str {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+            DataBlock::F64 { ts, val, .. } => {
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, PhysicalDType::Float))
+                } else {
+                    (
+                        DataBlock::F64 {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::F64 {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+            DataBlock::Bool { ts, val, .. } => {
+                if i >= ts.len() {
+                    (self, DataBlock::new(0, PhysicalDType::Boolean))
+                } else {
+                    (
+                        DataBlock::Bool {
+                            ts: ts[..i].to_vec(),
+                            val: val[..i].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                        DataBlock::Bool {
+                            ts: ts[i..].to_vec(),
+                            val: val[i..].to_vec(),
+                            enc: DataBlockEncoding::default(),
+                        },
+                    )
+                }
+            }
+        }
     }
 
     /// Merges one or many `DataBlock`s into some `DataBlock` with fixed length,
@@ -667,6 +763,7 @@ impl DataBlock {
         Some((min_idx, max_idx))
     }
 
+    /// Append another `DataBlock` into self, does nothing if value types are different.
     #[rustfmt::skip]
     pub fn extend(&mut self, mut data_block: DataBlock) {
         match (self, &mut data_block) {
@@ -692,6 +789,43 @@ impl DataBlock {
             }
             _ => {}
         }
+    }
+
+    /// Returns a subset of `DataBlock` with timestamps included in the specified time range.
+    pub fn intersection(self, time_range: &TimeRange) -> Option<DataBlock> {
+        self.index_range(time_range).map(|(min, max)| {
+            if min == 0 && max >= self.len() {
+                self
+            } else {
+                match self {
+                    DataBlock::U64 { ts, val, enc } => DataBlock::U64 {
+                        ts: ts[min..=max].to_vec(),
+                        val: val[min..=max].to_vec(),
+                        enc,
+                    },
+                    DataBlock::I64 { ts, val, enc } => DataBlock::I64 {
+                        ts: ts[min..=max].to_vec(),
+                        val: val[min..=max].to_vec(),
+                        enc,
+                    },
+                    DataBlock::Str { ts, val, enc } => DataBlock::Str {
+                        ts: ts[min..=max].to_vec(),
+                        val: val[min..=max].to_vec(),
+                        enc,
+                    },
+                    DataBlock::F64 { ts, val, enc } => DataBlock::F64 {
+                        ts: ts[min..=max].to_vec(),
+                        val: val[min..=max].to_vec(),
+                        enc,
+                    },
+                    DataBlock::Bool { ts, val, enc } => DataBlock::Bool {
+                        ts: ts[min..=max].to_vec(),
+                        val: val[min..=max].to_vec(),
+                        enc,
+                    },
+                }
+            }
+        })
     }
 
     /// Encodes timestamps and values of this `DataBlock` to bytes.
@@ -1091,15 +1225,14 @@ impl EncodedDataBlock {
 
 #[cfg(test)]
 pub mod test {
-
-    use minivec::mini_vec;
+    use minivec::{mini_vec, MiniVec};
     use models::predicate::domain::{TimeRange, TimeRanges};
     use models::PhysicalDType;
 
     use super::DataBlockReader;
     use crate::memcache::DataType;
     use crate::tsm::codec::DataBlockEncoding;
-    use crate::tsm::DataBlock;
+    use crate::tsm::{DataBlock, EncodedDataBlock};
 
     pub(crate) fn check_data_block(block: &DataBlock, pattern: &[DataType]) {
         assert_eq!(block.len(), pattern.len());
@@ -1124,6 +1257,158 @@ pub mod test {
         assert_eq!(res, vec![
             DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![10, 12, 13, 15, 50], enc: DataBlockEncoding::default() },
         ]);
+    }
+
+    #[test]
+    fn test_data_block_split_at() {
+        let cases = vec![
+            (1, (1..=5), 0, vec![], vec![1, 2, 3, 4, 5]),
+            (2, (1..=5), 1, vec![1], vec![2, 3, 4, 5]),
+            (3, (1..=5), 2, vec![1, 2], vec![3, 4, 5]),
+            (4, (1..=5), 4, vec![1, 2, 3, 4], vec![5]),
+            (5, (1..=5), 5, vec![1, 2, 3, 4, 5], vec![]),
+        ];
+        for (i, ts_range, split_idx, left, right) in cases {
+            {
+                let u64_blk = DataBlock::U64 {
+                    ts: ts_range.clone().collect(),
+                    val: ts_range.clone().map(|t| t as u64).collect(),
+                    enc: DataBlockEncoding::default(),
+                };
+                let (a, b) = u64_blk.split_at(split_idx);
+                assert_eq!(
+                    a,
+                    DataBlock::U64 {
+                        ts: left.clone(),
+                        val: left.iter().map(|d| *d as u64).collect(),
+                        enc: DataBlockEncoding::default()
+                    },
+                    "for case: {i}, u64, the left is different",
+                );
+                assert_eq!(
+                    b,
+                    DataBlock::U64 {
+                        ts: right.clone(),
+                        val: right.iter().map(|d| *d as u64).collect(),
+                        enc: DataBlockEncoding::default()
+                    },
+                    "for case: {i}, u64, the right is different",
+                );
+            }
+            {
+                let i64_blk = DataBlock::I64 {
+                    ts: ts_range.clone().collect(),
+                    val: ts_range.clone().collect(),
+                    enc: DataBlockEncoding::default(),
+                };
+                let (a, b) = i64_blk.split_at(split_idx);
+                assert_eq!(
+                    a,
+                    DataBlock::I64 {
+                        ts: left.clone(),
+                        val: left.clone(),
+                        enc: DataBlockEncoding::default()
+                    },
+                    "for case: {i}, i64, the left is different",
+                );
+                assert_eq!(
+                    b,
+                    DataBlock::I64 {
+                        ts: right.clone(),
+                        val: right.clone(),
+                        enc: DataBlockEncoding::default()
+                    },
+                    "for case: {i}, i64, the right is different",
+                );
+            }
+            {
+                let str_blk = DataBlock::Str {
+                    ts: ts_range.clone().collect(),
+                    val: ts_range
+                        .clone()
+                        .map(|d| MiniVec::from(d.to_string().as_bytes()))
+                        .collect(),
+                    enc: DataBlockEncoding::default(),
+                };
+                let (a, b) = str_blk.split_at(split_idx);
+                assert_eq!(
+                    a,
+                    DataBlock::Str {
+                        ts: left.clone(),
+                        val: left
+                            .iter()
+                            .map(|d| MiniVec::from(d.to_string().as_bytes()))
+                            .collect(),
+                        enc: DataBlockEncoding::default()
+                    },
+                    "for case: {i}, str, the left is different",
+                );
+                assert_eq!(
+                    b,
+                    DataBlock::Str {
+                        ts: right.clone(),
+                        val: right
+                            .iter()
+                            .map(|d| MiniVec::from(d.to_string().as_bytes()))
+                            .collect(),
+                        enc: DataBlockEncoding::default()
+                    },
+                    "for case: {i}, str, the right is different",
+                );
+            }
+            {
+                let f64_blk = DataBlock::F64 {
+                    ts: ts_range.clone().collect(),
+                    val: ts_range.clone().map(|t| t as f64).collect(),
+                    enc: DataBlockEncoding::default(),
+                };
+                let (a, b) = f64_blk.split_at(split_idx);
+                assert_eq!(
+                    a,
+                    DataBlock::F64 {
+                        ts: left.clone(),
+                        val: left.iter().map(|t| *t as f64).collect(),
+                        enc: DataBlockEncoding::default()
+                    },
+                    "for case: {i}, f64, the left is different",
+                );
+                assert_eq!(
+                    b,
+                    DataBlock::F64 {
+                        ts: right.clone(),
+                        val: right.iter().map(|t| *t as f64).collect(),
+                        enc: DataBlockEncoding::default()
+                    },
+                    "for case: {i}, f64, the right is different",
+                );
+            }
+            {
+                let bool_blk = DataBlock::Bool {
+                    ts: ts_range.clone().collect(),
+                    val: ts_range.clone().map(|t| t % 2 == 0).collect(),
+                    enc: DataBlockEncoding::default(),
+                };
+                let (a, b) = bool_blk.split_at(split_idx);
+                assert_eq!(
+                    a,
+                    DataBlock::Bool {
+                        ts: left.clone(),
+                        val: left.iter().map(|t| *t % 2 == 0).collect(),
+                        enc: DataBlockEncoding::default()
+                    },
+                    "for case: {i}, bool, the left is different",
+                );
+                assert_eq!(
+                    b,
+                    DataBlock::Bool {
+                        ts: right.clone(),
+                        val: right.iter().map(|t| *t % 2 == 0).collect(),
+                        enc: DataBlockEncoding::default()
+                    },
+                    "for case: {i}, bool, the right is different",
+                );
+            }
+        }
     }
 
     #[test]
@@ -1201,7 +1486,7 @@ pub mod test {
                 val: vec![mini_vec![10], mini_vec![11], mini_vec![19]],
                 enc: DataBlockEncoding::default(),
             }
-        )
+        );
     }
 
     #[test]
@@ -1337,6 +1622,311 @@ pub mod test {
     }
 
     #[test]
+    fn test_data_block_extend() {
+        {
+            let mut block_1 = DataBlock::U64 {
+                ts: vec![0, 1, 2],
+                val: vec![10, 11, 12],
+                enc: DataBlockEncoding::default(),
+            };
+            let block_2 = DataBlock::U64 {
+                ts: vec![3, 4, 5],
+                val: vec![13, 14, 15],
+                enc: DataBlockEncoding::default(),
+            };
+            block_1.extend(block_2);
+            assert_eq!(
+                block_1,
+                DataBlock::U64 {
+                    ts: vec![0, 1, 2, 3, 4, 5],
+                    val: vec![10, 11, 12, 13, 14, 15],
+                    enc: DataBlockEncoding::default(),
+                }
+            );
+        }
+        {
+            let mut block_1 = DataBlock::I64 {
+                ts: vec![0, 1, 2],
+                val: vec![10, 11, 12],
+                enc: DataBlockEncoding::default(),
+            };
+            let block_2 = DataBlock::I64 {
+                ts: vec![3, 4, 5],
+                val: vec![13, 14, 15],
+                enc: DataBlockEncoding::default(),
+            };
+            block_1.extend(block_2);
+            assert_eq!(
+                block_1,
+                DataBlock::I64 {
+                    ts: vec![0, 1, 2, 3, 4, 5],
+                    val: vec![10, 11, 12, 13, 14, 15],
+                    enc: DataBlockEncoding::default(),
+                }
+            );
+        }
+        {
+            let mut block_1 = DataBlock::Str {
+                ts: vec![0, 1, 2],
+                val: vec![
+                    MiniVec::from("10".as_bytes()),
+                    MiniVec::from("11".as_bytes()),
+                    MiniVec::from("12".as_bytes()),
+                ],
+                enc: DataBlockEncoding::default(),
+            };
+            let block_2 = DataBlock::Str {
+                ts: vec![3, 4, 5],
+                val: vec![
+                    MiniVec::from("13".as_bytes()),
+                    MiniVec::from("14".as_bytes()),
+                    MiniVec::from("15".as_bytes()),
+                ],
+                enc: DataBlockEncoding::default(),
+            };
+            block_1.extend(block_2);
+            assert_eq!(
+                block_1,
+                DataBlock::Str {
+                    ts: vec![0, 1, 2, 3, 4, 5],
+                    val: vec![
+                        MiniVec::from("10".as_bytes()),
+                        MiniVec::from("11".as_bytes()),
+                        MiniVec::from("12".as_bytes()),
+                        MiniVec::from("13".as_bytes()),
+                        MiniVec::from("14".as_bytes()),
+                        MiniVec::from("15".as_bytes()),
+                    ],
+                    enc: DataBlockEncoding::default(),
+                }
+            );
+        }
+        {
+            let mut block_1 = DataBlock::F64 {
+                ts: vec![0, 1, 2],
+                val: vec![10.0, 11.0, 12.0],
+                enc: DataBlockEncoding::default(),
+            };
+            let block_2 = DataBlock::F64 {
+                ts: vec![3, 4, 5],
+                val: vec![13.0, 14.0, 15.0],
+                enc: DataBlockEncoding::default(),
+            };
+            block_1.extend(block_2);
+            assert_eq!(
+                block_1,
+                DataBlock::F64 {
+                    ts: vec![0, 1, 2, 3, 4, 5],
+                    val: vec![10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+                    enc: DataBlockEncoding::default(),
+                }
+            );
+        }
+        {
+            let mut block_1 = DataBlock::Bool {
+                ts: vec![0, 1, 2],
+                val: vec![true, true, true],
+                enc: DataBlockEncoding::default(),
+            };
+            let block_2 = DataBlock::Bool {
+                ts: vec![3, 4, 5],
+                val: vec![false, false, false],
+                enc: DataBlockEncoding::default(),
+            };
+            block_1.extend(block_2);
+            assert_eq!(
+                block_1,
+                DataBlock::Bool {
+                    ts: vec![0, 1, 2, 3, 4, 5],
+                    val: vec![true, true, true, false, false, false],
+                    enc: DataBlockEncoding::default(),
+                }
+            );
+        }
+        {
+            // Test extend with different value type.
+            let mut block_1 = DataBlock::U64 {
+                ts: vec![0, 1, 2],
+                val: vec![10, 11, 12],
+                enc: DataBlockEncoding::default(),
+            };
+            let block_2 = DataBlock::Bool {
+                ts: vec![3, 4, 5],
+                val: vec![false, false, false],
+                enc: DataBlockEncoding::default(),
+            };
+            block_1.extend(block_2);
+            assert_eq!(
+                block_1,
+                DataBlock::U64 {
+                    ts: vec![0, 1, 2],
+                    val: vec![10, 11, 12],
+                    enc: DataBlockEncoding::default(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn test_data_block_intersection() {
+        let cases = vec![
+            (1, (1..=5), (1, 5), Some(1..=5)),
+            (2, (1..=5), (0, 6), Some(1..=5)),
+            (3, (1..=5), (0, 1), Some(1..=1)),
+            (4, (1..=5), (1, 2), Some(1..=2)),
+            (5, (1..=5), (-1, 0), None),
+            (6, (1..=5), (4, 5), Some(4..=5)),
+            (7, (1..=5), (5, 6), Some(5..=5)),
+            (8, (1..=5), (6, 7), None),
+        ];
+        for (i, block_time_range, out_time_range, expect_block_time_range) in cases {
+            {
+                let u64_blk = DataBlock::U64 {
+                    ts: block_time_range.clone().collect(),
+                    val: block_time_range.clone().map(|t| t as u64).collect(),
+                    enc: DataBlockEncoding::default(),
+                };
+                let intersection_ret = u64_blk.intersection(&out_time_range.into());
+                match &expect_block_time_range {
+                    Some(exp_time_range) => {
+                        assert!(
+                            intersection_ret.is_some(),
+                            "for case: {i}, u64, the result is not a Some(_)",
+                        );
+                        let blk_ret = intersection_ret.unwrap();
+                        assert!(
+                            blk_ret.time_range().is_some(),
+                            "for case: {i}, u64, the result's time_range is not a Some(_)",
+                        );
+                        let (min_ts, max_ts) = blk_ret.time_range().unwrap();
+                        assert_eq!(
+                            &(min_ts..=max_ts),
+                            exp_time_range,
+                            "for case: {i}, u64, the result's time_range is not as expected",
+                        );
+                    }
+                    None => assert!(intersection_ret.is_none()),
+                }
+            }
+            {
+                let i64_blk = DataBlock::I64 {
+                    ts: block_time_range.clone().collect(),
+                    val: block_time_range.clone().collect(),
+                    enc: DataBlockEncoding::default(),
+                };
+                let intersection_ret = i64_blk.intersection(&out_time_range.into());
+                match &expect_block_time_range {
+                    Some(exp_time_range) => {
+                        assert!(
+                            intersection_ret.is_some(),
+                            "for case: {i}, i64, the result is not a Some(_)",
+                        );
+                        let blk_ret = intersection_ret.unwrap();
+                        assert!(
+                            blk_ret.time_range().is_some(),
+                            "for case: {i}, i64, the result's time_range is not a Some(_)",
+                        );
+                        let (min_ts, max_ts) = blk_ret.time_range().unwrap();
+                        assert_eq!(
+                            &(min_ts..=max_ts),
+                            exp_time_range,
+                            "for case: {i}, i64, the result's time_range is not as expected",
+                        );
+                    }
+                    None => assert!(intersection_ret.is_none()),
+                }
+            }
+            {
+                let str_blk = DataBlock::Str {
+                    ts: block_time_range.clone().collect(),
+                    val: block_time_range
+                        .clone()
+                        .map(|d| MiniVec::from(d.to_string().as_bytes()))
+                        .collect(),
+                    enc: DataBlockEncoding::default(),
+                };
+                let intersection_ret = str_blk.intersection(&out_time_range.into());
+                match &expect_block_time_range {
+                    Some(exp_time_range) => {
+                        assert!(
+                            intersection_ret.is_some(),
+                            "for case: {i}, str, the result is not a Some(_)",
+                        );
+                        let blk_ret = intersection_ret.unwrap();
+                        assert!(
+                            blk_ret.time_range().is_some(),
+                            "for case: {i}, str, the result's time_range is not a Some(_)",
+                        );
+                        let (min_ts, max_ts) = blk_ret.time_range().unwrap();
+                        assert_eq!(
+                            &(min_ts..=max_ts),
+                            exp_time_range,
+                            "for case: {i}, str, the result's time_range is not as expected",
+                        );
+                    }
+                    None => assert!(intersection_ret.is_none()),
+                }
+            }
+            {
+                let f64_blk = DataBlock::F64 {
+                    ts: block_time_range.clone().collect(),
+                    val: block_time_range.clone().map(|t| t as f64).collect(),
+                    enc: DataBlockEncoding::default(),
+                };
+                let intersection_ret = f64_blk.intersection(&out_time_range.into());
+                match &expect_block_time_range {
+                    Some(exp_time_range) => {
+                        assert!(
+                            intersection_ret.is_some(),
+                            "for case: {i}, f64, the result is not a Some(_)",
+                        );
+                        let blk_ret = intersection_ret.unwrap();
+                        assert!(
+                            blk_ret.time_range().is_some(),
+                            "for case: {i}, f64, the result's time_range is not a Some(_)",
+                        );
+                        let (min_ts, max_ts) = blk_ret.time_range().unwrap();
+                        assert_eq!(
+                            &(min_ts..=max_ts),
+                            exp_time_range,
+                            "for case: {i}, f64, the result's time_range is not as expected",
+                        );
+                    }
+                    None => assert!(intersection_ret.is_none()),
+                }
+            }
+            {
+                let bool_blk = DataBlock::Bool {
+                    ts: block_time_range.clone().collect(),
+                    val: block_time_range.clone().map(|t| t % 2 == 0).collect(),
+                    enc: DataBlockEncoding::default(),
+                };
+                let intersection_ret = bool_blk.intersection(&out_time_range.into());
+                match &expect_block_time_range {
+                    Some(exp_time_range) => {
+                        assert!(
+                            intersection_ret.is_some(),
+                            "for case: {i}, bool, the result is not a Some(_)",
+                        );
+                        let blk_ret = intersection_ret.unwrap();
+                        assert!(
+                            blk_ret.time_range().is_some(),
+                            "for case: {i}, bool, the result's time_range is not a Some(_)",
+                        );
+                        let (min_ts, max_ts) = blk_ret.time_range().unwrap();
+                        assert_eq!(
+                            &(min_ts..=max_ts),
+                            exp_time_range,
+                            "for case: {i}, bool, the result's time_range is not as expected",
+                        );
+                    }
+                    None => assert!(intersection_ret.is_none()),
+                }
+            }
+        }
+    }
+
+    #[test]
     fn test_data_block_reader() {
         {
             let mut blk_reader = DataBlockReader::new_uninit(PhysicalDType::Float);
@@ -1395,6 +1985,35 @@ pub mod test {
             assert_eq!(blk_reader.next(), Some(DataType::U64(1001, 3003)));
             assert_eq!(blk_reader.next(), Some(DataType::U64(1002, 3006)));
             assert_eq!(blk_reader.next(), None);
+        }
+    }
+
+    #[test]
+    fn test_encoded_data_block() {
+        let blk = DataBlock::U64 {
+            ts: vec![1, 3, 5, 7, 9],
+            val: vec![10, 30, 50, 70, 90],
+            enc: DataBlockEncoding::default(),
+        };
+
+        {
+            let blk_enc = EncodedDataBlock::encode(&blk, 0, blk.len()).unwrap();
+            let blk_dec = blk_enc.decode().unwrap();
+            assert_eq!(blk, blk_dec);
+        }
+        {
+            let blk = blk.clone();
+            let blk_enc = EncodedDataBlock::encode(&blk, 0, 1).unwrap();
+            let blk_dec = blk_enc.decode().unwrap();
+            let (blk_exp, _) = blk.split_at(1);
+            assert_eq!(blk_exp, blk_dec);
+        }
+        {
+            let blk_enc = EncodedDataBlock::encode(&blk, 1, 2).unwrap();
+            let blk_dec = blk_enc.decode().unwrap();
+            let (_, blk_exp) = blk.split_at(1);
+            let (blk_exp, _) = blk_exp.split_at(1);
+            assert_eq!(blk_exp, blk_dec);
         }
     }
 }

--- a/tskv/src/tsm/codec/mod.rs
+++ b/tskv/src/tsm/codec/mod.rs
@@ -25,7 +25,7 @@ pub struct DataBlockEncoding {
 }
 
 impl DataBlockEncoding {
-    pub fn new(ts_encoding: Encoding, val_encoding: Encoding) -> Self {
+    pub const fn new(ts_encoding: Encoding, val_encoding: Encoding) -> Self {
         Self {
             ts_encoding,
             val_encoding,

--- a/tskv/src/tsm/mod.rs
+++ b/tskv/src/tsm/mod.rs
@@ -8,7 +8,7 @@ mod writer;
 pub use block::*;
 pub use index::*;
 pub use reader::*;
-pub use tombstone::{Tombstone, TsmTombstone, TOMBSTONE_FILE_SUFFIX};
+pub use tombstone::{tombstone_compact_tmp_path, Tombstone, TsmTombstone, TOMBSTONE_FILE_SUFFIX};
 pub use writer::*;
 
 // MAX_BLOCK_VALUES is the maximum number of values a TSM block can store.

--- a/tskv/src/version_set.rs
+++ b/tskv/src/version_set.rs
@@ -35,7 +35,13 @@ impl VersionSet {
         memory_pool: MemoryPoolRef,
         metrics_register: Arc<MetricsRegister>,
     ) -> Self {
-        let db_factory = DatabaseFactory::new(meta, memory_pool.clone(), metrics_register, opt);
+        let db_factory = DatabaseFactory::new(
+            meta,
+            memory_pool.clone(),
+            metrics_register,
+            opt,
+            runtime.clone(),
+        );
 
         Self {
             dbs: HashMap::new(),
@@ -51,7 +57,7 @@ impl VersionSet {
         let register = Arc::new(MetricsRegister::default());
         let memory_pool = Arc::new(memory_pool::GreedyMemoryPool::default());
         let meta = Arc::new(AdminMeta::mock());
-        let db_factory = DatabaseFactory::new(meta, memory_pool, register, opt);
+        let db_factory = DatabaseFactory::new(meta, memory_pool, register, opt, runtime.clone());
         Self {
             dbs: HashMap::new(),
             runtime,
@@ -70,7 +76,13 @@ impl VersionSet {
         metrics_register: Arc<MetricsRegister>,
     ) -> Result<Self> {
         let mut dbs = HashMap::new();
-        let db_factory = DatabaseFactory::new(meta.clone(), memory_pool, metrics_register, opt);
+        let db_factory = DatabaseFactory::new(
+            meta.clone(),
+            memory_pool,
+            metrics_register,
+            opt,
+            runtime.clone(),
+        );
 
         for ver in ver_set.into_values() {
             let owner = ver.tenant_database().to_string();


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #1244.

# Rationale for this change

## Conclusion

### Others

1. `DataBlock` - Add method `split_at(self, index)-> (DataBlock, DataBlock)` and `intersection(self, time_range) -> Option<DataBlock>`.
2. `ColumnFile`, `LevelInfo` - Implement `std::fmt::Display`, also add `ColumnFiles<F: AsRef<ColumnFile>>(&[F])` and `LevelInfos(&[LevelInfo])` to decrease code when we need to log them.
3. `TimeRange`, add function `compact(time_ranges: &mut Vec<TimeRange>)` to compact time ranges.

### Compaction

- Changes measurement of compaction from `"db", "ts_family", "level"` to `"db", "ts_family", "in_level", "out_level"`.
- Add file `delta_compact.rs` for delta compaction:
  1. Pick delta files and the out_level, get the `out_level_max_ts` of the out_level.
  2. Now we have many delta files, for each field_id in these files, find grouped blocks which should be merged together: `Vec<CompactingBlockMetaGroup>`.
  3. For each `CompactingBlockMetaGroup`, get merge-split blocks(only data in time_range `0..=out_level_max_ts` is needed) and write them into files in the out_level, store these files in `VersionEdit`.
  4. Write a temporary tsm-tombstone file for the delta-file, named `xxxxxxx.tombstone.compact.tmp`, includes all it's field_ids and time_range `0..=out_level_max_ts`, because data in the time_range is already merged into the out_level. Tombstones will be compacted by `compact(time_ranges: &mut Vec<TimeRange>)` before write.
  5. Write the `VersionEdit` into summary, and rename these `xxxxxxx.tombstone.compact.tmp` files to `xxxxxxx.tombstone`.

#### Task definition

Some changes in `CompactTask`:

- Normal(from old CompactTask::Vnode) - Compact the files in the in_level into the out_level.
- Cold(from old CompactTask::ColdVnode) - Flush memcaches and then compact the files in the in_level into the out_level.
- Delta - Compact the files in level-0 into the out_level.

#### Pick

- Remove trait `Picker: Send + Sync + Debug`, add two function instead of it:
  - `pick_level_compaction(version: Arc<Version>) -> Option<CompactReq>`
  - `pick_delta_compaction(version: Arc<Version>) -> Option<CompactReq>`
- Add function `pick_delta_compaction` only for picking delta files, it partly merges data in level-0 files to the destination level, the merged data will leave a tombstone file for the source level-0 files.

#### Scheduler

- Now `schedule_compaction()` not only check if a tseries family is cold but also check num of level-0 files with config `compact_trigger_file_num` or constant `DEFAULT_COMPACT_TRIGGER_DETLA_FILE_NUM` (This change makes unit tests in summary.rs won't stop, so I fixed  it by some changes in unit test cases in summary.rs).
- `schedule_compaction()` holds a shared reference of `Arc<TseriesFamily`, now we must manually stop it by `TseriesFamily::close()`. Implementation of `Drop` for `Database` will call that method of all it's tseries families.
- Compact job structure `compaction::job::CompactProcessor` is changed to hold the map of `(TsFamilyId, IsDeltaCompaction)` to `ShouldFlushBeforeCompaction`.

## TODOs

There may be some logs for debug may be deleted.

# Are there any user-facing changes?

No.

 

