### PR TITLE
Fix: LRU cache of TSM readers break down

### DIFF
--- a/common/cache/src/sharded_async_cache.rs
+++ b/common/cache/src/sharded_async_cache.rs
@@ -38,12 +38,9 @@ where
         self.shard.get(index)?.lock().await.pop()
     }
 
-    pub async fn lock_shard(
-        &self,
-        key: &K,
-    ) -> Option<MutexGuard<'_, Box<dyn Cache<K = K, V = V>>>> {
+    pub async fn lock_shard(&self, key: &K) -> MutexGuard<'_, Box<dyn Cache<K = K, V = V>>> {
         let index = shard(&key, self.shard.len());
-        Some(self.shard.get(index)?.lock().await)
+        self.shard[index].lock().await
     }
 }
 


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

fix(tskv): lru cache break down in query that lead to open too many files when opening tsm reader

[//]: # (Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.)

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

