### PR TITLE
Feature(2.3): add compaction task for delta files

### DIFF
--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -206,7 +206,7 @@ pub static COMPACTION_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
         .namespace(NAMESPACE)
         .subsystem(TSKV_SUBSYSTEM)
         .buckets(linear_buckets(0.0, 300.0, 2400).unwrap()),
-        &["db", "ts_family", "level"],
+        &["db", "ts_family", "in_level", "out_level"],
     )
     .expect("tskv metric cannot be created")
 });
@@ -231,9 +231,15 @@ pub fn incr_compaction_failed() {
     COMPACTION_FAILED.inc();
 }
 
-pub fn sample_tskv_compaction_duration(db: &str, ts_family: &str, level: &str, delta: f64) {
+pub fn sample_tskv_compaction_duration(
+    db: &str,
+    ts_family: &str,
+    in_level: &str,
+    out_level: &str,
+    delta: f64,
+) {
     COMPACTION_DURATION
-        .with_label_values(&[db, ts_family, level])
+        .with_label_values(&[db, ts_family, in_level, out_level])
         .observe(delta)
 }
 

--- a/tskv/src/compaction/compact.rs
+++ b/tskv/src/compaction/compact.rs
@@ -1,6 +1,5 @@
 use std::collections::{BinaryHeap, HashMap, VecDeque};
 use std::fmt::{Display, Formatter};
-use std::pin::Pin;
 use std::sync::Arc;
 
 use models::predicate::domain::TimeRange;
@@ -21,12 +20,13 @@ use crate::tsm::{
 };
 use crate::{ColumnFileId, Error, LevelId, TseriesFamilyId};
 
-/// Temporary compacting data block meta
+/// Temporary compacting data block meta, holding the priority of reader,
+/// the reader and the meta of data block.
 #[derive(Clone)]
 pub(crate) struct CompactingBlockMeta {
-    reader_idx: usize,
-    reader: Arc<TsmReader>,
-    meta: BlockMeta,
+    pub reader_idx: usize,
+    pub reader: Arc<TsmReader>,
+    pub meta: BlockMeta,
 }
 
 impl PartialEq for CompactingBlockMeta {
@@ -83,6 +83,11 @@ impl CompactingBlockMeta {
         self.meta.min_ts() <= time_range.max_ts && self.meta.max_ts() >= time_range.min_ts
     }
 
+    pub fn included_in_time_range(&self, time_range: &TimeRange) -> bool {
+        self.meta.min_ts() >= time_range.min_ts && self.meta.max_ts() <= time_range.max_ts
+    }
+
+    /// Read data block of block meta from reader.
     pub async fn get_data_block(&self) -> Result<DataBlock> {
         self.reader
             .get_data_block(&self.meta)
@@ -90,6 +95,18 @@ impl CompactingBlockMeta {
             .context(error::ReadTsmSnafu)
     }
 
+    /// Read data block of block meta from reader.
+    pub async fn get_data_block_opt(&self, time_range: &TimeRange) -> Result<Option<DataBlock>> {
+        // It's impossible that the reader got None by meta,
+        // or blk.intersection(time_range) returned None.
+        self.reader
+            .get_data_block(&self.meta)
+            .await
+            .map(|blk| blk.intersection(time_range))
+            .context(error::ReadTsmSnafu)
+    }
+
+    /// Read raw data of block meta from reader.
     pub async fn get_raw_data(&self, dst: &mut Vec<u8>) -> Result<usize> {
         self.reader
             .get_raw_data(&self.meta, dst)
@@ -108,6 +125,7 @@ pub(crate) struct CompactingBlockMetaGroup {
     blk_metas: Vec<CompactingBlockMeta>,
     time_range: TimeRange,
 }
+
 impl CompactingBlockMetaGroup {
     pub fn new(field_id: FieldId, blk_meta: CompactingBlockMeta) -> Self {
         let time_range = blk_meta.time_range();
@@ -141,7 +159,7 @@ impl CompactingBlockMetaGroup {
         let merged_block;
         if self.blk_metas.len() == 1 && !self.blk_metas[0].has_tombstone() {
             // Only one compacting block and has no tombstone, write as raw block.
-            trace!("only one compacting block, write as raw block");
+            trace!("only one compacting block without tombstone, handled as raw block");
             let meta_0 = &self.blk_metas[0].meta;
             let mut buf_0 = Vec::with_capacity(meta_0.size() as usize);
             let data_len_0 = self.blk_metas[0].get_raw_data(&mut buf_0).await?;
@@ -174,7 +192,6 @@ impl CompactingBlockMetaGroup {
                 merged_block = data_block;
             } else {
                 // Raw block is not full, but nothing to merge with, directly return.
-
                 return Ok(vec![CompactingBlock::raw(
                     self.blk_metas[0].reader_idx,
                     meta_0.clone(),
@@ -220,6 +237,34 @@ impl CompactingBlockMetaGroup {
     }
 }
 
+impl Display for CompactingBlockMetaGroup {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{field_id: {}, blk_metas: [", self.field_id)?;
+        if !self.blk_metas.is_empty() {
+            write!(f, "{}", &self.blk_metas[0])?;
+            for b in self.blk_metas.iter().skip(1) {
+                write!(f, ", {}", b)?;
+            }
+        }
+        write!(f, "]}}")
+    }
+}
+
+struct CompactingBlockMetaGroupsVecDeque<'a>(&'a VecDeque<CompactingBlockMetaGroup>);
+
+impl<'a> Display for CompactingBlockMetaGroupsVecDeque<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut iter = self.0.iter();
+        if let Some(d) = iter.next() {
+            write!(f, "{}", d)?;
+            for d in iter {
+                write!(f, ", {d}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
 fn chunk_merged_block(
     field_id: FieldId,
     data_block: DataBlock,
@@ -231,6 +276,7 @@ fn chunk_merged_block(
         // Try to merge with the next CompactingBlockMetaGroup.
         merged_blks.push(CompactingBlock::decoded(0, field_id, data_block));
     } else {
+        // Data block is so big that split into multi CompactingBlock
         let len = data_block.len();
         let mut start = 0;
         let mut end = len.min(max_block_size);
@@ -290,15 +336,20 @@ impl Display for CompactingBlock {
             } => {
                 write!(f, "p: {priority}, f: {field_id}, block: {data_block}")
             }
-            CompactingBlock::Raw { priority, meta, .. } => {
+            CompactingBlock::Raw {
+                priority,
+                meta,
+                raw,
+            } => {
                 write!(
                     f,
-                    "p: {priority}, f: {}, block: {}: {{ len: {}, min_ts: {}, max_ts: {} }}",
+                    "p: {priority}, f: {}, block: {}: {{ len: {}, min_ts: {}, max_ts: {}, raw_len: {} }}",
                     meta.field_id(),
                     meta.field_type(),
                     meta.count(),
                     meta.min_ts(),
-                    meta.max_ts()
+                    meta.max_ts(),
+                    raw.len(),
                 )
             }
         }
@@ -347,6 +398,29 @@ impl CompactingBlock {
         }
     }
 
+    /// Decode data block and return the intersected segment with out_time_range.
+    pub fn decode_opt(self, out_time_range: &TimeRange) -> Result<Option<DataBlock>> {
+        let data_block = match self {
+            CompactingBlock::Decoded { data_block, .. } => data_block,
+            CompactingBlock::Encoded { data_block, .. } => {
+                data_block.decode().context(error::DecodeSnafu)?
+            }
+            CompactingBlock::Raw { raw, meta, .. } => {
+                tsm::decode_data_block(&raw, meta.field_type(), meta.val_off() - meta.offset())
+                    .context(error::ReadTsmSnafu)?
+            }
+        };
+        if let Some((min_ts, _max_ts)) = data_block.time_range() {
+            if min_ts < out_time_range.max_ts {
+                Ok(data_block.intersection(out_time_range))
+            } else {
+                Ok(None)
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
     pub fn len(&self) -> usize {
         match self {
             CompactingBlock::Decoded { data_block, .. } => data_block.len(),
@@ -356,32 +430,38 @@ impl CompactingBlock {
     }
 }
 
-struct CompactingFile {
-    i: usize,
-    tsm_reader: Arc<TsmReader>,
-    index_iter: BufferedIterator<IndexIterator>,
-    field_id: Option<FieldId>,
+pub(crate) struct CompactingFile {
+    pub i: usize,
+    pub tsm_reader: Arc<TsmReader>,
+    pub index_iter: BufferedIterator<IndexIterator>,
+    pub field_id: FieldId,
 }
 
 impl CompactingFile {
-    fn new(i: usize, tsm_reader: Arc<TsmReader>) -> Self {
+    pub(crate) fn new(i: usize, tsm_reader: Arc<TsmReader>) -> Option<Self> {
         let mut index_iter = BufferedIterator::new(tsm_reader.index_iterator());
-        let first_field_id = index_iter.peek().map(|i| i.field_id());
-        Self {
-            i,
-            tsm_reader,
-            index_iter,
-            field_id: first_field_id,
+        index_iter
+            .peek()
+            .map(|idx_meta| idx_meta.field_id())
+            .map(|field_id| Self {
+                i,
+                tsm_reader,
+                index_iter,
+                field_id,
+            })
+    }
+
+    /// Fetch the next index meta of tsm-file, field_id may be changed.
+    pub(crate) fn next(&mut self) -> Option<&IndexMeta> {
+        if let Some(idx_meta) = self.index_iter.next() {
+            self.field_id = idx_meta.field_id();
+            Some(idx_meta)
+        } else {
+            None
         }
     }
 
-    fn next(&mut self) -> Option<&IndexMeta> {
-        let idx_meta = self.index_iter.next();
-        idx_meta.map(|i| self.field_id.replace(i.field_id()));
-        idx_meta
-    }
-
-    fn peek(&mut self) -> Option<&IndexMeta> {
+    pub(crate) fn peek(&mut self) -> Option<&IndexMeta> {
         self.index_iter.peek()
     }
 }
@@ -408,17 +488,15 @@ impl PartialOrd for CompactingFile {
 
 pub(crate) struct CompactIterator {
     tsm_readers: Vec<Arc<TsmReader>>,
-    compacting_files: BinaryHeap<Pin<Box<CompactingFile>>>,
+    compacting_files: BinaryHeap<CompactingFile>,
     /// Maximum values in generated CompactingBlock
     max_data_block_size: usize,
-    // /// The time range of data to be merged of level-0 data blocks.
-    // /// The level-0 data that out of the thime range will write back to level-0.
-    // level_time_range: TimeRange,
     /// Decode a data block even though it doesn't need to merge with others,
     /// return CompactingBlock::DataBlock rather than CompactingBlock::Raw .
     decode_non_overlap_blocks: bool,
 
     /// Temporarily stored index of `TsmReader` in self.tsm_readers,
+    /// and if `TsmReader` is a delta file,
     /// and `BlockMetaIterator` of current field_id.
     tmp_tsm_blk_meta_iters: Vec<(usize, BlockMetaIterator)>,
     /// When a TSM file at index i is ended, finished_idxes[i] is set to true.
@@ -453,25 +531,31 @@ impl CompactIterator {
         max_data_block_size: usize,
         decode_non_overlap_blocks: bool,
     ) -> Self {
-        let compacting_files: BinaryHeap<Pin<Box<CompactingFile>>> = tsm_readers
-            .iter()
-            .enumerate()
-            .map(|(i, r)| Box::pin(CompactingFile::new(i, r.clone())))
-            .collect();
-        let compacting_files_cnt = compacting_files.len();
+        let mut compacting_tsm_readers = Vec::with_capacity(tsm_readers.len());
+        let mut compacting_files = BinaryHeap::with_capacity(tsm_readers.len());
+        let mut compacting_tsm_file_idx = 0_usize;
+        for tsm_reader in tsm_readers {
+            if let Some(cf) = CompactingFile::new(compacting_tsm_file_idx, tsm_reader.clone()) {
+                compacting_tsm_readers.push(tsm_reader);
+                compacting_files.push(cf);
+                compacting_tsm_file_idx += 1;
+            }
+        }
 
         Self {
-            tsm_readers,
+            tsm_readers: compacting_tsm_readers,
             compacting_files,
             max_data_block_size,
             decode_non_overlap_blocks,
-            finished_readers: vec![false; compacting_files_cnt],
+            tmp_tsm_blk_meta_iters: Vec::with_capacity(compacting_tsm_file_idx),
+            finished_readers: vec![false; compacting_tsm_file_idx],
             ..Default::default()
         }
     }
 
     /// Update tmp_tsm_blks and tmp_tsm_blk_tsm_reader_idx for field id in next iteration.
     fn next_field_id(&mut self) {
+        trace!("===============================");
         self.curr_fid = None;
 
         if let Some(f) = self.compacting_files.peek() {
@@ -481,7 +565,7 @@ impl CompactIterator {
                     f.field_id,
                     f.tsm_reader.file_id()
                 );
-                self.curr_fid = f.field_id
+                self.curr_fid = Some(f.field_id);
             }
         } else {
             // TODO finished
@@ -489,14 +573,15 @@ impl CompactIterator {
             self.finished_reader_cnt += 1;
         }
         self.tmp_tsm_blk_meta_iters.clear();
+        let mut loop_file_i;
         while let Some(mut f) = self.compacting_files.pop() {
-            let loop_field_id = f.field_id;
-            let loop_file_i = f.i;
-            if self.curr_fid == loop_field_id {
+            loop_file_i = f.i;
+            if self.curr_fid == Some(f.field_id) {
                 if let Some(idx_meta) = f.peek() {
                     self.tmp_tsm_blk_meta_iters
                         .push((loop_file_i, idx_meta.block_iterator()));
-                    trace!("merging idx_meta: field_id: {}, field_type: {:?}, block_count: {}, time_range: {:?}",
+                    trace!("merging idx_meta({}): field_id: {}, field_type: {:?}, block_count: {}, time_range: {:?}",
+                        self.tmp_tsm_blk_meta_iters.len(),
                         idx_meta.field_id(),
                         idx_meta.field_type(),
                         idx_meta.block_count(),
@@ -505,12 +590,13 @@ impl CompactIterator {
                     f.next();
                     self.compacting_files.push(f);
                 } else {
-                    // This tsm-file has been finished
-                    trace!("file {} is finished.", loop_file_i);
+                    // This tsm-file has been finished, do not push it back.
+                    trace!("file {loop_file_i} is finished.");
                     self.finished_readers[loop_file_i] = true;
                     self.finished_reader_cnt += 1;
                 }
             } else {
+                // This tsm-file do not need to compact at this time, push it back.
                 self.compacting_files.push(f);
                 break;
             }
@@ -518,7 +604,7 @@ impl CompactIterator {
     }
 
     /// Collect merging `DataBlock`s.
-    async fn fetch_merging_block_meta_groups(&mut self) -> bool {
+    fn fetch_merging_block_meta_groups(&mut self) -> bool {
         if self.tmp_tsm_blk_meta_iters.is_empty() {
             return false;
         }
@@ -579,20 +665,10 @@ impl CompactIterator {
             .into_iter()
             .filter(|l| !l.is_empty())
             .collect();
+
         trace!(
             "selected merging meta groups: {}",
-            blk_meta_groups
-                .iter()
-                .map(|g| format!(
-                    "[{}]",
-                    g.blk_metas
-                        .iter()
-                        .map(|b| format!("{}", b))
-                        .collect::<Vec<String>>()
-                        .join(", ")
-                ))
-                .collect::<Vec<String>>()
-                .join(", ")
+            CompactingBlockMetaGroupsVecDeque(&blk_meta_groups),
         );
 
         self.merging_blk_meta_groups = blk_meta_groups;
@@ -621,12 +697,16 @@ impl CompactIterator {
         }
 
         // Get all of block_metas of this field id, and merge these blocks
-        self.fetch_merging_block_meta_groups().await;
+        self.fetch_merging_block_meta_groups();
 
         if let Some(g) = self.merging_blk_meta_groups.pop_front() {
             return Some(g);
         }
         None
+    }
+
+    pub fn curr_fid(&self) -> Option<FieldId> {
+        self.curr_fid
     }
 }
 
@@ -639,24 +719,7 @@ pub async fn run_compaction_job(
     request: CompactReq,
     kernel: Arc<GlobalContext>,
 ) -> Result<Option<(VersionEdit, HashMap<ColumnFileId, Arc<BloomFilter>>)>> {
-    info!(
-        "Compaction: Running compaction job on ts_family: {} and files: [ {} ]",
-        request.ts_family_id,
-        request
-            .files
-            .iter()
-            .map(|f| {
-                format!(
-                    "{{ Level-{}, file_id: {}, time_range: {}-{} }}",
-                    f.level(),
-                    f.file_id(),
-                    f.time_range().min_ts,
-                    f.time_range().max_ts
-                )
-            })
-            .collect::<Vec<String>>()
-            .join(", ")
-    );
+    info!("Compaction: Running compaction job on {request}");
 
     if request.files.is_empty() {
         // Nothing to compact
@@ -893,11 +956,11 @@ pub mod test {
 
     use lru_cache::asynchronous::ShardedCache;
     use minivec::MiniVec;
+    use models::codec::Encoding;
     use models::predicate::domain::TimeRange;
     use models::{FieldId, Timestamp, ValueType};
 
-    use crate::compaction::compact::chunk_merged_block;
-    use crate::compaction::{run_compaction_job, CompactReq, CompactingBlock};
+    use super::{chunk_merged_block, run_compaction_job, CompactReq, CompactingBlock};
     use crate::context::GlobalContext;
     use crate::file_system::file_manager;
     use crate::kv_option::Options;
@@ -905,7 +968,7 @@ pub mod test {
     use crate::tseries_family::{ColumnFile, LevelInfo, Version};
     use crate::tsm::codec::DataBlockEncoding;
     use crate::tsm::{self, DataBlock, EncodedDataBlock, TsmReader, TsmTombstone};
-    use crate::{file_utils, ColumnFileId};
+    use crate::{file_utils, ColumnFileId, LevelId};
 
     #[test]
     fn test_chunk_merged_block() {
@@ -993,7 +1056,7 @@ pub mod test {
         }
     }
 
-    pub(crate) async fn write_data_blocks_to_column_file(
+    pub async fn write_data_blocks_to_column_file(
         dir: impl AsRef<Path>,
         data: Vec<HashMap<FieldId, Vec<DataBlock>>>,
     ) -> (u64, Vec<Arc<ColumnFile>>) {
@@ -1020,13 +1083,13 @@ pub mod test {
                 false,
                 writer.path(),
             );
-            cf.set_field_id_filter(Arc::new(writer.bloom_filter_cloned()));
+            cf.set_field_id_filter(Arc::new(writer.into_bloom_filter()));
             cfs.push(Arc::new(cf));
         }
         (file_seq + 1, cfs)
     }
 
-    async fn read_data_blocks_from_column_file(
+    pub async fn read_data_blocks_from_column_file(
         path: impl AsRef<Path>,
     ) -> HashMap<FieldId, Vec<DataBlock>> {
         let tsm_reader = TsmReader::open(path).await.unwrap();
@@ -1041,27 +1104,41 @@ pub mod test {
         data
     }
 
-    fn get_result_file_path(dir: impl AsRef<Path>, version_edit: VersionEdit) -> PathBuf {
+    fn get_result_file_path(
+        dir: impl AsRef<Path>,
+        version_edit: VersionEdit,
+        level: LevelId,
+    ) -> PathBuf {
         if version_edit.has_file_id && !version_edit.add_files.is_empty() {
-            let file_id = version_edit.add_files.first().unwrap().file_id;
-            return file_utils::make_tsm_file_name(dir, file_id);
+            if let Some(f) = version_edit
+                .add_files
+                .into_iter()
+                .find(|f| f.level == level)
+            {
+                if level == 0 {
+                    return file_utils::make_delta_file_name(dir, f.file_id);
+                } else {
+                    return file_utils::make_tsm_file_name(dir, f.file_id);
+                }
+            }
+            panic!("VersionEdit::add_files doesn't contain any file matches level-{level}.");
         }
-
-        panic!("VersionEdit doesn't contain any add_files.");
+        panic!("VersionEdit::add_files is empty, no file to read.");
     }
 
     /// Compare DataBlocks in path with the expected_Data using assert_eq.
-    async fn check_column_file(
+    pub async fn check_column_file(
         dir: impl AsRef<Path>,
         version_edit: VersionEdit,
         expected_data: HashMap<FieldId, Vec<DataBlock>>,
+        expected_data_level: LevelId,
     ) {
-        let path = get_result_file_path(dir, version_edit);
+        let path = get_result_file_path(dir, version_edit, expected_data_level);
         let data = read_data_blocks_from_column_file(path).await;
         let mut data_field_ids = data.keys().copied().collect::<Vec<_>>();
-        data_field_ids.sort_unstable();
+        data_field_ids.sort();
         let mut expected_data_field_ids = expected_data.keys().copied().collect::<Vec<_>>();
-        expected_data_field_ids.sort_unstable();
+        expected_data_field_ids.sort();
         assert_eq!(data_field_ids, expected_data_field_ids);
 
         for (k, v) in expected_data.iter() {
@@ -1069,7 +1146,7 @@ pub mod test {
             if v.len() != data_blks.len() {
                 let v_str = format_data_blocks(v.as_slice());
                 let data_blks_str = format_data_blocks(data_blks.as_slice());
-                panic!("fid={k}, v.len != data_blks.len: v={v_str}, data_blks={data_blks_str}")
+                panic!("fid={k}, v.len != data_blks.len:\n          v={v_str}\n  data_blks={data_blks_str}")
             }
             assert_eq!(v.len(), data_blks.len());
             for (v_idx, v_blk) in v.iter().enumerate() {
@@ -1078,40 +1155,43 @@ pub mod test {
         }
     }
 
-    pub(crate) fn create_options(base_dir: String) -> Arc<Options> {
+    pub fn create_options(base_dir: String) -> Arc<Options> {
         let mut config = config::get_config_for_test();
-        config.storage.path = base_dir;
-        let opt = Options::from(&config);
-        Arc::new(opt)
+        config.storage.path = base_dir.clone();
+        config.log.path = base_dir;
+        Arc::new(Options::from(&config))
     }
 
-    fn prepare_compact_req_and_kernel(
-        database: Arc<String>,
+    pub fn prepare_compaction(
+        tenant_database: Arc<String>,
         opt: Arc<Options>,
-        next_file_id: u64,
+        next_file_id: ColumnFileId,
         files: Vec<Arc<ColumnFile>>,
+        max_level_ts: Timestamp,
     ) -> (CompactReq, Arc<GlobalContext>) {
         let version = Arc::new(Version::new(
             1,
-            database.clone(),
+            tenant_database.clone(),
             opt.storage.clone(),
             1,
-            LevelInfo::init_levels(database.clone(), 0, opt.storage.clone()),
-            1000,
+            LevelInfo::init_levels(tenant_database.clone(), 0, opt.storage.clone()),
+            max_level_ts,
             Arc::new(ShardedCache::with_capacity(1)),
         ));
         let compact_req = CompactReq {
             ts_family_id: 1,
-            database,
+            database: tenant_database,
             storage_opt: opt.storage.clone(),
             files,
             version,
+            in_level: 1,
             out_level: 2,
+            max_ts: Timestamp::MAX,
         };
-        let kernel = Arc::new(GlobalContext::new());
-        kernel.set_file_id(next_file_id);
+        let context = Arc::new(GlobalContext::new());
+        context.set_file_id(next_file_id);
 
-        (compact_req, kernel)
+        (compact_req, context)
     }
 
     fn format_data_blocks(data_blocks: &[DataBlock]) -> String {
@@ -1125,6 +1205,7 @@ pub mod test {
         )
     }
 
+    /// Test compaction with ordered data.
     #[tokio::test]
     async fn test_compaction_fast() {
         #[rustfmt::skip]
@@ -1152,104 +1233,117 @@ pub mod test {
             (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
         ]);
 
-        let dir = "/tmp/test/compaction";
-        let database = Arc::new("dba".to_string());
+        let dir = "/tmp/test/compaction/0";
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
+        let max_level_ts = 9;
 
         let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, files);
+            prepare_compaction(tenant_database, opt, next_file_id, files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
+
+    const INT_BLOCK_ENCODING: DataBlockEncoding =
+        DataBlockEncoding::new(Encoding::Delta, Encoding::Delta);
 
     #[tokio::test]
     async fn test_compaction_1() {
         #[rustfmt::skip]
         let data = vec![
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
             ]),
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
             ]),
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
             ]),
         ];
         #[rustfmt::skip]
         let expected_data = HashMap::from([
-            (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (2, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
+            (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (2, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
         ]);
 
         let dir = "/tmp/test/compaction/1";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
+        let max_level_ts = 9;
 
         let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, files);
+            prepare_compaction(tenant_database, opt, next_file_id, files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
+    /// Test compact with duplicate timestamp.
     #[tokio::test]
     async fn test_compaction_2() {
         #[rustfmt::skip]
         let data = vec![
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4], val: vec![1, 2, 3, 5], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4], val: vec![1, 2, 3, 5], enc: DataBlockEncoding::default() }]),
-                (4, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4], val: vec![1, 2, 3, 5], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4], val: vec![1, 2, 3, 5], enc: INT_BLOCK_ENCODING }]),
+                (4, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
             ]),
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![4, 5, 6, 7], val: vec![4, 5, 6, 8], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![4, 5, 6], val: vec![4, 5, 6], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![4, 5, 6, 7], val: vec![4, 5, 6, 8], enc: INT_BLOCK_ENCODING }]),
             ]),
             HashMap::from([
-                (1, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
-                (2, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
-                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: DataBlockEncoding::default() }]),
+                (1, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+                (2, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+                (3, vec![DataBlock::I64 { ts: vec![7, 8, 9], val: vec![7, 8, 9], enc: INT_BLOCK_ENCODING }]),
             ]),
         ];
         #[rustfmt::skip]
         let expected_data = HashMap::from([
-            (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (2, vec![DataBlock::I64 { ts: vec![4, 5, 6, 7, 8, 9], val: vec![4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: DataBlockEncoding::default() }]),
-            (4, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: DataBlockEncoding::default() }]),
+            (1, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (2, vec![DataBlock::I64 { ts: vec![4, 5, 6, 7, 8, 9], val: vec![4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (3, vec![DataBlock::I64 { ts: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], val: vec![1, 2, 3, 4, 5, 6, 7, 8, 9], enc: INT_BLOCK_ENCODING }]),
+            (4, vec![DataBlock::I64 { ts: vec![1, 2, 3], val: vec![1, 2, 3], enc: INT_BLOCK_ENCODING }]),
         ]);
 
         let dir = "/tmp/test/compaction/2";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
+        let max_level_ts = 9;
 
         let (next_file_id, files) = write_data_blocks_to_column_file(&dir, data).await;
         let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, files);
+            prepare_compaction(tenant_database, opt, next_file_id, files, max_level_ts);
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
     /// Returns a generated `DataBlock` with default value and specified size, `DataBlock::ts`
@@ -1262,7 +1356,10 @@ pub mod test {
     /// - Float: 1.0
     /// - Boolean: true
     /// - Unknown: will create a panic
-    fn generate_data_block(value_type: ValueType, data_descriptors: Vec<(i64, i64)>) -> DataBlock {
+    pub fn generate_data_block(
+        value_type: ValueType,
+        data_descriptors: Vec<(i64, i64)>,
+    ) -> DataBlock {
         match value_type {
             ValueType::Unsigned => {
                 let mut ts_vec: Vec<Timestamp> = Vec::with_capacity(1000);
@@ -1276,7 +1373,7 @@ pub mod test {
                 DataBlock::U64 {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::Delta),
                 }
             }
             ValueType::Integer => {
@@ -1291,11 +1388,11 @@ pub mod test {
                 DataBlock::I64 {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::Delta),
                 }
             }
             ValueType::String => {
-                let word = MiniVec::from(&b"1"[..]);
+                let word = MiniVec::from(&b"hello_world"[..]);
                 let mut ts_vec: Vec<Timestamp> = Vec::with_capacity(10000);
                 let mut val_vec: Vec<MiniVec<u8>> = Vec::with_capacity(10000);
                 for (min_ts, max_ts) in data_descriptors {
@@ -1307,7 +1404,7 @@ pub mod test {
                 DataBlock::Str {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::Snappy),
                 }
             }
             ValueType::Float => {
@@ -1322,7 +1419,7 @@ pub mod test {
                 DataBlock::F64 {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::Gorilla),
                 }
             }
             ValueType::Boolean => {
@@ -1337,7 +1434,7 @@ pub mod test {
                 DataBlock::Bool {
                     ts: ts_vec,
                     val: val_vec,
-                    enc: DataBlockEncoding::default(),
+                    enc: DataBlockEncoding::new(Encoding::Delta, Encoding::BitPack),
                 }
             }
             ValueType::Unknown => {
@@ -1346,10 +1443,56 @@ pub mod test {
         }
     }
 
+    pub type TsmSchema = (
+        ColumnFileId,                                    // tsm file id
+        Vec<(ValueType, FieldId, Timestamp, Timestamp)>, // Data block definitions
+        Vec<(FieldId, Timestamp, Timestamp)>,            // Tombstone definitions
+    );
+
+    pub async fn write_data_block_desc(
+        dir: impl AsRef<Path>,
+        data_desc: &[TsmSchema],
+    ) -> Vec<Arc<ColumnFile>> {
+        let mut column_files = Vec::new();
+        for (tsm_sequence, tsm_desc, tombstone_desc) in data_desc.iter() {
+            let mut tsm_writer = tsm::new_tsm_writer(&dir, *tsm_sequence, false, 0)
+                .await
+                .unwrap();
+            for &(val_type, fid, min_ts, max_ts) in tsm_desc.iter() {
+                tsm_writer
+                    .write_block(fid, &generate_data_block(val_type, vec![(min_ts, max_ts)]))
+                    .await
+                    .unwrap();
+            }
+            tsm_writer.write_index().await.unwrap();
+            tsm_writer.finish().await.unwrap();
+            let tsm_tombstone = TsmTombstone::open(&dir, *tsm_sequence).await.unwrap();
+            for (fid, min_ts, max_ts) in tombstone_desc.iter() {
+                tsm_tombstone
+                    .add_range(&[*fid][..], &TimeRange::new(*min_ts, *max_ts), None)
+                    .await
+                    .unwrap();
+            }
+
+            tsm_tombstone.flush().await.unwrap();
+            column_files.push(Arc::new(ColumnFile::new(
+                *tsm_sequence,
+                2,
+                TimeRange::new(tsm_writer.min_ts(), tsm_writer.max_ts()),
+                tsm_writer.size(),
+                false,
+                tsm_writer.path(),
+            )));
+        }
+
+        column_files
+    }
+
+    /// Test compaction without tombstones.
     #[tokio::test]
     async fn test_compaction_3() {
         #[rustfmt::skip]
-        let data_desc = [
+        let data_desc: [TsmSchema; 3] = [
             // [( tsm_sequence, vec![ (ValueType, FieldId, Timestamp_Begin, Timestamp_end) ] )]
             (1_u64, vec![
                 // 1, 1~2500
@@ -1362,7 +1505,7 @@ pub mod test {
                 // 3, 1~1500
                 (ValueType::Boolean, 3, 1, 1000),
                 (ValueType::Boolean, 3, 1001, 1500),
-            ]),
+            ], vec![]),
             (2, vec![
                 // 1, 2001~4500
                 (ValueType::Unsigned, 1, 2001, 3000),
@@ -1377,7 +1520,7 @@ pub mod test {
                 // 4, 1~1500
                 (ValueType::Float, 4, 1, 1000),
                 (ValueType::Float, 4, 1001, 1500),
-            ]),
+            ], vec![]),
             (3, vec![
                 // 1, 4001~6500
                 (ValueType::Unsigned, 1, 4001, 5000),
@@ -1392,7 +1535,7 @@ pub mod test {
                 // 4. 1001~2500
                 (ValueType::Float, 4, 1001, 2000),
                 (ValueType::Float, 4, 2001, 2500),
-            ]),
+            ], vec![]),
         ];
         #[rustfmt::skip]
         let expected_data: HashMap<FieldId, Vec<DataBlock>> = HashMap::from(
@@ -1432,102 +1575,46 @@ pub mod test {
         );
 
         let dir = "/tmp/test/compaction/3";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
+        let max_level_ts = 6500;
 
-        let mut column_files = Vec::new();
-        for (tsm_sequence, args) in data_desc.iter() {
-            let mut tsm_writer = tsm::new_tsm_writer(&dir, *tsm_sequence, false, 0)
-                .await
-                .unwrap();
-            for arg in args.iter() {
-                tsm_writer
-                    .write_block(arg.1, &generate_data_block(arg.0, vec![(arg.2, arg.3)]))
-                    .await
-                    .unwrap();
-            }
-            tsm_writer.write_index().await.unwrap();
-            tsm_writer.finish().await.unwrap();
-            column_files.push(Arc::new(ColumnFile::new(
-                *tsm_sequence,
-                2,
-                TimeRange::new(tsm_writer.min_ts(), tsm_writer.max_ts()),
-                tsm_writer.size(),
-                false,
-                tsm_writer.path(),
-            )));
-        }
-
+        let column_files = write_data_block_desc(&dir, &data_desc).await;
         let next_file_id = 4_u64;
 
-        let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
-
+        let (compact_req, kernel) = prepare_compaction(
+            tenant_database,
+            opt,
+            next_file_id,
+            column_files,
+            max_level_ts,
+        );
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
 
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
-    #[allow(clippy::type_complexity)]
-    async fn write_data_block_desc(
-        dir: impl AsRef<Path>,
-        data_desc: &[(
-            ColumnFileId,
-            Vec<(ValueType, FieldId, Timestamp, Timestamp)>,
-            Vec<(FieldId, Timestamp, Timestamp)>,
-        )],
-    ) -> Vec<Arc<ColumnFile>> {
-        let mut column_files = Vec::new();
-        for (tsm_sequence, tsm_desc, tombstone_desc) in data_desc.iter() {
-            let mut tsm_writer = tsm::new_tsm_writer(&dir, *tsm_sequence, false, 0)
-                .await
-                .unwrap();
-            for &(val_type, fid, min_ts, max_ts) in tsm_desc.iter() {
-                tsm_writer
-                    .write_block(fid, &generate_data_block(val_type, vec![(min_ts, max_ts)]))
-                    .await
-                    .unwrap();
-            }
-            tsm_writer.write_index().await.unwrap();
-            tsm_writer.finish().await.unwrap();
-            let mut tsm_tombstone = TsmTombstone::open(&dir, *tsm_sequence).await.unwrap();
-            for (fid, min_ts, max_ts) in tombstone_desc.iter() {
-                tsm_tombstone
-                    .add_range(&[*fid][..], &TimeRange::new(*min_ts, *max_ts))
-                    .await
-                    .unwrap();
-            }
-
-            tsm_tombstone.flush().await.unwrap();
-            column_files.push(Arc::new(ColumnFile::new(
-                *tsm_sequence,
-                2,
-                TimeRange::new(tsm_writer.min_ts(), tsm_writer.max_ts()),
-                tsm_writer.size(),
-                false,
-                tsm_writer.path(),
-            )));
-        }
-
-        column_files
-    }
-
+    /// Test compaction with tombstones
     #[tokio::test]
     async fn test_compaction_4() {
         #[rustfmt::skip]
-        let data_desc = [
-            // [( tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)], vec![Option<(FieldId, MinTimestamp, MaxTimestamp)>] )]
-            (1_u64, vec![
+        let data_desc: [TsmSchema; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
                 // 1, 1~2500
-                (ValueType::Unsigned, 1_u64, 1_i64, 1000_i64), (ValueType::Unsigned, 1, 1001, 2000), (ValueType::Unsigned, 1, 2001, 2500),
-            ], vec![(1_u64, 1_i64, 2_i64), (1, 2001, 2100)]),
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000), (ValueType::Unsigned, 1, 2001, 2500),
+            ], vec![(1, 1, 2), (1, 2001, 2100)]),
             (2, vec![
                 // 1, 2001~4500
                 // 2101~3100, 3101~4100, 4101~4499
@@ -1556,40 +1643,50 @@ pub mod test {
         );
 
         let dir = "/tmp/test/compaction/4";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
+        let max_level_ts = 6500;
 
         let column_files = write_data_block_desc(&dir, &data_desc).await;
         let next_file_id = 4_u64;
-        let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
-
+        let (compact_req, kernel) = prepare_compaction(
+            tenant_database,
+            opt,
+            next_file_id,
+            column_files,
+            max_level_ts,
+        );
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
 
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 
+    /// Test compaction with multi-field and tombstones.
     #[tokio::test]
     async fn test_compaction_5() {
         #[rustfmt::skip]
-        let data_desc = [
-            // [( tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)], vec![Option<(FieldId, MinTimestamp, MaxTimestamp)>] )]
-            (1_u64, vec![
+        let data_desc: [TsmSchema; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
                 // 1, 1~2500
-                (ValueType::Unsigned, 1_u64, 1_i64, 1000_i64), (ValueType::Unsigned, 1, 1001, 2000),  (ValueType::Unsigned, 1, 2001, 2500),
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000),  (ValueType::Unsigned, 1, 2001, 2500),
                 // 2, 1~1500
                 (ValueType::Integer, 2, 1, 1000), (ValueType::Integer, 2, 1001, 1500),
                 // 3, 1~1500
                 (ValueType::Boolean, 3, 1, 1000), (ValueType::Boolean, 3, 1001, 1500),
             ], vec![
-                (1_u64, 1_i64, 2_i64), (1, 2001, 2100),
+                (1, 1, 2), (1, 2001, 2100),
                 (2, 1001, 1002),
                 (3, 1499, 1500),
             ]),
@@ -1659,23 +1756,30 @@ pub mod test {
         );
 
         let dir = "/tmp/test/compaction/5";
-        let database = Arc::new("dba".to_string());
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
         let opt = create_options(dir.to_string());
-        let dir = opt.storage.tsm_dir(&database, 1);
+        let dir = opt.storage.tsm_dir(&tenant_database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
         }
+        let max_level_ts = 6500;
 
         let column_files = write_data_block_desc(&dir, &data_desc).await;
         let next_file_id = 4_u64;
-        let (compact_req, kernel) =
-            prepare_compact_req_and_kernel(database, opt, next_file_id, column_files);
-
+        let (compact_req, kernel) = prepare_compaction(
+            tenant_database,
+            opt,
+            next_file_id,
+            column_files,
+            max_level_ts,
+        );
+        let out_level = compact_req.out_level;
         let (version_edit, _) = run_compaction_job(compact_req, kernel)
             .await
             .unwrap()
             .unwrap();
 
-        check_column_file(dir, version_edit, expected_data).await;
+        check_column_file(dir, version_edit, expected_data, out_level).await;
     }
 }

--- a/tskv/src/compaction/delta_compact.rs
+++ b/tskv/src/compaction/delta_compact.rs
@@ -1,0 +1,1123 @@
+use std::collections::{BinaryHeap, HashMap};
+use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use models::predicate::domain::{TimeRange, TimeRanges};
+use models::FieldId;
+use snafu::ResultExt;
+use utils::BloomFilter;
+
+use crate::compaction::compact::{CompactingBlock, CompactingBlockMeta, CompactingFile};
+use crate::compaction::CompactReq;
+use crate::context::GlobalContext;
+use crate::error::{self, Result};
+use crate::summary::{CompactMeta, VersionEdit};
+use crate::tseries_family::TseriesFamily;
+use crate::tsm::{
+    self, BlockMetaIterator, DataBlock, EncodedDataBlock, TsmReader, TsmWriter, WriteTsmError,
+    WriteTsmResult,
+};
+use crate::{ColumnFileId, Error, LevelId, TseriesFamilyId};
+
+pub async fn run_compaction_job(
+    request: CompactReq,
+    kernel: Arc<GlobalContext>,
+) -> Result<Option<(VersionEdit, HashMap<ColumnFileId, Arc<BloomFilter>>)>> {
+    let out_time_range = TimeRange::new(0, request.max_ts);
+    trace::info!("Compaction(delta): Running compaction job on {request}");
+
+    if request.files.is_empty() {
+        // Nothing to compact
+        return Ok(None);
+    }
+
+    // Buffers all tsm-files and it's indexes for this compaction
+    let mut tsm_readers = Vec::new();
+    for col_file in request.files.iter() {
+        let tsm_reader = request.version.get_tsm_reader(col_file.file_path()).await?;
+        tsm_reader
+            .add_tombstone_and_compact_to_tmp(&out_time_range)
+            .await?;
+        tsm_readers.push(tsm_reader);
+    }
+
+    let max_block_size = TseriesFamily::MAX_DATA_BLOCK_SIZE as usize;
+    let mut state = CompactState::new(tsm_readers, out_time_range, max_block_size);
+    let mut writer_wrapper = WriterWrapper::new(&request, kernel.clone());
+
+    let mut previous_merged_block = Option::<CompactingBlock>::None;
+    let mut merging_blk_meta_groups = Vec::with_capacity(32);
+    let mut merged_blks = Vec::with_capacity(32);
+
+    let mut curr_fid: Option<FieldId> = None;
+    while let Some(fid) = state.next(&mut merging_blk_meta_groups).await {
+        for blk_meta_group in merging_blk_meta_groups.drain(..) {
+            trace::trace!("merging meta group: {blk_meta_group}");
+            if let Some(c_fid) = curr_fid {
+                if c_fid != fid {
+                    // Iteration of next field id, write previous merged block.
+                    if let Some(blk) = previous_merged_block.take() {
+                        // Write the small previous merged block.
+                        trace::trace!(
+                            "write the previous compacting block (fid={curr_fid:?}): {blk}"
+                        );
+                        writer_wrapper.write(blk).await?;
+                    }
+                }
+            }
+            curr_fid = Some(fid);
+
+            blk_meta_group
+                .merge_with_previous_block(
+                    previous_merged_block.take(),
+                    max_block_size,
+                    &out_time_range,
+                    &mut merged_blks,
+                )
+                .await?;
+            if merged_blks.is_empty() {
+                continue;
+            }
+            if merged_blks.len() == 1 && merged_blks[0].len() < max_block_size {
+                // The only one data block too small, try to extend the next compacting blocks.
+                previous_merged_block = Some(merged_blks.remove(0));
+                continue;
+            }
+
+            let last_blk_idx = merged_blks.len() - 1;
+            for (i, blk) in merged_blks.drain(..).enumerate() {
+                if i == last_blk_idx && blk.len() < max_block_size {
+                    // The last data block too small, try to extend to
+                    // the next compacting blocks (current field id).
+                    trace::trace!("compacting block (fid={fid}) {blk} is too small, try to merge with the next compacting blocks");
+                    previous_merged_block = Some(blk);
+                    break;
+                }
+                trace::trace!("write compacting block(fid={fid}): {blk}");
+                writer_wrapper.write(blk).await?;
+            }
+        }
+    }
+    if let Some(blk) = previous_merged_block {
+        trace::trace!("write the final compacting block(fid={curr_fid:?}): {blk}");
+        writer_wrapper.write(blk).await?;
+    }
+
+    let (mut version_edit, file_metas) = writer_wrapper.close().await?;
+    for file in request.files {
+        if file.time_range().max_ts <= out_time_range.max_ts {
+            // All files merged into target level.
+            version_edit.del_file(file.level(), file.file_id(), file.is_delta());
+        } else {
+            // Only part of the tsm file merged into target level.
+            version_edit.del_file_part(
+                file.level(),
+                file.file_id(),
+                file.is_delta(),
+                out_time_range.min_ts,
+                out_time_range.max_ts,
+            );
+            if let Some(time_range) = file.time_range().intersect(&out_time_range) {
+                // Re-add file but with the intersected time range if file has something.
+                version_edit.add_file(
+                    CompactMeta {
+                        file_id: file.file_id(),
+                        file_size: file.size(),
+                        tsf_id: request.ts_family_id,
+                        level: file.level(),
+                        min_ts: time_range.min_ts,
+                        max_ts: time_range.max_ts,
+                        high_seq: 0,
+                        low_seq: 0,
+                        is_delta: file.is_delta(),
+                    },
+                    out_time_range.max_ts,
+                )
+            } else {
+                // Seems file has nothing merged into target level, it is impossible.
+            }
+        }
+    }
+
+    trace::info!(
+        "Compaction(delta): Compact finished, version edits: {:?}",
+        version_edit
+    );
+    Ok(Some((version_edit, file_metas)))
+}
+
+pub(crate) struct CompactState {
+    tsm_readers: Vec<Arc<TsmReader>>,
+    /// The TimeRange for delta files to partly compact with other files.
+    out_time_range: TimeRange,
+    /// The TimeRanges for delta files to partly compact with other files.
+    out_time_ranges: Arc<TimeRanges>,
+    /// Maximum values in generated CompactingBlock
+    max_data_block_size: usize,
+
+    compacting_files: BinaryHeap<CompactingFile>,
+    /// Temporarily stored index of `TsmReader` in self.tsm_readers,
+    /// and `BlockMetaIterator` of current field_id.
+    tmp_tsm_blk_meta_iters: Vec<(usize, BlockMetaIterator)>,
+}
+
+impl CompactState {
+    pub fn new(
+        tsm_readers: Vec<Arc<TsmReader>>,
+        out_time_range: TimeRange,
+        max_data_block_size: usize,
+    ) -> Self {
+        let mut compacting_tsm_readers = Vec::with_capacity(tsm_readers.len());
+        let mut compacting_files = BinaryHeap::with_capacity(tsm_readers.len());
+        let mut compacting_tsm_file_idx = 0_usize;
+        for tsm_reader in tsm_readers {
+            if let Some(cf) = CompactingFile::new(compacting_tsm_file_idx, tsm_reader.clone()) {
+                compacting_tsm_readers.push(tsm_reader);
+                compacting_files.push(cf);
+                compacting_tsm_file_idx += 1;
+            }
+        }
+
+        Self {
+            tsm_readers: compacting_tsm_readers,
+            compacting_files,
+            out_time_range,
+            out_time_ranges: Arc::new(TimeRanges::new(vec![out_time_range])),
+            max_data_block_size,
+            tmp_tsm_blk_meta_iters: Vec::with_capacity(compacting_tsm_file_idx),
+        }
+    }
+
+    pub async fn next(
+        &mut self,
+        compacting_blk_meta_groups: &mut Vec<CompactingBlockMetaGroup>,
+    ) -> Option<FieldId> {
+        // For each tsm-file, get next index reader for current iteration field id
+        if let Some(field_id) = self.next_field() {
+            // Get all of block_metas of this field id, and group these block_metas.
+            self.fill_compacting_block_meta_groups(field_id, compacting_blk_meta_groups);
+
+            Some(field_id)
+        } else {
+            None
+        }
+    }
+}
+
+impl CompactState {
+    /// Update tmp_tsm_blk_meta_iters for field id in next iteration.
+    fn next_field(&mut self) -> Option<FieldId> {
+        trace::trace!("===============================");
+
+        self.tmp_tsm_blk_meta_iters.clear();
+        let mut curr_fid: FieldId;
+
+        loop {
+            if let Some(f) = self.compacting_files.peek() {
+                trace::trace!(
+                    "selected new field {:?} from file {} as current field id",
+                    f.field_id,
+                    f.tsm_reader.file_id()
+                );
+                curr_fid = f.field_id
+            } else {
+                trace::trace!("no file to select, mark finished");
+                return None;
+            }
+
+            let mut loop_file_i;
+            while let Some(mut f) = self.compacting_files.pop() {
+                loop_file_i = f.i;
+                if curr_fid == f.field_id {
+                    if let Some(idx_meta) = f.peek() {
+                        trace::trace!(
+                            "for delta file @{loop_file_i}, put block iterator with time_range {:?}",
+                            &self.out_time_range
+                        );
+                        self.tmp_tsm_blk_meta_iters.push((
+                            loop_file_i,
+                            idx_meta.block_iterator_opt(self.out_time_ranges.clone()),
+                        ));
+
+                        trace::trace!("merging idx_meta({}): field_id: {}, field_type: {:?}, block_count: {}, time_range: {:?}",
+                            self.tmp_tsm_blk_meta_iters.len(),
+                            idx_meta.field_id(),
+                            idx_meta.field_type(),
+                            idx_meta.block_count(),
+                            idx_meta.time_range(),
+                        );
+                        f.next();
+                        self.compacting_files.push(f);
+                    } else {
+                        // This tsm-file has been finished, do not push it back.
+                        trace::trace!("file {loop_file_i} is finished.");
+                    }
+                } else {
+                    // This tsm-file do not need to compact at this time, push it back.
+                    self.compacting_files.push(f);
+                    break;
+                }
+            }
+
+            if !self.tmp_tsm_blk_meta_iters.is_empty() {
+                trace::trace!(
+                    "selected {} blocks meta iterators",
+                    self.tmp_tsm_blk_meta_iters.len()
+                );
+                break;
+            } else {
+                trace::trace!("iteration field_id {curr_fid} is finished, trying next field.");
+                continue;
+            }
+        }
+
+        Some(curr_fid)
+    }
+
+    /// Clear buffer vector and collect compacting `DataBlock`s into the buffer vector.
+    fn fill_compacting_block_meta_groups(
+        &mut self,
+        field_id: FieldId,
+        compacting_blk_meta_groups: &mut Vec<CompactingBlockMetaGroup>,
+    ) -> bool {
+        if self.tmp_tsm_blk_meta_iters.is_empty() {
+            return false;
+        }
+
+        let mut blk_metas: Vec<CompactingBlockMeta> =
+            Vec::with_capacity(self.tmp_tsm_blk_meta_iters.len());
+        // Get all block_meta, and check if it's tsm file has a related tombstone file.
+        for (tsm_reader_idx, blk_iter) in self.tmp_tsm_blk_meta_iters.iter_mut() {
+            for blk_meta in blk_iter.by_ref() {
+                let tsm_reader_ptr = self.tsm_readers[*tsm_reader_idx].clone();
+                blk_metas.push(CompactingBlockMeta::new(
+                    *tsm_reader_idx,
+                    tsm_reader_ptr,
+                    blk_meta,
+                ));
+            }
+        }
+        // Sort by field_id, min_ts and max_ts.
+        blk_metas.sort();
+
+        let mut blk_meta_groups: Vec<CompactingBlockMetaGroup> =
+            Vec::with_capacity(blk_metas.len());
+        for blk_meta in blk_metas {
+            blk_meta_groups.push(CompactingBlockMetaGroup::new(field_id, blk_meta));
+        }
+        // Compact blk_meta_groups.
+        let mut i = 0;
+        loop {
+            let mut head_idx = i;
+            // Find the first non-empty as head.
+            for (off, bmg) in blk_meta_groups[i..].iter().enumerate() {
+                if !bmg.is_empty() {
+                    head_idx += off;
+                    break;
+                }
+            }
+            if head_idx >= blk_meta_groups.len() - 1 {
+                // There no other blk_meta_group to merge with the last one.
+                break;
+            }
+            let mut head = blk_meta_groups[head_idx].clone();
+            i = head_idx + 1;
+            for bmg in blk_meta_groups[i..].iter_mut() {
+                if bmg.is_empty() {
+                    continue;
+                }
+                if head.overlaps(bmg) {
+                    head.append(bmg);
+                }
+            }
+            blk_meta_groups[head_idx] = head;
+        }
+
+        compacting_blk_meta_groups.clear();
+        for cbm_group in blk_meta_groups {
+            if !cbm_group.is_empty() {
+                compacting_blk_meta_groups.push(cbm_group);
+            }
+        }
+        trace::trace!(
+            "selected merging meta groups: {}",
+            CompactingBlockMetaGroups(compacting_blk_meta_groups),
+        );
+        true
+    }
+}
+
+///
+#[derive(Clone)]
+pub(crate) struct CompactingBlockMetaGroup {
+    field_id: FieldId,
+    blk_metas: Vec<CompactingBlockMeta>,
+    time_range: TimeRange,
+}
+
+impl CompactingBlockMetaGroup {
+    pub fn new(field_id: FieldId, blk_meta: CompactingBlockMeta) -> Self {
+        let time_range = blk_meta.time_range();
+        Self {
+            field_id,
+            blk_metas: vec![blk_meta],
+            time_range,
+        }
+    }
+
+    pub fn overlaps(&self, other: &Self) -> bool {
+        self.time_range.overlaps(&other.time_range)
+    }
+
+    pub fn append(&mut self, other: &mut CompactingBlockMetaGroup) {
+        self.blk_metas.append(&mut other.blk_metas);
+        self.time_range.merge(&other.time_range);
+    }
+
+    pub async fn merge_with_previous_block(
+        mut self,
+        previous_block: Option<CompactingBlock>,
+        max_block_size: usize,
+        time_range: &TimeRange,
+        compacting_blocks: &mut Vec<CompactingBlock>,
+    ) -> Result<()> {
+        compacting_blocks.clear();
+        if self.blk_metas.is_empty() {
+            return Ok(());
+        }
+        self.blk_metas
+            .sort_by(|a, b| a.reader_idx.cmp(&b.reader_idx).reverse());
+
+        let mut merged_block = Option::<DataBlock>::None;
+        if self.blk_metas.len() == 1
+            && !self.blk_metas[0].has_tombstone()
+            && self.blk_metas[0].included_in_time_range(time_range)
+        {
+            // Only one compacting block and has no tombstone, write as raw block.
+            trace::trace!("only one compacting block without tombstone and time_range is entirely included by target level, handled as raw block");
+            let head_meta = &self.blk_metas[0].meta;
+            let mut buf = Vec::with_capacity(head_meta.size() as usize);
+            let data_len = self.blk_metas[0].get_raw_data(&mut buf).await?;
+            buf.truncate(data_len);
+
+            if head_meta.size() >= max_block_size as u64 {
+                // Raw data block is full, so do not merge with the previous, directly return.
+                if let Some(prev_compacting_block) = previous_block {
+                    compacting_blocks.push(prev_compacting_block);
+                }
+                compacting_blocks.push(CompactingBlock::raw(
+                    self.blk_metas[0].reader_idx,
+                    head_meta.clone(),
+                    buf,
+                ));
+
+                return Ok(());
+            } else if let Some(prev_compacting_block) = previous_block {
+                // Raw block is not full, so decode and merge with compacting_block.
+                let decoded_raw_block = tsm::decode_data_block(
+                    &buf,
+                    head_meta.field_type(),
+                    head_meta.val_off() - head_meta.offset(),
+                )
+                .context(error::ReadTsmSnafu)?;
+                if let Some(mut data_block) = prev_compacting_block.decode_opt(time_range)? {
+                    data_block.extend(decoded_raw_block);
+                    merged_block = Some(data_block);
+                }
+            } else {
+                // Raw block is not full, but nothing to merge with, directly return.
+                compacting_blocks.push(CompactingBlock::raw(
+                    self.blk_metas[0].reader_idx,
+                    head_meta.clone(),
+                    buf,
+                ));
+                return Ok(());
+            }
+        } else {
+            // One block with tombstone or multi compacting blocks, decode and merge these data block.
+            trace::trace!(
+                "there are {} compacting blocks, need to decode and merge",
+                self.blk_metas.len()
+            );
+
+            let (mut head_block, mut head_i) = (Option::<DataBlock>::None, 0_usize);
+            for (i, meta) in self.blk_metas.iter().enumerate() {
+                if let Some(blk) = meta.get_data_block_opt(time_range).await? {
+                    head_block = Some(blk);
+                    head_i = i;
+                    break;
+                }
+            }
+            if let Some(mut head_blk) = head_block.take() {
+                if let Some(prev_compacting_block) = previous_block {
+                    if let Some(mut data_block) = prev_compacting_block.decode_opt(time_range)? {
+                        data_block.extend(head_blk);
+                        head_blk = data_block;
+                    }
+                }
+                for blk_meta in self.blk_metas.iter_mut().skip(head_i + 1) {
+                    // Merge decoded data block.
+                    if let Some(blk) = blk_meta.get_data_block_opt(time_range).await? {
+                        head_blk = head_blk.merge(blk);
+                    }
+                }
+                head_block = Some(head_blk);
+            }
+
+            merged_block = head_block;
+        }
+        if let Some(blk) = merged_block {
+            chunk_data_block_into_compacting_blocks(
+                self.field_id,
+                blk,
+                max_block_size,
+                compacting_blocks,
+            )
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn into_compacting_block_metas(self) -> Vec<CompactingBlockMeta> {
+        self.blk_metas
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.blk_metas.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.blk_metas.len()
+    }
+}
+
+impl Display for CompactingBlockMetaGroup {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{field_id: {}, blk_metas: [", self.field_id)?;
+        if !self.blk_metas.is_empty() {
+            write!(f, "{}", &self.blk_metas[0])?;
+            for b in self.blk_metas.iter().skip(1) {
+                write!(f, ", {}", b)?;
+            }
+        }
+        write!(f, "]}}")
+    }
+}
+
+struct CompactingBlockMetaGroups<'a>(&'a [CompactingBlockMetaGroup]);
+
+impl<'a> Display for CompactingBlockMetaGroups<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut iter = self.0.iter();
+        if let Some(d) = iter.next() {
+            write!(f, "{}", d)?;
+            for d in iter {
+                write!(f, ", {d}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn chunk_data_block_into_compacting_blocks(
+    field_id: FieldId,
+    data_block: DataBlock,
+    max_block_size: usize,
+    compacting_blocks: &mut Vec<CompactingBlock>,
+) -> Result<()> {
+    compacting_blocks.clear();
+    if max_block_size == 0 || data_block.len() < max_block_size {
+        // Data block elements less than max_block_size, do not encode it.
+        // Try to merge with the next CompactingBlockMetaGroup.
+        compacting_blocks.push(CompactingBlock::decoded(0, field_id, data_block));
+    } else {
+        // Data block is so big that split into multi CompactingBlock
+        let len = data_block.len();
+        let mut start = 0;
+        let mut end = len.min(max_block_size);
+        while start < len {
+            // Encode decoded data blocks into chunks.
+            let encoded_blk =
+                EncodedDataBlock::encode(&data_block, start, end).map_err(|e| Error::WriteTsm {
+                    source: WriteTsmError::Encode { source: e },
+                })?;
+            compacting_blocks.push(CompactingBlock::encoded(0, field_id, encoded_blk));
+
+            start = end;
+            end = len.min(start + max_block_size);
+        }
+    }
+
+    Ok(())
+}
+
+struct WriterWrapper {
+    // Init values.
+    ts_family_id: TseriesFamilyId,
+    out_level: LevelId,
+    max_file_size: u64,
+    tsm_dir: PathBuf,
+    context: Arc<GlobalContext>,
+
+    // Temporary values.
+    tsm_writer_full: bool,
+    tsm_writer: Option<TsmWriter>,
+
+    // Result values.
+    version_edit: VersionEdit,
+    file_metas: HashMap<ColumnFileId, Arc<BloomFilter>>,
+}
+
+impl WriterWrapper {
+    pub fn new(request: &CompactReq, context: Arc<GlobalContext>) -> Self {
+        Self {
+            ts_family_id: request.ts_family_id,
+            out_level: request.out_level,
+            max_file_size: request
+                .version
+                .storage_opt()
+                .level_max_file_size(request.out_level),
+            tsm_dir: request
+                .storage_opt
+                .tsm_dir(&request.database, request.ts_family_id),
+            context,
+
+            tsm_writer_full: false,
+            tsm_writer: None,
+
+            version_edit: VersionEdit::new(request.ts_family_id),
+            file_metas: HashMap::new(),
+        }
+    }
+
+    pub async fn close(mut self) -> Result<(VersionEdit, HashMap<ColumnFileId, Arc<BloomFilter>>)> {
+        self.close_writer_and_append_compact_meta().await?;
+        Ok((self.version_edit, self.file_metas))
+    }
+
+    /// Write CompactingBlock to TsmWriter, fill file_metas and version_edit.
+    pub async fn write(&mut self, blk: CompactingBlock) -> Result<usize> {
+        let write_result: WriteTsmResult<usize> = match blk {
+            CompactingBlock::Decoded {
+                field_id,
+                data_block,
+                ..
+            } => {
+                self.tsm_writer_mut()
+                    .await?
+                    .write_block(field_id, &data_block)
+                    .await
+            }
+            CompactingBlock::Encoded {
+                field_id,
+                data_block,
+                ..
+            } => {
+                self.tsm_writer_mut()
+                    .await?
+                    .write_encoded_block(field_id, &data_block)
+                    .await
+            }
+            CompactingBlock::Raw { meta, raw, .. } => {
+                self.tsm_writer_mut().await?.write_raw(&meta, &raw).await
+            }
+        };
+        match write_result {
+            Ok(size) => Ok(size),
+            Err(WriteTsmError::WriteIO { source }) => {
+                // TODO try re-run compaction on other time.
+                trace::error!("Failed compaction: IO error when write tsm: {:?}", source);
+                Err(Error::IO { source })
+            }
+            Err(WriteTsmError::Encode { source }) => {
+                // TODO try re-run compaction on other time.
+                trace::error!(
+                    "Failed compaction: encoding error when write tsm: {:?}",
+                    source
+                );
+                Err(Error::Encode { source })
+            }
+            Err(WriteTsmError::Finished { path }) => {
+                trace::error!(
+                    "Failed compaction: Trying write already finished tsm file: '{}'",
+                    path.display()
+                );
+                Err(Error::WriteTsm {
+                    source: WriteTsmError::Finished { path },
+                })
+            }
+            Err(WriteTsmError::MaxFileSizeExceed { write_size, .. }) => {
+                self.tsm_writer_full = true;
+                Ok(write_size)
+            }
+        }
+    }
+
+    async fn tsm_writer_mut(&mut self) -> Result<&mut TsmWriter> {
+        if self.tsm_writer_full {
+            self.close_writer_and_append_compact_meta().await?;
+            self.new_writer_mut().await
+        } else {
+            match self.tsm_writer {
+                Some(ref mut w) => Ok(w),
+                None => self.new_writer_mut().await,
+            }
+        }
+    }
+
+    async fn new_writer_mut(&mut self) -> Result<&mut TsmWriter> {
+        let writer = tsm::new_tsm_writer(
+            &self.tsm_dir,
+            self.context.file_id_next(),
+            false,
+            self.max_file_size,
+        )
+        .await?;
+        trace::info!(
+            "Compaction(delta): File: {} been created (level: {}).",
+            writer.sequence(),
+            self.out_level,
+        );
+
+        self.tsm_writer_full = false;
+        Ok(self.tsm_writer.insert(writer))
+    }
+
+    async fn close_writer_and_append_compact_meta(&mut self) -> Result<()> {
+        if let Some(mut tsm_writer) = self.tsm_writer.take() {
+            tsm_writer
+                .write_index()
+                .await
+                .context(error::WriteTsmSnafu)?;
+            tsm_writer.finish().await.context(error::WriteTsmSnafu)?;
+
+            trace::info!(
+                "Compaction(delta): File: {} write finished (level: {}, {} B).",
+                tsm_writer.sequence(),
+                self.out_level,
+                tsm_writer.size()
+            );
+
+            let file_id = tsm_writer.sequence();
+            let cm = CompactMeta {
+                file_id,
+                file_size: tsm_writer.size(),
+                tsf_id: self.ts_family_id,
+                level: self.out_level,
+                min_ts: tsm_writer.min_ts(),
+                max_ts: tsm_writer.max_ts(),
+                high_seq: 0,
+                low_seq: 0,
+                is_delta: false,
+            };
+            self.version_edit.add_file(cm, tsm_writer.max_ts());
+            let bloom_filter = tsm_writer.into_bloom_filter();
+            self.file_metas.insert(file_id, Arc::new(bloom_filter));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use lru_cache::asynchronous::ShardedCache;
+    use models::{FieldId, Timestamp, ValueType};
+
+    use super::*;
+    use crate::compaction::test::{
+        check_column_file, create_options, generate_data_block, write_data_block_desc, TsmSchema,
+    };
+    use crate::file_system::file_manager;
+    use crate::tseries_family::{ColumnFile, LevelInfo, Version};
+    use crate::tsm::codec::DataBlockEncoding;
+    use crate::Options;
+
+    #[test]
+    fn test_chunk_merged_block() {
+        let data_block = DataBlock::U64 {
+            ts: vec![0, 1, 2, 10, 11, 12, 100, 101, 102, 1000, 1001, 1002],
+            val: vec![0, 3, 6, 30, 33, 36, 300, 303, 306, 3000, 3003, 3006],
+            enc: DataBlockEncoding::default(),
+        };
+        let field_id = 1;
+        // Trying to chunk with no chunk size
+        {
+            let mut chunks = Vec::new();
+            chunk_data_block_into_compacting_blocks(field_id, data_block.clone(), 0, &mut chunks)
+                .unwrap();
+            assert_eq!(chunks.len(), 1);
+            assert_eq!(
+                chunks[0],
+                CompactingBlock::decoded(0, 1, data_block.clone())
+            );
+        }
+        // Trying to chunk with too big chunk size
+        {
+            let mut chunks: Vec<_> = Vec::new();
+            chunk_data_block_into_compacting_blocks(field_id, data_block.clone(), 100, &mut chunks)
+                .unwrap();
+            assert_eq!(chunks.len(), 1);
+            assert_eq!(
+                chunks[0],
+                CompactingBlock::decoded(0, 1, data_block.clone())
+            );
+        }
+        // Trying to chunk with chunk size that can divide data block exactly
+        {
+            let mut chunks = Vec::new();
+            chunk_data_block_into_compacting_blocks(field_id, data_block.clone(), 4, &mut chunks)
+                .unwrap();
+            assert_eq!(chunks.len(), 3);
+            assert_eq!(
+                chunks[0],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 0, 4).unwrap()
+                )
+            );
+            assert_eq!(
+                chunks[1],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 4, 8).unwrap()
+                )
+            );
+            assert_eq!(
+                chunks[2],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 8, 12).unwrap()
+                )
+            );
+        }
+        // Trying to chunk with chunk size that cannot divide data block exactly
+        {
+            let mut chunks = Vec::new();
+            chunk_data_block_into_compacting_blocks(field_id, data_block.clone(), 5, &mut chunks)
+                .unwrap();
+            assert_eq!(chunks.len(), 3);
+            assert_eq!(
+                chunks[0],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 0, 5).unwrap()
+                )
+            );
+            assert_eq!(
+                chunks[1],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 5, 10).unwrap()
+                )
+            );
+            assert_eq!(
+                chunks[2],
+                CompactingBlock::encoded(
+                    0,
+                    field_id,
+                    EncodedDataBlock::encode(&data_block, 10, 12).unwrap()
+                )
+            );
+        }
+    }
+
+    pub fn prepare_delta_compaction(
+        tenant_database: Arc<String>,
+        opt: Arc<Options>,
+        next_file_id: ColumnFileId,
+        files: Vec<Arc<ColumnFile>>,
+        out_level_max_ts: Timestamp,
+    ) -> (CompactReq, Arc<GlobalContext>) {
+        let version = Arc::new(Version::new(
+            1,
+            tenant_database.clone(),
+            opt.storage.clone(),
+            1,
+            LevelInfo::init_levels(tenant_database.clone(), 0, opt.storage.clone()),
+            out_level_max_ts,
+            Arc::new(ShardedCache::with_capacity(1)),
+        ));
+        let compact_req = CompactReq {
+            ts_family_id: 1,
+            database: tenant_database,
+            storage_opt: opt.storage.clone(),
+            files,
+            version,
+            in_level: 1,
+            out_level: 2,
+            max_ts: out_level_max_ts,
+        };
+        let context = Arc::new(GlobalContext::new());
+        context.set_file_id(next_file_id);
+
+        (compact_req, context)
+    }
+
+    async fn test_delta_compaction(
+        dir: &str,
+        source_data_desc: &[TsmSchema],
+        max_ts: Timestamp,
+        expected_data_desc: HashMap<FieldId, Vec<DataBlock>>,
+        expected_data_level: LevelId,
+    ) {
+        let _ = std::fs::remove_dir_all(dir);
+        let tenant_database = Arc::new("cnosdb.dba".to_string());
+        let opt = create_options(dir.to_string());
+        let tsm_dir = opt.storage.tsm_dir(&tenant_database, 1);
+        if !file_manager::try_exists(&tsm_dir) {
+            std::fs::create_dir_all(&tsm_dir).unwrap();
+        }
+        let delta_dir = opt.storage.delta_dir(&tenant_database, 1);
+        if !file_manager::try_exists(&delta_dir) {
+            std::fs::create_dir_all(&delta_dir).unwrap();
+        }
+
+        let column_files = write_data_block_desc(&delta_dir, source_data_desc).await;
+        let next_file_id = source_data_desc
+            .iter()
+            .map(|(_file_id, blk_desc, _tomb_desc)| {
+                blk_desc
+                    .iter()
+                    .map(|(_vtype, field_id, _min_ts, _max_ts)| *field_id)
+                    .max()
+                    .unwrap_or(1)
+            })
+            .max()
+            .unwrap_or(1)
+            + 1;
+        let (mut compact_req, kernel) =
+            prepare_delta_compaction(tenant_database, opt, next_file_id, column_files, max_ts);
+        compact_req.in_level = 0;
+        compact_req.out_level = expected_data_level;
+
+        let (version_edit, _) = run_compaction_job(compact_req, kernel)
+            .await
+            .unwrap()
+            .unwrap();
+
+        check_column_file(
+            tsm_dir,
+            version_edit,
+            expected_data_desc,
+            expected_data_level,
+        )
+        .await;
+    }
+
+    /// Test compaction on level-0 (delta compaction) with multi-field.
+    #[tokio::test]
+    async fn test_delta_compaction_1() {
+        #[rustfmt::skip]
+        let data_desc: [TsmSchema; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
+                // 1, 1~2500
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000),  (ValueType::Unsigned, 1, 2001, 2500),
+                // 2, 1~1500
+                (ValueType::Integer, 2, 1, 1000), (ValueType::Integer, 2, 1001, 1500),
+                // 3, 1~1500
+                (ValueType::Boolean, 3, 1, 1000), (ValueType::Boolean, 3, 1001, 1500),
+            ], vec![]),
+            (2, vec![
+                // 1, 2001~4500
+                (ValueType::Unsigned, 1, 2001, 3000), (ValueType::Unsigned, 1, 3001, 4000), (ValueType::Unsigned, 1, 4001, 4500),
+                // 2, 1001~3000
+                (ValueType::Integer, 2, 1001, 2000), (ValueType::Integer, 2, 2001, 3000),
+                // 3, 1001~2500
+                (ValueType::Boolean, 3, 1001, 2000), (ValueType::Boolean, 3, 2001, 2500),
+                // 4, 1~1500
+                (ValueType::Float, 4, 1, 1000), (ValueType::Float, 4, 1001, 1500),
+            ], vec![]),
+            (3, vec![
+                // 1, 4001~6500
+                (ValueType::Unsigned, 1, 4001, 5000), (ValueType::Unsigned, 1, 5001, 6000), (ValueType::Unsigned, 1, 6001, 6500),
+                // 2, 3001~5000
+                (ValueType::Integer, 2, 3001, 4000), (ValueType::Integer, 2, 4001, 5000),
+                // 3, 2001~3500
+                (ValueType::Boolean, 3, 2001, 3000), (ValueType::Boolean, 3, 3001, 3500),
+                // 4. 1001~2500
+                (ValueType::Float, 4, 1001, 2000), (ValueType::Float, 4, 2001, 2500),
+            ], vec![]),
+        ];
+        let max_ts = 3000;
+        let expected_data_target_level: HashMap<FieldId, Vec<DataBlock>> = HashMap::from([
+            (
+                // 1, 1~6500
+                1,
+                vec![
+                    generate_data_block(ValueType::Unsigned, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(2001, 3000)]),
+                ],
+            ),
+            (
+                // 2, 1~5000
+                2,
+                vec![
+                    generate_data_block(ValueType::Integer, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Integer, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Integer, vec![(2001, 3000)]),
+                ],
+            ),
+            (
+                // 3, 1~3500
+                3,
+                vec![
+                    generate_data_block(ValueType::Boolean, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Boolean, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Boolean, vec![(2001, 3000)]),
+                ],
+            ),
+            (
+                // 4, 1~2500
+                4,
+                vec![
+                    generate_data_block(ValueType::Float, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Float, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Float, vec![(2001, 2500)]),
+                ],
+            ),
+        ]);
+
+        test_delta_compaction(
+            "/tmp/test/delta_compaction/1",
+            &data_desc,
+            max_ts,
+            expected_data_target_level,
+            2,
+        )
+        .await;
+    }
+
+    /// Test compaction on level-0 (delta compaction) with samll blocks.
+    #[tokio::test]
+    async fn test_delta_compaction_2() {
+        #[rustfmt::skip]
+        let data_desc: [TsmSchema; 3] = [
+            // [( tsm_data:  tsm_sequence, vec![(ValueType, FieldId, Timestamp_Begin, Timestamp_end)],
+            //    tombstone: vec![(FieldId, MinTimestamp, MaxTimestamp)]
+            // )]
+            (1, vec![
+                // 1, 1~4000
+                (ValueType::Unsigned, 1, 1, 1000), (ValueType::Unsigned, 1, 1001, 2000), (ValueType::Unsigned, 1, 2001, 2500),
+                (ValueType::Unsigned, 1, 2501, 3100), (ValueType::Unsigned, 1, 3101, 3500), (ValueType::Unsigned, 1, 3501, 4000),
+                // 2, 2~2501
+                (ValueType::Integer, 2, 2, 1001), (ValueType::Integer, 2, 1002, 1501), (ValueType::Integer, 2, 1502, 2501),
+                // 3, 3~1002, 2003~2502, 3003~4002
+                (ValueType::Boolean, 3, 3, 1002), (ValueType::Boolean, 3, 2003, 2502), (ValueType::Boolean, 3, 3003, 4002),
+                // 5, 5~1504, 2005~2504
+                (ValueType::String, 5, 5, 1004), (ValueType::String, 5, 1005, 1504), (ValueType::String, 5, 2005, 2504),
+            ], vec![]),
+            (2, vec![
+                // 1, 3501~3700, 3801~4500
+                (ValueType::Unsigned, 1, 3501, 3700), (ValueType::Unsigned, 1, 3801, 4000), (ValueType::Unsigned, 1, 4001, 4500),
+                // 2, 1002~2001, 2502~3001, 3502~4001
+                (ValueType::Integer, 2, 1002, 2001), (ValueType::Integer, 2, 2502, 3001), (ValueType::Integer, 2, 3502, 4001),
+                // 3, 1003~3002, 3503~4502, 5003~7002
+                (ValueType::Boolean, 3, 1003, 2002), (ValueType::Boolean, 3, 2003, 2502), (ValueType::Boolean, 3, 2503, 3002),
+                (ValueType::Boolean, 3, 3503, 4502), (ValueType::Boolean, 3, 5003, 6002), (ValueType::Boolean, 3, 6003, 7002),
+                // 4, 4~1503, 2004~2503
+                (ValueType::Float, 4, 4, 1003), (ValueType::Float, 4, 1004, 1503), (ValueType::Float, 4, 2004, 2503),
+                // 5, 2505~3004. 4005~5004, 6005~7004
+                (ValueType::String, 5, 2505, 3004), (ValueType::String, 5, 4005, 5004), (ValueType::String, 5, 6005, 7004),
+            ], vec![]),
+            (3, vec![
+                // 1, 4001~6500
+                (ValueType::Unsigned, 1, 4001, 5000), (ValueType::Unsigned, 1, 5001, 6000), (ValueType::Unsigned, 1, 6001, 6500),
+                // 2, 3002~6501, 6602~6801, 6802~7001
+                (ValueType::Integer, 2, 3002, 4001), (ValueType::Integer, 2, 4002, 5001), (ValueType::Integer, 2, 5002, 6001),
+                (ValueType::Integer, 2, 6002, 6501), (ValueType::Integer, 2, 6602, 6801), (ValueType::Integer, 2, 6802, 7001),
+                // 3, 2003~3502
+                (ValueType::Boolean, 3, 2003, 3002), (ValueType::Boolean, 3, 3003, 3502),
+                // 4. 1004~2503
+                (ValueType::Float, 4, 1004, 2003), (ValueType::Float, 4, 2004, 2503),
+            ], vec![]),
+        ];
+        let max_ts = 5000;
+        let expected_data_target_level: HashMap<FieldId, Vec<DataBlock>> = HashMap::from([
+            (
+                // 1
+                // 1~4000
+                // 3501~3700, 3801~4500
+                // 4001~6500
+                1,
+                vec![
+                    generate_data_block(ValueType::Unsigned, vec![(1, 1000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(1001, 2000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(2001, 3000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(3001, 4000)]),
+                    generate_data_block(ValueType::Unsigned, vec![(4001, 5000)]),
+                ],
+            ),
+            (
+                // 2
+                // 2~2501
+                // 1002~2001, 2502~3001, 3502~4001
+                // 3002~6501, 6602~6801, 6802~7001
+                2,
+                vec![
+                    generate_data_block(ValueType::Integer, vec![(2, 1001)]),
+                    generate_data_block(ValueType::Integer, vec![(1002, 2001)]),
+                    generate_data_block(ValueType::Integer, vec![(2002, 3001)]),
+                    generate_data_block(ValueType::Integer, vec![(3002, 4001)]),
+                    generate_data_block(ValueType::Integer, vec![(4002, 5000)]),
+                ],
+            ),
+            (
+                // 3
+                // 3~1002, 2003~2502, 3003~4002
+                // 1003~3002, 3503~4502, 5003~7002
+                // 2003~3502
+                3,
+                vec![
+                    generate_data_block(ValueType::Boolean, vec![(3, 1002)]),
+                    generate_data_block(ValueType::Boolean, vec![(1003, 2002)]),
+                    generate_data_block(ValueType::Boolean, vec![(2003, 3002)]),
+                    generate_data_block(ValueType::Boolean, vec![(3003, 4002)]),
+                    generate_data_block(ValueType::Boolean, vec![(4003, 4502)]),
+                ],
+            ),
+            (
+                // 4
+                // 4~1503, 2004~2503
+                // 1004~2503
+                4,
+                vec![
+                    generate_data_block(ValueType::Float, vec![(4, 1003)]),
+                    generate_data_block(ValueType::Float, vec![(1004, 2003)]),
+                    generate_data_block(ValueType::Float, vec![(2004, 2503)]),
+                ],
+            ),
+            (
+                // 5
+                // 5~1504, 2005~2504
+                // 2505~3004. 4005~5004, 6005~7004
+                5,
+                vec![
+                    generate_data_block(ValueType::String, vec![(5, 1004)]),
+                    generate_data_block(ValueType::String, vec![(1005, 1504), (2005, 2504)]),
+                    generate_data_block(ValueType::String, vec![(2505, 3004), (4005, 4504)]),
+                    generate_data_block(ValueType::String, vec![(4505, 5000)]),
+                ],
+            ),
+        ]);
+
+        test_delta_compaction(
+            "/tmp/test/delta_compaction/2",
+            &data_desc,
+            max_ts,
+            expected_data_target_level,
+            2,
+        )
+        .await;
+    }
+}

--- a/tskv/src/compaction/flush.rs
+++ b/tskv/src/compaction/flush.rs
@@ -234,7 +234,7 @@ pub async fn run_flush_memtable_job(
         tsf.read().await.update_last_modified().await;
 
         if let Some(sender) = compact_task_sender.as_ref() {
-            let _ = sender.send(CompactTask::Vnode(req.ts_family_id)).await;
+            let _ = sender.send(CompactTask::Normal(req.ts_family_id)).await;
         }
     }
 

--- a/tskv/src/compaction/job.rs
+++ b/tskv/src/compaction/job.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::{oneshot, RwLock, Semaphore};
 use trace::{error, info};
 
-use crate::compaction::{flush, CompactTask, LevelCompactionPicker, Picker};
+use crate::compaction::{flush, picker, CompactTask};
 use crate::context::{GlobalContext, GlobalSequenceContext};
 use crate::kv_option::StorageOptions;
 use crate::summary::SummaryTask;
@@ -17,26 +17,42 @@ use crate::TseriesFamilyId;
 const COMPACT_BATCH_CHECKING_SECONDS: u64 = 1;
 
 struct CompactProcessor {
-    vnode_ids: HashMap<TseriesFamilyId, bool>,
+    /// Maps (vnode_id, is_delta_compaction) to should_flush_vnode.
+    compact_task_keys: HashMap<CompactTaskKey, bool>,
 }
 
 impl CompactProcessor {
-    fn insert(&mut self, vnode_id: TseriesFamilyId, should_flush: bool) {
-        let old_should_flush = self.vnode_ids.entry(vnode_id).or_insert(should_flush);
+    fn insert(&mut self, key: CompactTaskKey, should_flush: bool) {
+        let old_should_flush = self.compact_task_keys.entry(key).or_insert(should_flush);
         if should_flush && !*old_should_flush {
             *old_should_flush = should_flush
         }
     }
 
-    fn take(&mut self) -> HashMap<TseriesFamilyId, bool> {
-        std::mem::replace(&mut self.vnode_ids, HashMap::with_capacity(32))
+    fn take(&mut self) -> HashMap<CompactTaskKey, bool> {
+        std::mem::replace(&mut self.compact_task_keys, HashMap::with_capacity(32))
     }
 }
 
 impl Default for CompactProcessor {
     fn default() -> Self {
         Self {
-            vnode_ids: HashMap::with_capacity(32),
+            compact_task_keys: HashMap::with_capacity(32),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+struct CompactTaskKey {
+    vnode_id: TseriesFamilyId,
+    delta_compaction: bool,
+}
+
+impl CompactTaskKey {
+    pub fn new(vnode_id: TseriesFamilyId, delta_compaction: bool) -> Self {
+        Self {
+            vnode_id,
+            delta_compaction,
         }
     }
 }
@@ -64,33 +80,40 @@ pub fn run(
         loop {
             check_interval.tick().await;
             let processor = compact_batch_processor.read().await;
-            if processor.vnode_ids.is_empty() {
+            if processor.compact_task_keys.is_empty() {
                 continue;
             }
             drop(processor);
-            let vnode_ids = compact_batch_processor.write().await.take();
-            let vnode_ids_for_debug = vnode_ids.clone();
-            let now = Instant::now();
-            info!("Compacting on vnode(job start): {:?}", &vnode_ids_for_debug);
-            for (vnode_id, flush_vnode) in vnode_ids {
+            let compact_tasks = compact_batch_processor.write().await.take();
+            for (compact_task_key, should_flush) in compact_tasks {
                 let ts_family = version_set
                     .read()
                     .await
-                    .get_tsfamily_by_tf_id(vnode_id)
+                    .get_tsfamily_by_tf_id(compact_task_key.vnode_id)
                     .await;
                 if let Some(tsf) = ts_family {
-                    info!("Starting compaction on ts_family {}", vnode_id);
+                    info!(
+                        "Starting compaction on ts_family {}",
+                        compact_task_key.vnode_id
+                    );
                     let start = Instant::now();
                     if !tsf.read().await.can_compaction() {
-                        info!("forbidden compaction on moving vnode {}", vnode_id);
+                        info!(
+                            "forbidden compaction on moving vnode {}",
+                            compact_task_key.vnode_id
+                        );
                         return;
                     }
-                    let picker = LevelCompactionPicker::new(storage_opt.clone());
                     let version = tsf.read().await.version();
-                    let compact_req = picker.pick_compaction(version);
+                    let compact_req = if compact_task_key.delta_compaction {
+                        picker::pick_delta_compaction(version)
+                    } else {
+                        picker::pick_level_compaction(version)
+                    };
                     if let Some(req) = compact_req {
                         let database = req.database.clone();
                         let compact_ts_family = req.ts_family_id;
+                        let in_level = req.in_level;
                         let out_level = req.out_level;
 
                         let ctx_inner = ctx.clone();
@@ -101,7 +124,7 @@ pub fn run(
                         // Method acquire_owned() will return AcquireError if the semaphore has been closed.
                         let permit = compaction_limit.clone().acquire_owned().await.unwrap();
                         runtime_inner.spawn(async move {
-                            if flush_vnode {
+                            if should_flush {
                                 let mut tsf_wlock = tsf.write().await;
                                 tsf_wlock.switch_to_immutable();
                                 let flush_req = tsf_wlock.build_flush_req(true);
@@ -117,7 +140,10 @@ pub fn run(
                                     )
                                     .await
                                     {
-                                        error!("Failed to flush vnode {}: {:?}", vnode_id, e);
+                                        error!(
+                                            "Failed to flush vnode {}: {:?}",
+                                            compact_task_key.vnode_id, e
+                                        );
                                     }
                                 }
                             }
@@ -138,6 +164,7 @@ pub fn run(
                                     metrics::sample_tskv_compaction_duration(
                                         database.as_str(),
                                         compact_ts_family.to_string().as_str(),
+                                        in_level.to_string().as_str(),
                                         out_level.to_string().as_str(),
                                         start.elapsed().as_secs_f64(),
                                     )
@@ -156,53 +183,110 @@ pub fn run(
                     }
                 }
             }
-            info!(
-                "Compacting on vnode(job start): {:?} costs {} sec",
-                vnode_ids_for_debug,
-                now.elapsed().as_secs()
-            );
         }
     });
 
     runtime.spawn(async move {
         while let Some(compact_task) = receiver.recv().await {
-            // Vnode id to compact & whether vnode be flushed before compact
-            let (vnode_id, flush_vnode) = match compact_task {
-                CompactTask::Vnode(id) => (id, false),
-                CompactTask::ColdVnode(id) => (id, true),
-            };
-            compact_processor
-                .write()
-                .await
-                .insert(vnode_id, flush_vnode);
+            let mut compact_processor_wlock = compact_processor.write().await;
+            match compact_task {
+                CompactTask::Normal(id) => compact_processor_wlock.insert(
+                    CompactTaskKey {
+                        vnode_id: id,
+                        delta_compaction: false,
+                    },
+                    false,
+                ),
+                CompactTask::Cold(id) => compact_processor_wlock.insert(
+                    CompactTaskKey {
+                        vnode_id: id,
+                        delta_compaction: false,
+                    },
+                    true,
+                ),
+                CompactTask::Delta(id) => compact_processor_wlock.insert(
+                    CompactTaskKey {
+                        vnode_id: id,
+                        delta_compaction: true,
+                    },
+                    false,
+                ),
+            }
         }
     });
 }
 
 #[cfg(test)]
 mod test {
-    use crate::compaction::job::CompactProcessor;
-    use crate::TseriesFamilyId;
+    use crate::compaction::job::{CompactProcessor, CompactTaskKey};
 
     #[test]
     fn test_build_compact_batch() {
         let mut compact_batch_builder = CompactProcessor::default();
-        compact_batch_builder.insert(1, false);
-        compact_batch_builder.insert(2, false);
-        compact_batch_builder.insert(1, true);
-        compact_batch_builder.insert(3, true);
-        assert_eq!(compact_batch_builder.vnode_ids.len(), 3);
-        let mut keys: Vec<TseriesFamilyId> =
-            compact_batch_builder.vnode_ids.keys().cloned().collect();
+        compact_batch_builder.insert(CompactTaskKey::new(1, false), false);
+        compact_batch_builder.insert(CompactTaskKey::new(2, false), false);
+        compact_batch_builder.insert(CompactTaskKey::new(1, true), true);
+        compact_batch_builder.insert(CompactTaskKey::new(3, false), true);
+        compact_batch_builder.insert(CompactTaskKey::new(1, false), true);
+        assert_eq!(compact_batch_builder.compact_task_keys.len(), 4);
+        let mut keys: Vec<CompactTaskKey> = compact_batch_builder
+            .compact_task_keys
+            .keys()
+            .cloned()
+            .collect();
         keys.sort();
-        assert_eq!(keys, vec![1, 2, 3]);
-        assert_eq!(compact_batch_builder.vnode_ids.get(&1), Some(&true));
-        assert_eq!(compact_batch_builder.vnode_ids.get(&2), Some(&false));
-        assert_eq!(compact_batch_builder.vnode_ids.get(&3), Some(&true));
-        let vnode_ids = compact_batch_builder.take();
-        assert_eq!(vnode_ids.len(), 3);
-        assert_eq!(vnode_ids.get(&1), Some(&true));
-        assert_eq!(vnode_ids.get(&2), Some(&false));
-        assert_eq!(vnode_ids.get(&3), Some(&true));
+        assert_eq!(
+            keys,
+            vec![
+                CompactTaskKey::new(1, false),
+                CompactTaskKey::new(1, true),
+                CompactTaskKey::new(2, false),
+                CompactTaskKey::new(3, false),
+            ],
+        );
+        assert_eq!(
+            compact_batch_builder
+                .compact_task_keys
+                .get(&CompactTaskKey::new(1, false)),
+            Some(&true)
+        );
+        assert_eq!(
+            compact_batch_builder
+                .compact_task_keys
+                .get(&CompactTaskKey::new(1, true)),
+            Some(&true)
+        );
+        assert_eq!(
+            compact_batch_builder
+                .compact_task_keys
+                .get(&CompactTaskKey::new(2, false)),
+            Some(&false)
+        );
+        assert_eq!(
+            compact_batch_builder
+                .compact_task_keys
+                .get(&CompactTaskKey::new(3, false)),
+            Some(&true)
+        );
+        let compact_tasks = compact_batch_builder.take();
+        assert_eq!(compact_tasks.len(), 4);
+        assert_eq!(
+            compact_tasks.get(&CompactTaskKey::new(1, true)),
+            Some(&true)
+        );
+        assert_eq!(
+            compact_tasks.get(&CompactTaskKey::new(1, false)),
+            Some(&true)
+        );
+        assert_eq!(
+            compact_tasks.get(&CompactTaskKey::new(2, false)),
+            Some(&false)
+        );
+        assert_eq!(
+            compact_tasks.get(&CompactTaskKey::new(3, false)),
+            Some(&true)
+        );
+        let compact_tasks = compact_batch_builder.take();
+        assert!(compact_tasks.is_empty());
     }
 }

--- a/tskv/src/compaction/mod.rs
+++ b/tskv/src/compaction/mod.rs
@@ -1,35 +1,91 @@
 pub mod check;
 mod compact;
+mod delta_compact;
 mod flush;
 mod iterator;
 pub mod job;
 mod picker;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use chrono::Utc;
 pub use compact::*;
 pub use flush::*;
+use models::Timestamp;
 use parking_lot::RwLock;
 pub use picker::*;
+use utils::BloomFilter;
 
+use crate::context::GlobalContext;
 use crate::kv_option::StorageOptions;
 use crate::memcache::MemCache;
 use crate::tseries_family::{ColumnFile, Version};
-use crate::{LevelId, TseriesFamilyId};
+use crate::{ColumnFileId, LevelId, TseriesFamilyId, VersionEdit};
 
+#[cfg(test)]
+pub mod test {
+    pub use super::compact::test::{
+        check_column_file, create_options, generate_data_block, prepare_compaction,
+        read_data_blocks_from_column_file, write_data_block_desc, write_data_blocks_to_column_file,
+        TsmSchema,
+    };
+    pub use super::flush::flush_tests::default_table_schema;
+}
+
+#[derive(Debug, Clone, Copy)]
 pub enum CompactTask {
-    Vnode(TseriesFamilyId),
-    ColdVnode(TseriesFamilyId),
+    /// Compact the files in the in_level into the out_level.
+    Normal(TseriesFamilyId),
+    /// Flush memcaches and then compact the files in the in_level into the out_level.
+    Cold(TseriesFamilyId),
+    /// Compact the files in level-0 into the out_level.
+    Delta(TseriesFamilyId),
 }
 
 pub struct CompactReq {
     pub ts_family_id: TseriesFamilyId,
-    pub database: Arc<String>,
+    database: Arc<String>,
     storage_opt: Arc<StorageOptions>,
 
     files: Vec<Arc<ColumnFile>>,
     version: Arc<Version>,
-    pub out_level: LevelId,
+    in_level: LevelId,
+    out_level: LevelId,
+    /// The maximum timestamp of the data from the in_level to be compacted
+    /// into the out_level, only used in delta compaction.
+    max_ts: Timestamp,
+}
+
+impl std::fmt::Display for CompactReq {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "tenant_database: {}, ts_family: {}, max_ts: {}, files: [",
+            self.database, self.ts_family_id, self.max_ts,
+        )?;
+        if !self.files.is_empty() {
+            write!(
+                f,
+                "{{ Level-{}, file_id: {}, time_range: {}-{} }}",
+                self.files[0].level(),
+                self.files[0].file_id(),
+                self.files[0].time_range().min_ts,
+                self.files[0].time_range().max_ts
+            )?;
+            for file in self.files.iter().skip(1) {
+                write!(
+                    f,
+                    ", {{ Level-{}, file_id: {}, time_range: {}-{} }}",
+                    file.level(),
+                    file.file_id(),
+                    file.time_range().min_ts,
+                    file.time_range().max_ts
+                )?;
+            }
+        }
+        write!(f, "]")
+    }
 }
 
 #[derive(Debug)]
@@ -37,4 +93,23 @@ pub struct FlushReq {
     pub ts_family_id: TseriesFamilyId,
     pub mems: Vec<Arc<RwLock<MemCache>>>,
     pub force_flush: bool,
+}
+
+const PICKER_CONTEXT_DATETIME_FORMAT: &str = "%d%m%Y_%H%M%S_%3f";
+
+fn context_datetime() -> String {
+    Utc::now()
+        .format(PICKER_CONTEXT_DATETIME_FORMAT)
+        .to_string()
+}
+
+pub async fn run_compaction_job(
+    request: CompactReq,
+    kernel: Arc<GlobalContext>,
+) -> crate::Result<Option<(VersionEdit, HashMap<ColumnFileId, Arc<BloomFilter>>)>> {
+    if request.in_level == 0 {
+        delta_compact::run_compaction_job(request, kernel).await
+    } else {
+        compact::run_compaction_job(request, kernel).await
+    }
 }

--- a/tskv/src/compaction/picker.rs
+++ b/tskv/src/compaction/picker.rs
@@ -1,76 +1,59 @@
 use std::fmt::Debug;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use models::predicate::domain::TimeRange;
 use trace::{debug, info};
 
-use crate::compaction::CompactReq;
-use crate::kv_option::StorageOptions;
-use crate::tseries_family::{ColumnFile, LevelInfo, Version};
+use crate::compaction::{context_datetime, CompactReq};
+use crate::tseries_family::{ColumnFile, ColumnFiles, LevelInfo, LevelInfos, Version};
 use crate::LevelId;
 
-pub trait Picker: Send + Sync + Debug {
-    fn pick_compaction(&self, version: Arc<Version>) -> Option<CompactReq>;
+pub fn pick_level_compaction(version: Arc<Version>) -> Option<CompactReq> {
+    LevelCompactionPicker::new().pick_compaction(version)
 }
 
-/// Compaction picker for picking files in level
+pub fn pick_delta_compaction(version: Arc<Version>) -> Option<CompactReq> {
+    DeltaCompactionPicker::new().pick_compaction(version)
+}
+
+/// Compaction picker for picking a level from level-1 to level-4, and then
+/// pick inner files of the level.
 #[derive(Debug)]
-pub struct LevelCompactionPicker {
-    picking: AtomicBool,
-    storage: Arc<StorageOptions>,
+struct LevelCompactionPicker {
+    /// Datetime when this picker created.
+    datetime: String,
 }
 
-impl Picker for LevelCompactionPicker {
+impl LevelCompactionPicker {
+    fn new() -> LevelCompactionPicker {
+        Self {
+            datetime: context_datetime(),
+        }
+    }
+
     fn pick_compaction(&self, version: Arc<Version>) -> Option<CompactReq> {
         //! 1. Get TseriesFamily's newest **version**(`Arc<Version>`)
         //! 2. Get all level's score, pick LevelInfo with the max score.
         //! 3. Get files(`Vec<Arc<ColumnFile>>`) from the picked level, sorted by min_ts(ascending)
         //!    and size(ascending), pick ColumnFile until picking_files_size reaches
         //!    max_compact_size, remove away the last picked files with overlapped time_range.
-        //! 4. Get files(`Vec<Arc<ColumnFile>>`) from level-0, sorted by min_ts(ascending)
-        //!    and size(ascending), pick ColumnFile until picking_files_size reaches
-        //!    max_compact_size.
+        //! 4. (Deprecated and skipped): Pick files from level-0.
         //! 5. Build CompactReq using **version**, picked level and picked files.
 
         debug!(
-            "Picker: Version info: [ {} ]",
-            version
-                .levels_info()
-                .iter()
-                .enumerate()
-                .map(|(i, lvl)| {
-                    format!(
-                        "Level-{}: files: [ {} ]",
-                        i,
-                        lvl.files
-                            .iter()
-                            .map(|f| format!(
-                                "{}(C:{}, {}-{}, {} B)",
-                                f.file_id(),
-                                if f.is_compacting() { "Y" } else { "N" },
-                                f.time_range().min_ts,
-                                f.time_range().max_ts,
-                                f.size()
-                            ))
-                            .collect::<Vec<String>>()
-                            .join(", ")
-                    )
-                })
-                .collect::<Vec<String>>()
-                .join(", ")
+            "Picker(level): version: [ {} ]",
+            LevelInfos(version.levels_info())
         );
 
         let storage_opt = version.storage_opt();
         let level_infos = version.levels_info();
 
-        // Pick a level to compact with level 0
+        // Pick a level to compact
         let level_start: &LevelInfo;
+        let in_level;
         let out_level;
-
         if let Some((start_lvl, out_lvl)) = self.pick_level(level_infos) {
-            info!("Picker: picked level: {} to {}", start_lvl, out_lvl);
             level_start = &level_infos[start_lvl as usize];
+            in_level = start_lvl;
             out_level = out_lvl;
 
             // If start_lvl is L1, compare the number of L1 files
@@ -80,87 +63,45 @@ impl Picker for LevelCompactionPicker {
                 && (level_infos[1].files.len() as u32) < storage_opt.compact_trigger_file_num
             {
                 info!(
-                    "Picker: picked L1 files({}) does not reach trigger({}), return None",
+                    "Picker(level): picked L1 files({}) does not reach trigger({}), return None",
                     level_infos[1].files.len(),
                     storage_opt.compact_trigger_file_num
                 );
                 return None;
             }
         } else {
-            info!("Picker: picked no level");
+            info!("Picker(level): picked no level");
             return None;
         }
 
         // Pick selected level files.
-        let mut picking_files: Vec<Arc<ColumnFile>> = Vec::new();
-        let (mut picking_files_size, picking_time_range) = if level_start.files.is_empty() {
-            info!("Picker: picked no files from level {}", level_start.level);
+        if level_start.files.is_empty() {
             return None;
-        } else {
-            let mut files = level_start.files.clone();
-            files.sort_by(Self::compare_column_file);
-            Self::pick_files(files, storage_opt.max_compact_size, &mut picking_files)
-        };
-
-        // Pick level 0 files.
-        let mut files = level_infos[0].files.clone();
-        files.sort_by(Self::compare_column_file);
-        for file in files.iter() {
-            if file.time_range().min_ts > picking_time_range.max_ts {
-                break;
-            }
-            if file.is_compacting() || !file.time_range().overlaps(&picking_time_range) {
-                continue;
-            }
-            if !file.mark_compacting() {
-                // If file already compacting, continue to next file.
-                continue;
-            }
-            picking_files.push(file.clone());
-            picking_files_size += file.size();
-
-            if picking_files_size > storage_opt.max_compact_size {
-                // Picked file size >= max_compact_size, try break picking files.
-                break;
-            }
         }
 
-        // Even if picked only 1 file, send it to the next level.
-
+        let mut files = level_start.files.clone();
+        files.sort_by(Self::compare_column_file);
+        let picking_files: Vec<Arc<ColumnFile>> =
+            Self::pick_files(files, storage_opt.max_compact_size);
         info!(
-            "Picker: Picked files: [ {} ]",
-            picking_files
-                .iter()
-                .map(|f| {
-                    format!(
-                        "{{ Level-{}, file_id: {}, time_range: {}-{} }}",
-                        f.level(),
-                        f.file_id(),
-                        f.time_range().min_ts,
-                        f.time_range().max_ts
-                    )
-                })
-                .collect::<Vec<String>>()
-                .join(", ")
+            "Picker(level): Picked files: [ {} ]",
+            ColumnFiles(&picking_files)
         );
+        if picking_files.is_empty() {
+            return None;
+        }
 
+        // Run compaction and send them to the next level, even if picked only 1 file,.
         Some(CompactReq {
-            ts_family_id: version.ts_family_id,
-            database: version.database.clone(),
-            storage_opt: version.storage_opt.clone(),
+            ts_family_id: version.tf_id(),
+            database: version.database(),
+            storage_opt: version.storage_opt(),
             files: picking_files,
             version: version.clone(),
+            in_level,
             out_level,
+            max_ts: level_infos[out_level as usize].time_range.max_ts,
         })
-    }
-}
-
-impl LevelCompactionPicker {
-    pub fn new(storage_opt: Arc<StorageOptions>) -> LevelCompactionPicker {
-        Self {
-            picking: AtomicBool::new(false),
-            storage: storage_opt,
-        }
     }
 
     /// Weight of file number of a level to be picked.
@@ -247,8 +188,8 @@ impl LevelCompactionPicker {
             score_a.partial_cmp(score_b).expect("a NaN score").reverse()
         });
 
-        info!(
-            "Picker: Calculate level scores: [ {} ]",
+        debug!(
+            "Picker(level), level scores: [ {} ]",
             level_scores
                 .iter()
                 .map(|lc| format!("{{ Level-{}: {} }}", lc.0, lc.4))
@@ -265,30 +206,140 @@ impl LevelCompactionPicker {
         })
     }
 
-    fn pick_files(
-        src_files: Vec<Arc<ColumnFile>>,
-        max_compact_size: u64,
-        dst_files: &mut Vec<Arc<ColumnFile>>,
-    ) -> (u64, TimeRange) {
+    fn pick_files(src_files: Vec<Arc<ColumnFile>>, max_compact_size: u64) -> Vec<Arc<ColumnFile>> {
+        let mut dst_files = Vec::with_capacity(src_files.len());
+
         let mut picking_file_size = 0_u64;
-        let mut picking_time_range = TimeRange::none();
         for file in src_files.iter() {
             if file.is_compacting() || !file.mark_compacting() {
                 // If file already compacting, continue to next file.
                 continue;
             }
             picking_file_size += file.size();
-            picking_time_range.merge(file.time_range());
             dst_files.push(file.clone());
 
             if picking_file_size >= max_compact_size {
                 // Picked file size >= max_compact_size, try break picking files.
-                picking_file_size -= file.size();
                 break;
             }
         }
 
-        (picking_file_size, picking_time_range)
+        dst_files
+    }
+}
+
+/// Compaction picker for picking files in level-0 (delta files)
+/// and the output level (one of 1 to 4)
+#[derive(Debug)]
+struct DeltaCompactionPicker {
+    /// Datetime when this picker created.
+    datetime: String,
+}
+
+impl DeltaCompactionPicker {
+    fn new() -> Self {
+        Self {
+            datetime: context_datetime(),
+        }
+    }
+
+    fn pick_compaction(&self, version: Arc<Version>) -> Option<CompactReq> {
+        debug!(
+            "Picker(delta): version: [ {} ]",
+            LevelInfos(version.levels_info())
+        );
+
+        let levels = version.levels_info();
+        if levels[0].files.is_empty() {
+            return None;
+        }
+
+        let mut level_overlapped_files: [Vec<Arc<ColumnFile>>; 5] =
+            [vec![], Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+        let mut file_picked: bool;
+        let mut level_picking: usize;
+        for file in levels[0].files.iter() {
+            if file.is_compacting() {
+                continue;
+            }
+            file_picked = false;
+            level_picking = 4;
+            // Form level-4 to level-1, collect the overlapped level-0 files.
+            for level in levels.iter().skip(1).rev() {
+                if file.time_range().min_ts < level.time_range.max_ts {
+                    level_overlapped_files[level_picking].push(file.clone());
+                    file_picked = true;
+                    break;
+                }
+                level_picking -= 1;
+            }
+            // If time_range of a level-0 file is too old than level-4, put to level-4 files.
+            // TODO(zipper): remove this because it's impossible when a level-0 file is newer than level-1 to level-4
+            if !file_picked {
+                // impossible: level-0 files is newer than level-4 to level-1
+                level_overlapped_files[4].push(file.clone());
+            }
+        }
+        debug!(
+            "Picker(delta): level overlapped files: [ {} ]",
+            level_overlapped_files
+                .iter()
+                .enumerate()
+                .map(|(i, files)| format!("{{ Level-{}: {} }}", i, files.len()))
+                .collect::<Vec<String>>()
+                .join(", ")
+        );
+
+        // Find the level with maximum overlapped level-0 files.
+        let mut out_level = 0;
+        let mut max_files = 0_usize;
+        for (i, files) in level_overlapped_files.iter().enumerate() {
+            if files.len() > max_files {
+                out_level = i;
+                max_files = files.len();
+            }
+        }
+        if out_level == 0 || max_files == 0 {
+            info!("Picker(delta): picked out-level is 0 or picked no files",);
+            return None;
+        }
+
+        // Pick files from level-0 files overlapped with that level.
+        let max_compact_size = version.storage_opt().max_compact_size;
+        let mut picking_files = Vec::with_capacity(level_overlapped_files.len());
+        let mut picking_file_size = 0_u64;
+        for file in level_overlapped_files[out_level].iter() {
+            if file.is_compacting() || !file.mark_compacting() {
+                // If file already compacting, continue to next file.
+                continue;
+            }
+            picking_file_size += file.size();
+            picking_files.push(file.clone());
+
+            if picking_file_size >= max_compact_size {
+                // Picked file size >= max_compact_size
+                break;
+            }
+        }
+        info!(
+            "Picker(delta): Picked files: [ {} ]",
+            ColumnFiles(&picking_files)
+        );
+        if picking_files.is_empty() {
+            return None;
+        }
+
+        // Run compaction and send them to the target level, even if picked only 1 file,.
+        Some(CompactReq {
+            ts_family_id: version.tf_id(),
+            database: version.database(),
+            storage_opt: version.storage_opt(),
+            files: picking_files,
+            version: version.clone(),
+            in_level: 0,
+            out_level: out_level as u32,
+            max_ts: levels[out_level].time_range.max_ts,
+        })
     }
 }
 
@@ -303,7 +354,6 @@ mod test {
     use tokio::sync::mpsc;
 
     use crate::compaction::test::create_options;
-    use crate::compaction::{LevelCompactionPicker, Picker};
     use crate::file_utils::make_tsm_file_name;
     use crate::kv_option::Options;
     use crate::kvcore::COMPACT_REQ_CHANNEL_CAP;
@@ -393,11 +443,11 @@ mod test {
     }
 
     #[test]
-    fn test_pick_1() {
+    fn test_pick_level_files_1() {
         //! There are Level 0-4, and Level 1 is now in compaction.
         //! In this case, Level 2, and serial files in Level 0 will be picked,
         //! and compact to Level 3.
-        let dir = "/tmp/test/pick/1";
+        let dir = "/tmp/test/pick/level_files_1";
         let opt = create_options(dir.to_string());
 
         #[rustfmt::skip]
@@ -427,11 +477,56 @@ mod test {
             ]), // 0.00001
         ];
 
-        let storage_opt = opt.storage.clone();
         let tsf = create_tseries_family(Arc::new("dba".to_string()), opt, levels_sketch);
-        let picker = LevelCompactionPicker::new(storage_opt);
-        let compact_req = picker.pick_compaction(tsf.version()).unwrap();
+        let compact_req = super::pick_level_compaction(tsf.version()).unwrap();
         assert_eq!(compact_req.out_level, 2);
         assert_eq!(compact_req.files.len(), 2);
+    }
+
+    #[test]
+    fn test_pick_delta_files_1() {
+        //! There are Level 0-4, and Level 0 is now in compaction.
+        //! In this case, Level 2, and serial files in Level 0 will be picked,
+        //! and compact to Level 3.
+        let dir = "/tmp/test/pick/delta_files_1";
+        let opt = create_options(dir.to_string());
+
+        #[rustfmt::skip]
+        let levels_sketch: LevelsSketch = vec![
+            // vec![( level, Timestamp_Begin, Timestamp_end, vec![(file_id, Timestamp_Begin, Timestamp_end, size, being_compact)] )]
+            (0_u32, 1_i64, 370_i64, vec![
+                (11_u64, 1_i64, 5_i64, 10_u64, false), // 4
+                (12, 10, 20, 10, true),                // 4
+                (12, 30, 40, 10, false),               // 4
+                (12, 110, 120, 10, false),             // 4
+                (12, 230, 240, 10, false),             // 3
+                (12, 300, 350, 10, false),             // 3
+                (12, 340, 350, 10, false),             // 2
+                (12, 360, 370, 10, false),             // 1
+            ]),
+            (1, 341, 380, vec![
+                (7, 341, 350, 1000, false),
+                (8, 351, 360, 1000, false),
+                (9, 361, 370, 1000, true),
+                (10, 371, 380, 1000, true),
+            ]), // 1
+            (2, 301, 340, vec![
+                (5, 301, 320, 2000, false),
+                (6, 321, 340, 2000, false),
+            ]), // 1
+            (3, 201, 300, vec![
+                (3, 201, 250, 5000, false),
+                (4, 251, 300, 5000, false),
+            ]), // 2
+            (4, 1, 200, vec![
+                (1, 10, 100, 10000, false),
+                (2, 101, 200, 10000, false),
+            ]), // 3
+        ];
+
+        let tsf = create_tseries_family(Arc::new("dba".to_string()), opt, levels_sketch);
+        let compact_req = super::pick_delta_compaction(tsf.version()).unwrap();
+        assert_eq!(compact_req.out_level, 4);
+        assert_eq!(compact_req.files.len(), 3);
     }
 }

--- a/tskv/src/context.rs
+++ b/tskv/src/context.rs
@@ -172,6 +172,7 @@ impl GlobalSequenceContextInner {
     }
 }
 
+#[derive(Debug)]
 pub struct GlobalSequenceTask {
     pub del_ts_family: HashSet<TseriesFamilyId>,
     pub ts_family_min_seq: HashMap<TseriesFamilyId, u64>,

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -25,7 +25,7 @@ use crate::kv_option::{Options, INDEX_PATH};
 use crate::memcache::{MemCache, RowData, RowGroup};
 use crate::schema::schemas::DBschemas;
 use crate::summary::{SummaryTask, VersionEdit};
-use crate::tseries_family::{LevelInfo, TseriesFamily, Version};
+use crate::tseries_family::{schedule_vnode_compaction, LevelInfo, TseriesFamily, Version};
 use crate::Error::{self, InvalidPoint};
 use crate::{file_utils, ColumnFileId, TseriesFamilyId};
 
@@ -89,14 +89,14 @@ impl Database {
             self.opt.cache.clone(),
             self.opt.storage.clone(),
             flush_task_sender,
-            compact_task_sender,
+            compact_task_sender.clone(),
             self.memory_pool.clone(),
             &self.metrics_register,
         );
-        tf.schedule_compaction(self.runtime.clone());
+        let tf_ref = Arc::new(RwLock::new(tf));
+        schedule_vnode_compaction(self.runtime.clone(), tf_ref.clone(), compact_task_sender);
 
-        self.ts_families
-            .insert(ver.tf_id(), Arc::new(RwLock::new(tf)));
+        self.ts_families.insert(ver.tf_id(), tf_ref);
     }
 
     // todo: Maybe TseriesFamily::new() should be refactored.
@@ -180,7 +180,7 @@ impl Database {
             self.opt.cache.clone(),
             self.opt.storage.clone(),
             flush_task_sender,
-            compact_task_sender,
+            compact_task_sender.clone(),
             self.memory_pool.clone(),
             &self.metrics_register,
         );
@@ -189,6 +189,7 @@ impl Database {
         if let Some(tsf) = self.ts_families.get(&tsf_id) {
             return Ok(tsf.clone());
         }
+        schedule_vnode_compaction(self.runtime.clone(), tf.clone(), compact_task_sender);
         self.ts_families.insert(tsf_id, tf.clone());
 
         let (task_state_sender, _task_state_receiver) = oneshot::channel();
@@ -514,5 +515,16 @@ impl Database {
 impl Database {
     pub fn tsf_num(&self) -> usize {
         self.ts_families.len()
+    }
+}
+
+impl Drop for Database {
+    fn drop(&mut self) {
+        let vnodes: Vec<Arc<RwLock<TseriesFamily>>> = self.ts_families.values().cloned().collect();
+        self.runtime.spawn(async move {
+            for vnode in vnodes {
+                vnode.write().await.close();
+            }
+        });
     }
 }

--- a/tskv/src/kvcore.rs
+++ b/tskv/src/kvcore.rs
@@ -22,9 +22,7 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::{oneshot, RwLock};
 use trace::{debug, error, info, warn, SpanContext, SpanExt, SpanRecorder};
 
-use crate::compaction::{
-    self, check, run_flush_memtable_job, CompactTask, FlushReq, LevelCompactionPicker, Picker,
-};
+use crate::compaction::{self, check, run_flush_memtable_job, CompactTask, FlushReq};
 use crate::context::{self, GlobalContext, GlobalSequenceContext, GlobalSequenceTask};
 use crate::database::Database;
 use crate::error::{self, Result};
@@ -1247,9 +1245,8 @@ impl Engine for TsKv {
                     }
                 }
 
-                let picker = LevelCompactionPicker::new(self.options.storage.clone());
                 let version = ts_family.read().await.version();
-                if let Some(req) = picker.pick_compaction(version) {
+                if let Some(req) = compaction::pick_level_compaction(version) {
                     match compaction::run_compaction_job(req, self.global_ctx.clone()).await {
                         Ok(Some((version_edit, file_metas))) => {
                             let (summary_tx, _summary_rx) = oneshot::channel();

--- a/tskv/src/summary.rs
+++ b/tskv/src/summary.rs
@@ -164,6 +164,11 @@ pub struct VersionEdit {
     pub max_level_ts: Timestamp,
     pub add_files: Vec<CompactMeta>,
     pub del_files: Vec<CompactMeta>,
+    /// Partly deleted files, only for delta-compaction.
+    /// Field min_ts and max_ts are the partly deleted time_range.
+    /// This field won't serialize and write into summary file.
+    #[serde(skip)]
+    pub partly_del_files: Vec<CompactMeta>,
 
     pub del_tsf: bool,
     pub add_tsf: bool,
@@ -181,6 +186,7 @@ impl Default for VersionEdit {
             max_level_ts: i64::MIN,
             add_files: vec![],
             del_files: vec![],
+            partly_del_files: vec![],
             del_tsf: false,
             add_tsf: false,
             tsf_id: 0,
@@ -277,6 +283,24 @@ impl VersionEdit {
             file_id,
             level,
             is_delta,
+            ..Default::default()
+        });
+    }
+
+    pub fn del_file_part(
+        &mut self,
+        level: LevelId,
+        file_id: u64,
+        is_delta: bool,
+        min_ts: Timestamp,
+        max_ts: Timestamp,
+    ) {
+        self.partly_del_files.push(CompactMeta {
+            file_id,
+            level,
+            is_delta,
+            min_ts,
+            max_ts,
             ..Default::default()
         });
     }
@@ -569,21 +593,74 @@ impl Summary {
             }
         }
 
-        // For each TsereiesFamily - VersionEdits，generate a new Version and then apply it.
+        // For each TseriesFamily - VersionEdits，generate a new Version and then apply it.
         let version_set = self.version_set.read().await;
+        let mut partly_deleted_file_paths = Vec::new();
         for (tsf_id, edits) in tsf_version_edits {
             let min_seq = tsf_min_seq.get(&tsf_id);
             if let Some(tsf) = version_set.get_tsfamily_by_tf_id(tsf_id).await {
-                trace::info!("Applying new version for ts_family {}.", tsf_id);
+                // Store tsm paths.
+                let tenant_database = &tsf.read().await.database().clone();
+                partly_deleted_file_paths.clear();
+                for version_edit in edits.iter() {
+                    for compact_meta in version_edit.partly_del_files.iter() {
+                        partly_deleted_file_paths.push(compact_meta.file_path(
+                            &self.opt.storage,
+                            tenant_database.as_str(),
+                            tsf_id,
+                        ));
+                    }
+                }
+
+                // Generate new version by version edits.
                 let new_version = tsf.read().await.version().copy_apply_version_edits(
                     edits,
                     &mut file_metas,
                     min_seq.copied(),
                 );
-                let flushed_mem_cahces = mem_caches.get(&tsf_id);
+
+                // Try to replace tombstones with compact_tmp.
+                let mut replace_tombstone_compact_tmp_tasks =
+                    Vec::with_capacity(partly_deleted_file_paths.len());
+                for tsm_path in partly_deleted_file_paths.iter() {
+                    match new_version.get_tsm_reader(tsm_path).await {
+                        Ok(tsm_reader) => {
+                            replace_tombstone_compact_tmp_tasks.push(
+                                self.runtime.spawn(async move {
+                                    tsm_reader.replace_with_compact_tmp().await
+                                }),
+                            );
+                        }
+                        Err(e) => {
+                            trace::error!(
+                                "Failed to get tsm_reader for file '{}' when trying to replace tombstones generated in delta-compaction: {e}",
+                                tsm_path.display(),
+                            )
+                        }
+                    }
+                }
+                for jh in replace_tombstone_compact_tmp_tasks {
+                    match jh.await {
+                        Ok(Ok(_)) => {
+                            trace::info!("Successfully replaced tombstone with compact_tmp");
+                        }
+                        Ok(Err(e)) => {
+                            // TODO: This delta-compaction should be failed.
+                            trace::error!("Failed to replace tombstone with compact_tmp: {e}");
+                        }
+                        Err(e) => {
+                            trace::error!(
+                                "Maybe panicked replacing tombstone with compact_tmp: {e}"
+                            );
+                        }
+                    }
+                }
+
+                let flushed_mem_caches = mem_caches.get(&tsf_id);
+                trace::info!("Applying new version for ts_family {}.", tsf_id);
                 tsf.write()
                     .await
-                    .new_version(new_version, flushed_mem_cahces);
+                    .new_version(new_version, flushed_mem_caches);
                 trace::info!("Applied new version for ts_family {}.", tsf_id);
             }
         }
@@ -818,17 +895,17 @@ impl SummaryScheduler {
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
-    use std::fs;
     use std::sync::Arc;
 
-    use memory_pool::GreedyMemoryPool;
+    use config::Config;
+    use memory_pool::{GreedyMemoryPool, MemoryPool};
     use meta::model::meta_admin::AdminMeta;
-    use meta::model::MetaRef;
     use metrics::metric_register::MetricsRegister;
     use models::schema::{make_owner, DatabaseSchema, TenantOptions};
     use tokio::runtime::Runtime;
     use tokio::sync::mpsc;
     use tokio::sync::mpsc::Sender;
+    use tokio::task::JoinHandle;
     use utils::BloomFilter;
 
     use crate::compaction::{CompactTask, FlushReq};
@@ -839,6 +916,7 @@ mod test {
         COMPACT_REQ_CHANNEL_CAP, GLOBAL_TASK_REQ_CHANNEL_CAP, SUMMARY_REQ_CHANNEL_CAP,
     };
     use crate::summary::{CompactMeta, Summary, SummaryTask, VersionEdit};
+    use crate::TseriesFamilyId;
 
     #[test]
     fn test_version_edit() {
@@ -866,410 +944,439 @@ mod test {
         assert_eq!(ves, ves_2);
     }
 
-    #[test]
-    fn test_summary() {
-        let mut config = config::get_config_for_test();
+    #[derive(Debug)]
+    struct SummaryTestHelper {
+        test_case_name: String,
+        base_dir: String,
+        config: Config,
+        options: Arc<Options>,
+        runtime: Arc<Runtime>,
+        admin_meta: Arc<AdminMeta>,
+        memory_pool: Arc<dyn MemoryPool>,
+        global_context: Arc<GlobalContext>,
+        summary_task_sender: Sender<SummaryTask>,
+        summary_job: JoinHandle<()>,
+        flush_task_sender: Sender<FlushReq>,
+        flush_job: JoinHandle<()>,
+        global_seq_task_sender: Sender<GlobalSequenceTask>,
+        global_seq_job: JoinHandle<()>,
+        compact_task_sender: Sender<CompactTask>,
+        compact_job: JoinHandle<()>,
+    }
 
-        let runtime = Arc::new(
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .worker_threads(4)
-                .build()
-                .unwrap(),
+    impl SummaryTestHelper {
+        fn new(mut config: Config, base_dir: String, test_case_name: String) -> Self {
+            config.storage.path = base_dir.clone();
+            config.log.path = base_dir.clone();
+            let options = Arc::new(Options::from(&config));
+
+            let runtime = Arc::new(
+                tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .worker_threads(4)
+                    .build()
+                    .unwrap(),
+            );
+
+            let config_for_admin_meta = config.clone();
+            let test_case_name_clone = test_case_name.clone();
+            let admin_meta = runtime.block_on(async move {
+                let admin_meta = AdminMeta::new(config_for_admin_meta).await;
+                admin_meta
+                    .add_data_node()
+                    .await
+                    .map_err(|e| format!("[{}] {e}", &test_case_name_clone))
+                    .unwrap();
+                // TODO(zipper): `create_tenant()` add option: ignore already existed tenant.
+                let _ = admin_meta
+                    .create_tenant("cnosdb".to_string(), TenantOptions::default())
+                    .await;
+                admin_meta
+            });
+
+            let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
+
+            // NOTICE: Make sure these channel senders are dropped before test_summary() finished.
+            let (summary_task_sender, mut summary_task_receiver) =
+                mpsc::channel::<SummaryTask>(SUMMARY_REQ_CHANNEL_CAP);
+            let test_case_name_clone = test_case_name.clone();
+            let summary_job = runtime.spawn(async move {
+                println!("Mock summary job started ({test_case_name_clone}).");
+                while let Some(t) = summary_task_receiver.recv().await {
+                    // Do nothing
+                    println!("Mock summary task: {t:?}");
+                    let _ = t.request.call_back.send(Ok(()));
+                }
+                println!("Mock summary job finished ({test_case_name_clone}).");
+            });
+            let (flush_task_sender, mut flush_task_receiver) =
+                mpsc::channel::<FlushReq>(config.storage.flush_req_channel_cap);
+            let test_case_name_clone = test_case_name.clone();
+            let flush_job = runtime.spawn(async move {
+                println!("Mock flush job started ({test_case_name_clone}).");
+                while let Some(t) = flush_task_receiver.recv().await {
+                    // Do nothing
+                    println!("Mock flush request: {t:?}");
+                }
+                println!("Mock flush job finished ({test_case_name_clone}).");
+            });
+            let (global_seq_task_sender, mut global_seq_task_receiver) =
+                mpsc::channel::<GlobalSequenceTask>(GLOBAL_TASK_REQ_CHANNEL_CAP);
+            let global_seq_job = runtime.spawn(async move {
+                println!("Mock global sequence job started (test_summary).");
+                while let Some(t) = global_seq_task_receiver.recv().await {
+                    // Do nothing
+                    println!("Mock global sequence task: {t:?}");
+                }
+                println!("Mock global sequence job finished (test_summary).");
+            });
+            let (compact_task_sender, mut compact_task_receiver) =
+                mpsc::channel::<CompactTask>(COMPACT_REQ_CHANNEL_CAP);
+            let test_case_name_clone = test_case_name.clone();
+            let compact_job = runtime.spawn(async move {
+                println!("Mock compact job started ({test_case_name_clone}).");
+                while let Some(t) = compact_task_receiver.recv().await {
+                    // Do nothing
+                    println!("Mock compact task: {t:?}");
+                }
+                println!("Mock compact job finished ({test_case_name_clone}).");
+            });
+
+            Self {
+                test_case_name,
+                base_dir,
+                config,
+                options,
+                runtime,
+                admin_meta,
+                memory_pool,
+                global_context: Arc::new(GlobalContext::new()),
+                summary_task_sender,
+                summary_job,
+                flush_task_sender,
+                flush_job,
+                global_seq_task_sender,
+                global_seq_job,
+                compact_task_sender,
+                compact_job,
+            }
+        }
+
+        fn with_default_config(base_dir: String, test_case_name: String) -> Self {
+            let config = config::get_config_for_test();
+            Self::new(config, base_dir, test_case_name)
+        }
+
+        fn init(&self) -> Summary {
+            let summary_dir = self.options.storage.summary_dir();
+            if !file_manager::try_exists(&summary_dir) {
+                std::fs::create_dir_all(&summary_dir)
+                    .map_err(|e| format!("[{}] {e}", &self.test_case_name))
+                    .unwrap();
+            }
+            self.runtime
+                .block_on(Summary::new(
+                    self.options.clone(),
+                    self.runtime.clone(),
+                    self.memory_pool.clone(),
+                    self.global_seq_task_sender.clone(),
+                    Arc::new(MetricsRegister::default()),
+                ))
+                .map_err(|e| format!("[{}] {e}", &self.test_case_name))
+                .unwrap()
+        }
+
+        fn recover(&self) -> Summary {
+            self.runtime
+                .block_on(Summary::recover(
+                    self.admin_meta.clone(),
+                    self.options.clone(),
+                    self.runtime.clone(),
+                    self.memory_pool.clone(),
+                    self.flush_task_sender.clone(),
+                    self.global_seq_task_sender.clone(),
+                    self.compact_task_sender.clone(),
+                    false,
+                    Arc::new(MetricsRegister::default()),
+                ))
+                .unwrap()
+        }
+
+        /// Block until all inner tasks cancelled.
+        ///
+        /// Make sure all senders(usually be holden in TsKvContext or Summary) were dropped
+        /// before calling this method.
+        fn join(self) {
+            let SummaryTestHelper {
+                summary_task_sender,
+                summary_job,
+                flush_task_sender,
+                flush_job,
+                global_seq_task_sender,
+                global_seq_job,
+                compact_task_sender,
+                compact_job,
+                ..
+            } = self;
+            drop(summary_task_sender);
+            drop(compact_task_sender);
+            drop(global_seq_task_sender);
+            drop(flush_task_sender);
+            let _ = self.runtime.block_on(async {
+                tokio::join!(summary_job, flush_job, global_seq_job, compact_job)
+            });
+        }
+    }
+
+    #[test]
+    fn test_summary_recover() {
+        let base_dir = "/tmp/test/summary/test_summary_recover";
+        let _ = std::fs::remove_dir_all(base_dir);
+        std::fs::create_dir_all(base_dir).unwrap();
+        let test_helper = SummaryTestHelper::with_default_config(
+            base_dir.to_string(),
+            "test_summary_recover".to_string(),
         );
 
-        // NOTICE: Make sure these channel senders are dropped before test_summary() finished.
-        let (summary_task_sender, mut summary_task_receiver) =
-            mpsc::channel::<SummaryTask>(SUMMARY_REQ_CHANNEL_CAP);
-        let summary_job_mock = runtime.spawn(async move {
-            println!("Mock summary job started (test_summary).");
-            while let Some(t) = summary_task_receiver.recv().await {
-                // Do nothing
-                let _ = t.request.call_back.send(Ok(()));
-            }
-            println!("Mock summary job finished (test_summary).");
-        });
-        let (flush_task_sender, mut flush_task_receiver) =
-            mpsc::channel::<FlushReq>(config.storage.flush_req_channel_cap);
-        let flush_job_mock = runtime.spawn(async move {
-            println!("Mock flush job started (test_summary).");
-            while flush_task_receiver.recv().await.is_some() {
-                // Do nothing
-            }
-            println!("Mock flush job finished (test_summary).");
-        });
-        let (global_seq_task_sender, mut global_seq_task_receiver) =
-            mpsc::channel::<GlobalSequenceTask>(GLOBAL_TASK_REQ_CHANNEL_CAP);
-        let _global_seq_job_mock = runtime.spawn(async move {
-            println!("Mock global sequence job started (test_summary).");
-            while let Some(_t) = global_seq_task_receiver.recv().await {
-                // Do nothing
-            }
-            println!("Mock global sequence job finished (test_summary).");
-        });
-        let (compact_task_sender, mut compact_task_receiver) =
-            mpsc::channel::<CompactTask>(COMPACT_REQ_CHANNEL_CAP);
-        let compact_job_mock = runtime.spawn(async move {
-            println!("Mock compact job started (test_summary).");
-            while compact_task_receiver.recv().await.is_some() {
-                // Do nothing
-            }
-            println!("Mock compact job finished (test_summary).");
-        });
-
-        let runtime_ref = runtime.clone();
-        runtime.block_on(async move {
-            println!("Running test: test_summary_recover");
-            let base_dir = "/tmp/test/summary/test_summary_recover".to_string();
-            let _ = fs::remove_dir_all(&base_dir);
-            fs::create_dir_all(&base_dir).unwrap();
-            config.storage.path = base_dir.clone();
-            test_summary_recover(
-                config.clone(),
-                runtime_ref.clone(),
-                flush_task_sender.clone(),
-                global_seq_task_sender.clone(),
-                compact_task_sender.clone(),
-            )
-            .await;
-
-            println!("Running test: test_tsf_num_recover");
-            let base_dir = "/tmp/test/summary/test_tsf_num_recover".to_string();
-            let _ = fs::remove_dir_all(&base_dir);
-            fs::create_dir_all(&base_dir).unwrap();
-            config.storage.path = base_dir.clone();
-            test_tsf_num_recover(
-                config.clone(),
-                runtime_ref.clone(),
-                flush_task_sender.clone(),
-                global_seq_task_sender.clone(),
-                compact_task_sender.clone(),
-            )
-            .await;
-
-            println!("Running test: test_recover_summary_with_roll_0");
-            let base_dir = "/tmp/test/summary/test_recover_summary_with_roll_0".to_string();
-            let _ = fs::remove_dir_all(&base_dir);
-            fs::create_dir_all(&base_dir).unwrap();
-            config.storage.path = base_dir.clone();
-            test_recover_summary_with_roll_0(
-                config.clone(),
-                runtime_ref.clone(),
-                summary_task_sender.clone(),
-                flush_task_sender.clone(),
-                global_seq_task_sender.clone(),
-                compact_task_sender.clone(),
-            )
-            .await;
-
-            println!("Running test: test_recover_summary_with_roll_1");
-            let base_dir = "/tmp/test/summary/test_recover_summary_with_roll_1".to_string();
-            let _ = fs::remove_dir_all(&base_dir);
-            config.storage.path = base_dir.clone();
-            test_recover_summary_with_roll_1(
-                config.clone(),
-                runtime_ref.clone(),
-                summary_task_sender,
-                flush_task_sender,
-                global_seq_task_sender,
-                compact_task_sender,
-            )
-            .await;
-
-            let _ = tokio::join!(summary_job_mock, flush_job_mock, compact_job_mock);
-        });
-    }
-
-    async fn test_summary_recover(
-        config: config::Config,
-        runtime: Arc<Runtime>,
-        flush_task_sender: Sender<FlushReq>,
-        global_seq_task_sender: Sender<GlobalSequenceTask>,
-        compact_task_sender: Sender<CompactTask>,
-    ) {
-        let opt = Arc::new(Options::from(&config));
-        let meta_manager = AdminMeta::new(config.clone()).await;
-
-        meta_manager.add_data_node().await.unwrap();
-
-        let _ = meta_manager
-            .create_tenant("cnosdb".to_string(), TenantOptions::default())
-            .await;
-        let summary_dir = opt.storage.summary_dir();
-        if !file_manager::try_exists(&summary_dir) {
-            std::fs::create_dir_all(&summary_dir).unwrap();
-        }
-        let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
-        let mut summary = Summary::new(
-            opt.clone(),
-            runtime.clone(),
-            memory_pool.clone(),
-            global_seq_task_sender.clone(),
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-        let edit = VersionEdit::new_add_vnode(100, "cnosdb.hello".to_string(), 0);
-        summary
-            .apply_version_edit(vec![edit], HashMap::new(), HashMap::new())
-            .await
-            .unwrap();
-        let _summary = Summary::recover(
-            meta_manager,
-            opt.clone(),
-            runtime.clone(),
-            memory_pool,
-            flush_task_sender,
-            global_seq_task_sender,
-            compact_task_sender,
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-    }
-
-    async fn test_tsf_num_recover(
-        config: config::Config,
-        runtime: Arc<Runtime>,
-        flush_task_sender: Sender<FlushReq>,
-        global_seq_task_sender: Sender<GlobalSequenceTask>,
-        compact_task_sender: Sender<CompactTask>,
-    ) {
-        let opt = Arc::new(Options::from(&config));
-        let meta_manager: MetaRef = AdminMeta::new(config.clone()).await;
-
-        meta_manager.add_data_node().await.unwrap();
-
-        let _ = meta_manager
-            .create_tenant("cnosdb".to_string(), TenantOptions::default())
-            .await;
-        let summary_dir = opt.storage.summary_dir();
-        if !file_manager::try_exists(&summary_dir) {
-            std::fs::create_dir_all(&summary_dir).unwrap();
-        }
-        let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
-        let mut summary = Summary::new(
-            opt.clone(),
-            runtime.clone(),
-            memory_pool.clone(),
-            global_seq_task_sender.clone(),
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-
-        let edit = VersionEdit::new_add_vnode(100, "cnosdb.hello".to_string(), 0);
-        summary
-            .apply_version_edit(vec![edit], HashMap::new(), HashMap::new())
-            .await
-            .unwrap();
-        let mut summary = Summary::recover(
-            meta_manager.clone(),
-            opt.clone(),
-            runtime.clone(),
-            memory_pool.clone(),
-            flush_task_sender.clone(),
-            global_seq_task_sender.clone(),
-            compact_task_sender.clone(),
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-        assert_eq!(summary.version_set.read().await.tsf_num().await, 1);
-        let edit = VersionEdit::new_del_vnode(100);
-        summary
-            .apply_version_edit(vec![edit], HashMap::new(), HashMap::new())
-            .await
-            .unwrap();
-        let summary = Summary::recover(
-            meta_manager,
-            opt.clone(),
-            runtime,
-            memory_pool.clone(),
-            flush_task_sender,
-            global_seq_task_sender,
-            compact_task_sender,
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-        assert_eq!(summary.version_set.read().await.tsf_num().await, 0);
-    }
-
-    // tips : we can use a small max_summary_size
-    #[allow(clippy::too_many_arguments)]
-    async fn test_recover_summary_with_roll_0(
-        config: config::Config,
-        runtime: Arc<Runtime>,
-        summary_task_sender: Sender<SummaryTask>,
-        flush_task_sender: Sender<FlushReq>,
-        global_seq_task_sender: Sender<GlobalSequenceTask>,
-        compact_task_sender: Sender<CompactTask>,
-    ) {
-        let opt = Arc::new(Options::from(&config));
-        let meta_manager: MetaRef = AdminMeta::new(config.clone()).await;
-
-        meta_manager.add_data_node().await.unwrap();
-        let _ = meta_manager
-            .create_tenant("cnosdb".to_string(), TenantOptions::default())
-            .await;
-        let database = "test".to_string();
-        let summary_dir = opt.storage.summary_dir();
-        if !file_manager::try_exists(&summary_dir) {
-            std::fs::create_dir_all(&summary_dir).unwrap();
-        }
-        let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
-        let global = Arc::new(GlobalContext::new());
-        let mut summary = Summary::new(
-            opt.clone(),
-            runtime.clone(),
-            memory_pool.clone(),
-            global_seq_task_sender.clone(),
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-
-        let mut edits = vec![];
-        let db = summary
-            .version_set
-            .write()
-            .await
-            .create_db(
-                DatabaseSchema::new("cnosdb", &database),
-                meta_manager.clone(),
-                memory_pool.clone(),
-            )
-            .await
-            .unwrap();
-        for i in 0..40 {
-            db.write()
-                .await
-                .add_tsfamily(
-                    i,
-                    0,
-                    None,
-                    summary_task_sender.clone(),
-                    flush_task_sender.clone(),
-                    compact_task_sender.clone(),
-                    global.clone(),
-                )
-                .await
-                .expect("add tsfamily successfully");
-            let edit = VersionEdit::new_add_vnode(i, make_owner("cnosdb", &database), 0);
-            edits.push(edit.clone());
-        }
-
-        for _ in 0..100 {
-            for i in 0..20 {
-                db.write()
-                    .await
-                    .del_tsfamily(i, summary_task_sender.clone())
-                    .await;
-                edits.push(VersionEdit::new_del_vnode(i));
-            }
-        }
-        summary
-            .apply_version_edit(edits, HashMap::new(), HashMap::new())
-            .await
-            .unwrap();
-
-        let summary = Summary::recover(
-            meta_manager.clone(),
-            opt.clone(),
-            runtime,
-            memory_pool.clone(),
-            flush_task_sender.clone(),
-            global_seq_task_sender.clone(),
-            compact_task_sender,
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(summary.version_set.read().await.tsf_num().await, 20);
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn test_recover_summary_with_roll_1(
-        config: config::Config,
-        runtime: Arc<Runtime>,
-        summary_task_sender: Sender<SummaryTask>,
-        flush_task_sender: Sender<FlushReq>,
-        global_seq_task_sender: Sender<GlobalSequenceTask>,
-        compact_task_sender: Sender<CompactTask>,
-    ) {
-        let memory_pool = Arc::new(GreedyMemoryPool::new(1024 * 1024 * 1024));
-
-        let opt = Arc::new(Options::from(&config));
-        let meta_manager: MetaRef = AdminMeta::new(config.clone()).await;
-
-        meta_manager.add_data_node().await.unwrap();
-
-        let _ = meta_manager
-            .create_tenant("cnosdb".to_string(), TenantOptions::default())
-            .await;
-        let database = "test".to_string();
-        let summary_dir = opt.storage.summary_dir();
-        if !file_manager::try_exists(&summary_dir) {
-            std::fs::create_dir_all(&summary_dir).unwrap();
-        }
-        let mut summary = Summary::new(
-            opt.clone(),
-            runtime.clone(),
-            memory_pool.clone(),
-            global_seq_task_sender.clone(),
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-
-        let db = summary
-            .version_set
-            .write()
-            .await
-            .create_db(
-                DatabaseSchema::new("cnosdb", &database),
-                meta_manager.clone(),
-                memory_pool.clone(),
-            )
-            .await
-            .unwrap();
-        let cxt = Arc::new(GlobalContext::new());
-        db.write()
-            .await
-            .add_tsfamily(
-                10,
-                0,
-                None,
-                summary_task_sender.clone(),
-                flush_task_sender.clone(),
-                compact_task_sender.clone(),
-                cxt.clone(),
-            )
-            .await
-            .expect("add tsfamily failed");
-
-        let mut edits = vec![];
-        let edit = VersionEdit::new_add_vnode(10, "cnosdb.hello".to_string(), 0);
-        edits.push(edit);
-
-        for _ in 0..100 {
-            db.write()
-                .await
-                .del_tsfamily(0, summary_task_sender.clone())
-                .await;
-            let edit = VersionEdit::new_del_vnode(0);
-            edits.push(edit);
+        {
+            // Create vnode(id=100) in database "cnosdb.hello".
+            let mut summary = test_helper.init();
+            let edit = VersionEdit::new_add_vnode(100, "cnosdb.hello".to_string(), 0);
+            test_helper
+                .runtime
+                .block_on(summary.apply_version_edit(vec![edit], HashMap::new(), HashMap::new()))
+                .unwrap();
         }
 
         {
-            let vs = summary.version_set.write().await;
-            let tsf = vs.get_tsfamily_by_tf_id(10).await.unwrap();
+            // Check if vnode and database still exists after recover.
+            let summary = test_helper.recover();
+            test_helper.runtime.block_on(async move {
+                let version_set = summary.version_set.read().await;
+                assert_eq!(version_set.tsf_num().await, 1);
+                let all_db_names: Vec<String> = version_set.get_all_db().keys().cloned().collect();
+                assert_eq!(all_db_names, vec!["cnosdb.hello".to_string()]);
+                let db = version_set.get_all_db().get("cnosdb.hello").unwrap();
+                let vnode_ids: Vec<TseriesFamilyId> =
+                    db.read().await.ts_families().keys().cloned().collect();
+                assert_eq!(vnode_ids, vec![100]);
+            });
+        }
+
+        test_helper.join();
+    }
+
+    #[test]
+    fn test_tsf_num_recover() {
+        let base_dir = "/tmp/test/summary/test_tsf_num_recover";
+        let _ = std::fs::remove_dir_all(base_dir);
+        std::fs::create_dir_all(base_dir).unwrap();
+        let test_helper = SummaryTestHelper::with_default_config(
+            base_dir.to_string(),
+            "test_tsf_num_recover".to_string(),
+        );
+
+        let tenant_database = "cnosdb.test_tsf_num_recover";
+
+        {
+            // Create vnode(id=100) in database "cnosdb.test_tsf_num_recover".
+            let mut summary = test_helper.init();
+            test_helper.runtime.block_on(async move {
+                let edit = VersionEdit::new_add_vnode(100, tenant_database.to_string(), 0);
+                summary
+                    .apply_version_edit(vec![edit], HashMap::new(), HashMap::new())
+                    .await
+                    .unwrap();
+            });
+        }
+
+        {
+            // Check if vnode and database still exists after recover.
+            // Delete vnode(id=100).
+            let mut summary = test_helper.recover();
+            test_helper.runtime.block_on(async move {
+                let version_set = summary.version_set.read().await;
+                assert_eq!(version_set.tsf_num().await, 1);
+                let all_db_names: Vec<String> = version_set.get_all_db().keys().cloned().collect();
+                assert_eq!(all_db_names, vec![tenant_database.to_string()]);
+                let db = version_set.get_all_db().get(tenant_database).unwrap();
+                let vnode_ids: Vec<TseriesFamilyId> =
+                    db.read().await.ts_families().keys().cloned().collect();
+                assert_eq!(vnode_ids, vec![100]);
+                drop(version_set);
+
+                let edit = VersionEdit::new_del_vnode(100);
+                summary
+                    .apply_version_edit(vec![edit], HashMap::new(), HashMap::new())
+                    .await
+                    .unwrap();
+            });
+        }
+
+        {
+            // Check if database and vnode not exists after recover.
+            let summary = test_helper.recover();
+            test_helper.runtime.block_on(async move {
+                let version_set = summary.version_set.read().await;
+                assert_eq!(version_set.tsf_num().await, 0);
+                assert_eq!(version_set.get_all_db().len(), 0);
+            });
+        }
+
+        test_helper.join();
+    }
+
+    #[test]
+    fn test_recover_summary_with_roll_0() {
+        let base_dir = "/tmp/test/summary/test_recover_summary_with_roll_0";
+        let _ = std::fs::remove_dir_all(base_dir);
+        std::fs::create_dir_all(base_dir).unwrap();
+        let database = "test_recover_summary_with_roll_0";
+        let owned_database = make_owner("cnosdb", database);
+        let mut config = config::get_config_for_test();
+        config.storage.max_summary_size = 128;
+        let test_helper = SummaryTestHelper::new(
+            config,
+            base_dir.to_string(),
+            "test_recover_summary_with_roll_0".to_string(),
+        );
+
+        let test_helper = Arc::new(test_helper);
+
+        {
+            // Create database, add some vnodes then delete some vnodes.
+            let mut summary = test_helper.init();
+            let test_helper_inner = test_helper.clone();
+            test_helper.runtime.block_on(async {
+                let mut edits = vec![];
+                let db = summary
+                    .version_set
+                    .write()
+                    .await
+                    .create_db(
+                        DatabaseSchema::new("cnosdb", database),
+                        test_helper_inner.admin_meta.clone(),
+                        test_helper_inner.memory_pool.clone(),
+                    )
+                    .await
+                    .unwrap();
+                for i in 0..20 {
+                    db.write()
+                        .await
+                        .add_tsfamily(
+                            i,
+                            0,
+                            None,
+                            test_helper_inner.summary_task_sender.clone(),
+                            test_helper_inner.flush_task_sender.clone(),
+                            test_helper_inner.compact_task_sender.clone(),
+                            test_helper_inner.global_context.clone(),
+                        )
+                        .await
+                        .expect("add tsfamily successfully");
+                    let edit = VersionEdit::new_add_vnode(i, owned_database.to_string(), 0);
+                    edits.push(edit.clone());
+                }
+                summary
+                    .apply_version_edit(edits.drain(..).collect(), HashMap::new(), HashMap::new())
+                    .await
+                    .unwrap();
+
+                for _ in 0..10 {
+                    let mut edits = vec![];
+                    for i in 0..10 {
+                        db.write()
+                            .await
+                            .del_tsfamily(i, test_helper_inner.summary_task_sender.clone())
+                            .await;
+                        edits.push(VersionEdit::new_del_vnode(i));
+                    }
+                    summary
+                        .apply_version_edit(edits, HashMap::new(), HashMap::new())
+                        .await
+                        .unwrap();
+                }
+            });
+        }
+
+        {
+            // Recover and compare.
+            let summary = test_helper.recover();
+            test_helper.runtime.block_on(async move {
+                assert_eq!(summary.version_set.read().await.tsf_num().await, 10);
+            });
+        }
+
+        let test_helper = Arc::try_unwrap(test_helper).unwrap();
+        test_helper.join();
+    }
+
+    #[test]
+    fn test_recover_summary_with_roll_1() {
+        let base_dir = "/tmp/test/summary/test_recover_summary_with_roll_1";
+        let _ = std::fs::remove_dir_all(base_dir);
+        std::fs::create_dir_all(base_dir).unwrap();
+        let database = "test_recover_summary_with_roll_1";
+        let owned_database = make_owner("cnosdb", database);
+        const VNODE_ID: u32 = 10;
+        let mut config = config::get_config_for_test();
+        config.storage.max_summary_size = 256;
+        let test_helper = SummaryTestHelper::new(
+            config,
+            base_dir.to_string(),
+            "test_recover_summary_with_roll_1".to_string(),
+        );
+
+        let test_helper = Arc::new(test_helper);
+
+        let mut summary = test_helper.init();
+        // Create database, add some vnodes and delete some vnodes.
+        // Go to the next version.
+        let test_helper_inner = test_helper.clone();
+        test_helper.runtime.block_on(async move {
+            let db = summary
+                .version_set
+                .write()
+                .await
+                .create_db(
+                    DatabaseSchema::new("cnosdb", database),
+                    test_helper_inner.admin_meta.clone(),
+                    test_helper_inner.memory_pool.clone(),
+                )
+                .await
+                .unwrap();
+            db.write()
+                .await
+                .add_tsfamily(
+                    VNODE_ID,
+                    0,
+                    None,
+                    test_helper_inner.summary_task_sender.clone(),
+                    test_helper_inner.flush_task_sender.clone(),
+                    test_helper_inner.compact_task_sender.clone(),
+                    test_helper_inner.global_context.clone(),
+                )
+                .await
+                .expect("add vnode failed");
+            let mut edits = vec![VersionEdit::new_add_vnode(
+                VNODE_ID,
+                owned_database.to_string(),
+                0,
+            )];
+            for _ in 0..10 {
+                db.write()
+                    .await
+                    .del_tsfamily(0, test_helper_inner.summary_task_sender.clone())
+                    .await;
+                let edit = VersionEdit::new_del_vnode(0);
+                edits.push(edit);
+            }
+
+            // Go to the next version.
+            let tsf = {
+                let vs = summary.version_set.read().await;
+                vs.get_tsfamily_by_tf_id(VNODE_ID).await.unwrap()
+            };
             let mut version = tsf.read().await.version().copy_apply_version_edits(
                 edits.clone(),
                 &mut HashMap::new(),
@@ -1277,8 +1384,7 @@ mod test {
             );
             let tsm_reader_cache = Arc::downgrade(&version.tsm_reader_cache);
 
-            summary.ctx.set_last_seq(1);
-            let mut edit = VersionEdit::new(10);
+            let mut edit = VersionEdit::new(VNODE_ID);
             let meta = CompactMeta {
                 file_id: 15,
                 is_delta: false,
@@ -1286,7 +1392,7 @@ mod test {
                 level: 1,
                 min_ts: 1,
                 max_ts: 1,
-                tsf_id: 10,
+                tsf_id: VNODE_ID,
                 high_seq: 1,
                 ..Default::default()
             };
@@ -1298,40 +1404,35 @@ mod test {
             tsf.write().await.new_version(version, None);
             edit.add_file(meta, 1);
             edits.push(edit);
+
+            summary
+                .apply_version_edit(edits, HashMap::new(), HashMap::new())
+                .await
+                .unwrap();
+        });
+
+        {
+            // Recover and compare.
+            let summary = test_helper.recover();
+            test_helper.runtime.block_on(async move {
+                let vs = summary.version_set.read().await;
+                let tsf = vs.get_tsfamily_by_tf_id(VNODE_ID).await.unwrap();
+                assert_eq!(tsf.read().await.version().last_seq, 1);
+                assert_eq!(tsf.read().await.version().levels_info()[1].tsf_id, VNODE_ID);
+                assert!(!tsf.read().await.version().levels_info()[1].files[0].is_delta());
+                assert_eq!(
+                    tsf.read().await.version().levels_info()[1].files[0].file_id(),
+                    15
+                );
+                assert_eq!(
+                    tsf.read().await.version().levels_info()[1].files[0].size(),
+                    100
+                );
+                assert_eq!(summary.ctx.file_id(), 16);
+            });
         }
 
-        summary
-            .apply_version_edit(edits, HashMap::new(), HashMap::new())
-            .await
-            .unwrap();
-
-        let summary = Summary::recover(
-            meta_manager,
-            opt,
-            runtime,
-            memory_pool.clone(),
-            flush_task_sender,
-            global_seq_task_sender,
-            compact_task_sender,
-            false,
-            Arc::new(MetricsRegister::default()),
-        )
-        .await
-        .unwrap();
-
-        let vs = summary.version_set.read().await;
-        let tsf = vs.get_tsfamily_by_tf_id(10).await.unwrap();
-        assert_eq!(tsf.read().await.version().last_seq, 1);
-        assert_eq!(tsf.read().await.version().levels_info[1].tsf_id, 10);
-        assert!(!tsf.read().await.version().levels_info[1].files[0].is_delta());
-        assert_eq!(
-            tsf.read().await.version().levels_info[1].files[0].file_id(),
-            15
-        );
-        assert_eq!(
-            tsf.read().await.version().levels_info[1].files[0].size(),
-            100
-        );
-        assert_eq!(summary.ctx.file_id(), 16);
+        let test_helper = Arc::try_unwrap(test_helper).unwrap();
+        test_helper.join();
     }
 }

--- a/tskv/src/tsm/codec/mod.rs
+++ b/tskv/src/tsm/codec/mod.rs
@@ -25,7 +25,7 @@ pub struct DataBlockEncoding {
 }
 
 impl DataBlockEncoding {
-    pub fn new(ts_encoding: Encoding, val_encoding: Encoding) -> Self {
+    pub const fn new(ts_encoding: Encoding, val_encoding: Encoding) -> Self {
         Self {
             ts_encoding,
             val_encoding,

--- a/tskv/src/tsm/mod.rs
+++ b/tskv/src/tsm/mod.rs
@@ -8,7 +8,7 @@ mod writer;
 pub use block::*;
 pub use index::*;
 pub use reader::*;
-pub use tombstone::{Tombstone, TsmTombstone};
+pub use tombstone::{tombstone_compact_tmp_path, Tombstone, TsmTombstone, TOMBSTONE_FILE_SUFFIX};
 pub use writer::*;
 
 // MAX_BLOCK_VALUES is the maximum number of values a TSM block can store.

--- a/tskv/src/tsm/writer.rs
+++ b/tskv/src/tsm/writer.rs
@@ -362,6 +362,11 @@ impl TsmWriter {
     pub fn bloom_filter_cloned(&self) -> BloomFilter {
         self.index_buf.bloom_filter.clone()
     }
+
+    /// Consumes a finished tsm writer and take `BloomFilter` from currently buffered index data.
+    pub fn into_bloom_filter(self) -> BloomFilter {
+        self.index_buf.bloom_filter
+    }
 }
 
 pub async fn new_tsm_writer(
@@ -541,13 +546,15 @@ pub mod tsm_writer_tests {
     use crate::file_utils::{self, make_tsm_file_name};
     use crate::tsm::codec::DataBlockEncoding;
     use crate::tsm::tsm_reader_tests::read_and_check;
-    use crate::tsm::{DataBlock, TsmReader, TsmWriter};
+    use crate::tsm::{DataBlock, EncodedDataBlock, TsmReader, TsmWriter, WriteTsmError};
+    use crate::Error;
 
     const TEST_PATH: &str = "/tmp/test/tsm_writer";
 
     pub async fn write_to_tsm(
         path: impl AsRef<Path>,
         data: &HashMap<FieldId, Vec<DataBlock>>,
+        encode_data_block: bool,
     ) -> Result<()> {
         let tsm_seq = file_utils::get_tsm_file_id_by_path(&path)?;
         let path = path.as_ref();
@@ -556,12 +563,28 @@ pub mod tsm_writer_tests {
             std::fs::create_dir_all(dir).context(super::WriteIOSnafu)?;
         }
         let mut writer = TsmWriter::open(path, tsm_seq, false, 0).await?;
-        for (fid, blks) in data.iter() {
-            for blk in blks.iter() {
-                writer
-                    .write_block(*fid, blk)
-                    .await
-                    .context(error::WriteTsmSnafu)?;
+        if encode_data_block {
+            for (fid, blks) in data.iter() {
+                for blk in blks.iter() {
+                    let blk_enc = EncodedDataBlock::encode(blk, 0, blk.len()).map_err(|e| {
+                        Error::WriteTsm {
+                            source: WriteTsmError::Encode { source: e },
+                        }
+                    })?;
+                    writer
+                        .write_encoded_block(*fid, &blk_enc)
+                        .await
+                        .context(error::WriteTsmSnafu)?;
+                }
+            }
+        } else {
+            for (fid, blks) in data.iter() {
+                for blk in blks.iter() {
+                    writer
+                        .write_block(*fid, blk)
+                        .await
+                        .context(error::WriteTsmSnafu)?;
+                }
             }
         }
         writer.write_index().await.context(error::WriteTsmSnafu)?;
@@ -576,11 +599,24 @@ pub mod tsm_writer_tests {
             (2, vec![DataBlock::U64 { ts: vec![2, 3, 4], val: vec![101, 102, 103], enc: DataBlockEncoding::default() }]),
         ]);
 
-        let tsm_file = make_tsm_file_name(TEST_PATH, 0);
-        write_to_tsm(&tsm_file, &data).await.unwrap();
+        let dir = "/tmp/test/tsm_writer/test_tsm_write_fast";
+        let _ = std::fs::remove_dir_all(dir);
+        {
+            // Test write normal data block.
+            let tsm_file = make_tsm_file_name(dir, 0);
+            write_to_tsm(&tsm_file, &data, false).await.unwrap();
 
-        let reader = TsmReader::open(tsm_file).await.unwrap();
-        read_and_check(&reader, &data).await.unwrap();
+            let reader = TsmReader::open(tsm_file).await.unwrap();
+            read_and_check(&reader, &data).await.unwrap();
+        }
+        {
+            // Test write encoded data block.
+            let tsm_file = make_tsm_file_name(dir, 1);
+            write_to_tsm(&tsm_file, &data, true).await.unwrap();
+
+            let reader = TsmReader::open(tsm_file).await.unwrap();
+            read_and_check(&reader, &data).await.unwrap();
+        }
     }
 
     #[tokio::test]
@@ -606,10 +642,23 @@ pub mod tsm_writer_tests {
             ]),
         ]);
 
-        let tsm_file = make_tsm_file_name(TEST_PATH, 1);
-        write_to_tsm(&tsm_file, &data).await.unwrap();
+        let dir = "/tmp/test/tsm_writer/test_tsm_write_1";
+        let _ = std::fs::remove_dir_all(dir);
+        {
+            // Test write normal data block.
+            let tsm_file = make_tsm_file_name(dir, 0);
+            write_to_tsm(&tsm_file, &data, false).await.unwrap();
 
-        let reader = TsmReader::open(tsm_file).await.unwrap();
-        read_and_check(&reader, &data).await.unwrap();
+            let reader = TsmReader::open(tsm_file).await.unwrap();
+            read_and_check(&reader, &data).await.unwrap();
+        }
+        {
+            // Test write encoded data block.
+            let tsm_file = make_tsm_file_name(dir, 1);
+            write_to_tsm(&tsm_file, &data, true).await.unwrap();
+
+            let reader = TsmReader::open(tsm_file).await.unwrap();
+            read_and_check(&reader, &data).await.unwrap();
+        }
     }
 }


### PR DESCRIPTION
# Rationale for this change

Related #1244.

## Conclusion

### Others

1. `DataBlock` - Add method `split_at(self, index)-> (DataBlock, DataBlock)` and `intersection(self, time_range) -> Option<DataBlock>`.
2. `ColumnFile`, `LevelInfo` - Implement `std::fmt::Display`, also add `ColumnFiles<F: AsRef<ColumnFile>>(&[F])` and `LevelInfos(&[LevelInfo])` to decrease code when we need to log them.
3. `TimeRange`, add function `compact(time_ranges: &mut Vec<TimeRange>)` to compact time ranges.

### Compaction

- Changes measurement of compaction from `"db", "ts_family", "level"` to `"db", "ts_family", "in_level", "out_level"`.
- Add file `delta_compact.rs` for delta compaction:
  1. Pick delta files and the out_level, get the `out_level_max_ts` of the out_level.
  2. Now we have many delta files, for each field_id in these files, find grouped blocks which should be merged together: `Vec<CompactingBlockMetaGroup>`.
  3. For each `CompactingBlockMetaGroup`, get merge-split blocks(only data in time_range `0..=out_level_max_ts` is needed) and write them into files in the out_level, store these files in `VersionEdit`.
  4. Write a temporary tsm-tombstone file for the delta-file, named `xxxxxxx.tombstone.compact.tmp`, includes all it's field_ids and time_range `0..=out_level_max_ts`, because data in the time_range is already merged into the out_level. Tombstones will be compacted by `compact(time_ranges: &mut Vec<TimeRange>)` before write.
  5. Write the `VersionEdit` into summary, and rename these `xxxxxxx.tombstone.compact.tmp` files to `xxxxxxx.tombstone`.

#### Task definition

Some changes in `CompactTask`:

- Normal(from old CompactTask::Vnode) - Compact the files in the in_level into the out_level.
- Cold(from old CompactTask::ColdVnode) - Flush memcaches and then compact the files in the in_level into the out_level.
- Delta - Compact the files in level-0 into the out_level.

#### Pick

- Remove trait `Picker: Send + Sync + Debug`, add two function instead of it:
  - `pick_level_compaction(version: Arc<Version>) -> Option<CompactReq>`
  - `pick_delta_compaction(version: Arc<Version>) -> Option<CompactReq>`
- Add function `pick_delta_compaction` only for picking delta files, it partly merges data in level-0 files to the destination level, the merged data will leave a tombstone file for the source level-0 files.

#### Scheduler

- Now `schedule_compaction()` not only check if a tseries family is cold but also check num of level-0 files with config `compact_trigger_file_num` or constant `DEFAULT_COMPACT_TRIGGER_DETLA_FILE_NUM` (This change makes unit tests in summary.rs won't stop, so I fixed  it by some changes in unit test cases in summary.rs).
- `schedule_compaction()` holds a shared reference of `Arc<TseriesFamily`, now we must manually stop it by `TseriesFamily::close()`. Implementation of `Drop` for `Database` will call that method of all it's tseries families.
- Compact job structure `compaction::job::CompactProcessor` is changed to hold the map of `(TsFamilyId, IsDeltaCompaction)` to `ShouldFlushBeforeCompaction`.

## TODOs

There may be some logs for debug may be deleted.

# Are there any user-facing changes?

No.
