### PR TITLE
Fix(2.3) bugs around compaction

### DIFF
--- a/tskv/src/tsm/block.rs
+++ b/tskv/src/tsm/block.rs
@@ -962,6 +962,15 @@ pub struct EncodedDataBlock {
     pub time_range: Option<TimeRange>,
 }
 
+impl PartialEq for EncodedDataBlock {
+    fn eq(&self, other: &Self) -> bool {
+        self.field_type == other.field_type
+            && self.enc == other.enc
+            && self.ts == other.ts
+            && self.val == other.val
+    }
+}
+
 impl Display for EncodedDataBlock {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let time_range = self.time_range.unwrap_or(TimeRange::none());


### PR DESCRIPTION
…s in CompactIterator for better performance

# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

## Fix some bugs:

### 1. Errors in compact::chunk_merged_block();

There may be an error when chunking big blocks, this makes data lost.

### 2. Merge two tmp-fields in CompactIterator for better performance;

Merge `tmp_tsm_blk_meta_iters: Vec<BlockMetaIterator>` and `tmp_tsm_blk_tsm_reader_idx: Vec<usize>` into `tmp_tsm_blk_meta_iters: Vec<(usize, BlockMetaIterator)>`.
# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

