### PR TITLE
Fix(2.3): TsmWriter::size hasn't add index_size

### DIFF
--- a/tskv/src/compaction/flush.rs
+++ b/tskv/src/compaction/flush.rs
@@ -630,7 +630,7 @@ pub mod flush_tests {
             max_level_ts_before: max_level_ts,
             max_level_ts_after: 18,
             expected_delta_data: vec![expected_delta_data],
-            expected_file_size: vec![586],
+            expected_file_size: vec![1318],
             expected_min_ts: vec![1],
             expected_max_ts: vec![18],
         }

--- a/tskv/src/tsm/writer.rs
+++ b/tskv/src/tsm/writer.rs
@@ -342,6 +342,9 @@ impl TsmWriter {
         )
         .await?;
 
+        self.size += len1 as u64;
+        self.size += len2 as u64;
+
         Ok(len1 + len2)
     }
 


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

## Fix a bug in `TsmWriter::write_index()`

It did not add the field `TsmWriter::size` with the length of data just written. It follows that the file size recorded in the summary file is lesser than the real file size.

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

