### PR TITLE
Fix(2.3): fix some bugs and improve the delta-compaction

### DIFF
--- a/tskv/src/compaction/compact.rs
+++ b/tskv/src/compaction/compact.rs
@@ -1202,9 +1202,12 @@ pub mod test {
         }
     }
 
-    pub fn create_options(base_dir: String) -> Arc<Options> {
+    pub fn create_options(base_dir: String, always_compact: bool) -> Arc<Options> {
         let mut config = config::get_config_for_test();
         config.storage.path = base_dir.clone();
+        if always_compact {
+            config.storage.compact_trigger_file_num = 1;
+        }
         config.log.path = base_dir;
         Arc::new(Options::from(&config))
     }
@@ -1212,7 +1215,7 @@ pub mod test {
     #[test]
     fn test_create_options() {
         let dir = "/tmp/test/compaction/test_create_options";
-        let opt = create_options(dir.to_string());
+        let opt = create_options(dir.to_string(), false);
         assert_eq!(opt.storage.path.to_string_lossy(), dir);
     }
 
@@ -1239,6 +1242,7 @@ pub mod test {
             files,
             in_level: 1,
             out_level: 2,
+            out_time_range: TimeRange::all(),
         };
         let context = Arc::new(GlobalContext::new());
         context.set_file_id(next_file_id);
@@ -1288,7 +1292,7 @@ pub mod test {
         let dir = "/tmp/test/compaction/0";
         let _ = std::fs::remove_dir_all(dir);
         let tenant_database = Arc::new("cnosdb.dba".to_string());
-        let opt = create_options(dir.to_string());
+        let opt = create_options(dir.to_string(), true);
         let dir = opt.storage.tsm_dir(&tenant_database, 1);
         let max_level_ts = 9;
 
@@ -1336,7 +1340,7 @@ pub mod test {
         let dir = "/tmp/test/compaction/1";
         let _ = std::fs::remove_dir_all(dir);
         let tenant_database = Arc::new("cnosdb.dba".to_string());
-        let opt = create_options(dir.to_string());
+        let opt = create_options(dir.to_string(), true);
         let dir = opt.storage.tsm_dir(&tenant_database, 1);
         let max_level_ts = 9;
 
@@ -1383,7 +1387,7 @@ pub mod test {
         let dir = "/tmp/test/compaction/2";
         let _ = std::fs::remove_dir_all(dir);
         let tenant_database = Arc::new("cnosdb.dba".to_string());
-        let opt = create_options(dir.to_string());
+        let opt = create_options(dir.to_string(), true);
         let dir = opt.storage.tsm_dir(&tenant_database, 1);
         let max_level_ts = 9;
 
@@ -1424,7 +1428,7 @@ pub mod test {
         let dir = "/tmp/test/compaction/3";
         let _ = std::fs::remove_dir_all(dir);
         let tenant_database = Arc::new("cnosdb.dba".to_string());
-        let opt = create_options(dir.to_string());
+        let opt = create_options(dir.to_string(), true);
         let dir = opt.storage.tsm_dir(&tenant_database, 1);
         let max_level_ts = 9;
 
@@ -1676,7 +1680,7 @@ pub mod test {
         let dir = "/tmp/test/compaction/big_1";
         let _ = std::fs::remove_dir_all(dir);
         let tenant_database = Arc::new("cnosdb.dba".to_string());
-        let opt = create_options(dir.to_string());
+        let opt = create_options(dir.to_string(), true);
         let dir = opt.storage.tsm_dir(&tenant_database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
@@ -1744,7 +1748,7 @@ pub mod test {
         let dir = "/tmp/test/compaction/big_2";
         let _ = std::fs::remove_dir_all(dir);
         let tenant_database = Arc::new("cnosdb.dba".to_string());
-        let opt = create_options(dir.to_string());
+        let opt = create_options(dir.to_string(), true);
         let dir = opt.storage.tsm_dir(&tenant_database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();
@@ -1857,7 +1861,7 @@ pub mod test {
         let dir = "/tmp/test/compaction/big_3";
         let _ = std::fs::remove_dir_all(dir);
         let tenant_database = Arc::new("cnosdb.dba".to_string());
-        let opt = create_options(dir.to_string());
+        let opt = create_options(dir.to_string(), true);
         let dir = opt.storage.tsm_dir(&tenant_database, 1);
         if !file_manager::try_exists(&dir) {
             std::fs::create_dir_all(&dir).unwrap();

--- a/tskv/src/compaction/job.rs
+++ b/tskv/src/compaction/job.rs
@@ -59,7 +59,7 @@ pub fn run(
 ) {
     let runtime_inner = runtime.clone();
     let compact_task_group_producer = Arc::new(RwLock::new(CompactTaskGroup::default()));
-    let compact_task_group_comsumer = compact_task_group_producer.clone();
+    let compact_task_group_consumer = compact_task_group_producer.clone();
     runtime.spawn(async move {
         // TODO: Concurrent compactions should not over argument $cpu.
         let compaction_limit = Arc::new(Semaphore::new(
@@ -70,10 +70,10 @@ pub fn run(
 
         loop {
             check_interval.tick().await;
-            if compact_task_group_comsumer.read().await.is_empty() {
+            if compact_task_group_consumer.read().await.is_empty() {
                 continue;
             }
-            let compact_tasks = match compact_task_group_comsumer.write().await.try_take() {
+            let compact_tasks = match compact_task_group_consumer.write().await.try_take() {
                 Some(t) => t,
                 None => continue,
             };

--- a/tskv/src/file_system/file_manager.rs
+++ b/tskv/src/file_system/file_manager.rs
@@ -177,6 +177,14 @@ pub async fn open_create_file(path: impl AsRef<Path>) -> Result<AsyncFile> {
     get_file_manager().open_create_file(path).await
 }
 
+/// Move 'file' to 'file.del', for test of file deletions.
+pub fn fake_remove(path: impl AsRef<Path>) -> std::io::Result<()> {
+    let mut new_path = path.as_ref().to_path_buf();
+    let file_name = new_path.file_name().expect("file has name");
+    new_path.set_file_name(format!("{}.del", file_name.to_string_lossy()));
+    std::fs::rename(path, new_path)
+}
+
 #[cfg(test)]
 mod test {
     use std::io::{IoSlice, SeekFrom};

--- a/tskv/src/tseries_family.rs
+++ b/tskv/src/tseries_family.rs
@@ -434,7 +434,11 @@ impl LevelInfo {
 
 impl std::fmt::Display for LevelInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{ L:{}, files: [ ", self.level)?;
+        write!(
+            f,
+            "{{ L:{}, time_range: {}, files: [ ",
+            self.level, self.time_range,
+        )?;
         for (i, file) in self.files.iter().enumerate() {
             write!(f, "{}", file.as_ref())?;
             if i < self.files.len() - 1 {
@@ -574,6 +578,7 @@ impl Version {
     }
 
     pub async fn unmark_compacting_files(&self, files_ids: &HashSet<ColumnFileId>) {
+        trace::info!("unmark_compacting_files: {:?}", files_ids);
         if files_ids.is_empty() {
             return;
         }

--- a/tskv/src/tsm/tombstone.rs
+++ b/tskv/src/tsm/tombstone.rs
@@ -488,7 +488,11 @@ impl TsmTombstoneCache {
         }
     }
 
+    ///  Append time_range, but if time_range is None, does nothing.
     pub fn insert(&mut self, tombstone_field: TombstoneField, time_range: TimeRange) {
+        if time_range.is_none() {
+            return;
+        }
         match tombstone_field {
             TombstoneField::One(field_id) => {
                 // Adding for ONE field: merge with existing tombstones.


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

- Fix some typos.
- Modifications in `TimeRanges::add_time_range`
   Now it merges [(t1, t2), (t2+1, t3)] into (t1, t3), at previous it won't merge them.
- Replace method `CompactReq::out_time_range()` to field `CompactReq::out_time_range`
   - In order to simplify the code.
   - It is `TimeRange::all()` when picking for normal compaction, while it has a lot of different logic in delta compaction picking.
- Fix a bug in `DeltaCompactionPicker::pick_compaction()`
   It did not reset `ColumnFile::compacting` when delta-files-num is lesser than the trigger.

# Are there any user-facing changes?

No.