### PR TITLE
Add Dependabot version updates configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+---
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      # Some crates need to be pinned to specific versions.
+    ignore:
+      # Those crates need to be manually updated or we need to reference a fixed version branch.
+      - dependency-name: "openraft"
+      - dependency-name: "arrow"
+      - dependency-name: "arrow-*"
+      - dependency-name: "parquet"
+      - dependency-name: "datafusion"
+      - dependency-name: "datafusion-*"


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

doc :  https://docs.github.com/zh/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates
1. Dependabot alerts: GitHub sends Dependabot alerts when we detect that your repository uses a vulnerable dependency.
2. Dependabot security updates: Dependabot can fix vulnerable dependencies for you by raising pull requests with security updates.
3. Dependabot versions updates: We can use Dependabot to keep the packages you use updated to the latest versions.

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

