### PR TITLE
fix : Updating outdated config files packaged with docker and other platforms

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -12,15 +12,15 @@ store_metrics = true
 
 [meta]
 service_addr = ["127.0.0.1:8901"]
-report_time_interval_secs = 30
+report_time_interval = "30s"
 
 [query]
 max_server_connections = 10240
-query_sql_limit = 16777216     # 16 * 1024 * 1024
-write_sql_limit = 167772160    # 160 * 1024 * 1024
+query_sql_limit = "16777216B"     # 16 * 1024 * 1024
+write_sql_limit = "167772160B"    # 160 * 1024 * 1024
 auth_enabled = false
-read_timeout_ms = 3000
-write_timeout_ms = 3000
+read_timeout = "3000ms"
+write_timeout = "3000ms"
 stream_trigger_cpu = 1
 stream_executor_cpu = 2
 


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?
https://github.com/cnosdb/cnosdb/pull/2006
Outdated configurations cause the configuration file to fail to parse when we package and upload the docker and it won't run.
```
2024-03-28 16:05:53 -----------------------------------------------------------
2024-03-28 16:05:53 Using Config File: /etc/cnosdb/cnosdb.conf
2024-03-28 16:05:53 
2024-03-28 16:06:04 -----------------------------------------------------------
2024-03-28 16:05:53 thread 'main' panicked at main/src/main.rs:230:54:
2024-03-28 16:05:53 called `Result::unwrap()` on an `Err` value: Custom { kind: Other, error: "Failed to parse configurtion file '/etc/cnosdb/cnosdb.conf': Error { inner: Error { inner: TomlError { message: \"invalid type: integer `16777216`, expected a string\", original: Some(\"[global]\\n# node_id = 100\\nhost = \\\"localhost\\\"\\ncluster_name = 'cluster_xxx'\\nstore_metrics = true\\n\\n\\n[deployment]\\n# mode = 'query_tskv'\\n# cpu = 8\\n# memory = 16\\n\\n[meta]\\nservice_addr = [\\\"127.0.0.1:8901\\\"]\\nreport_time_interval_secs = 30\\n\\n[query]\\nmax_server_connections = 10240\\nquery_sql_limit = 16777216     # 16 * 1024 * 1024\\nwrite_sql_limit = 167772160    # 160 * 1024 * 1024\\nauth_enabled = false\\nread_timeout_ms = 3000\\nwrite_timeout_ms = 3000\\nstream_trigger_cpu = 1\\nstream_executor_cpu = 2\\n\\n[storage]\\n\\n## The directory where database files stored.\\n# Directory for summary:    $path/summary\\n# Directory for index:      $path/$database/data/id/index\\n# Directory for tsm:        $path/$database/data/id/tsm\\n# Directory for delta:      $path/$database/data/id/delta\\npath = '/var/lib/cnosdb/data'\\n\\n## The maximum file size of summary file.\\n# max_summary_size = \\\"128M\\\" # 134,217,728 bytes\\n\\n## The maximum file size of a level is as follows:\\n## $base_file_size * level * $compact_trigger_file_num\\n# base_file_size = \\\"16M\\\" # 16,777,216 bytes\\n\\n## The maxmimum amount of flush requests in memory\\n# flush_req_channel_cap = 16\\n\\n## The maximum count of opened file handles (for query) in each vnode.\\n# max_cached_readers = 32\\n\\n## The maxmimum level of a data file (from 0 to 4).\\n# max_level = 4\\n\\n# Trigger of compaction using the number of level 0 files.\\n# compact_trigger_file_num = 4\\n\\n## Duration since last write to trigger compaction.\\n# compact_trigger_cold_duration = \\\"1h\\\"\\n\\n## The maximum size of all files in a compaction.\\n# max_compact_size = \\\"2G\\\" # 2,147,483,648 bytes\\n\\n## The maximum concurrent compactions.\\n# max_concurrent_compaction = 4\\n\\n## If true, write request will not be checked in detail.\\nstrict_write = false\\n\\n## copyinto trigger flush size\\n#copyinto_trigger_flush_size = \\\"128M\\\" # 134217728\\n\\n[wal]\\n\\n## If true, write requets on disk before writing to memory.\\nenabled = true\\n\\n## The directory where write ahead logs stored.\\npath = '/var/lib/cnosdb/wal'\\n\\n## The maxmimum amount of write request in memory.\\n# wal_req_channel_cap = 64\\n\\n## The maximum size of a WAL.\\n# max_file_size = '1G' # 1,073,741,824 bytes\\n\\n## Trigger all vnode flushing if size of WALs exceeds this value.\\n# flush_trigger_total_file_size = '2G' # 2,147,483,648 bytes\\n\\n## If true, fsync will be called after every WAL writes.\\n# sync = false\\n\\n## Interval for automatic WAL fsync.\\n# sync_interval = '0' # h, m, s\\n\\n[cache]\\n\\n## The maximum size of a mutable cache.\\n# max_buffer_size = '128M' # 134,217,728 bytes\\n\\n## The partion number of memcache cache,default equal to cpu number\\n# partition = 8\\n\\n[log]\\nlevel = 'info'\\npath = '/var/log/cnosdb'\\n## Tokio trace, default turn off tokio trace\\n# tokio_trace = { addr = \\\"127.0.0.1:6669\\\" }\\n\\n[security]\\n# [security.tls_config]\\n# certificate = \\\"/etc/config/tls/server.crt\\\"\\n# private_key = \\\"/etc/config/tls/server.key\\\"\\n\\n[service]\\nhttp_listen_port = 8902\\ngrpc_listen_port = 8903\\ngrpc_enable_gzip = false\\nflight_rpc_listen_port = 8904\\ntcp_listen_port = 8905\\nvector_listen_port = 8906\\nenable_report = true\\n\\n\\n[cluster]\\n# raft_logs_to_keep = 5000\\n# using_raft_replication = false\\n\\n[hinted_off]\\nenable = true\\npath = '/var/lib/cnosdb/hh'\\nthreads = 3\\n\\n\\n# [trace]\\n# auto_generate_span = false\\n# [trace.log]\\n# path = '/var/log/cnosdb'\\n# [trace.jaeger]\\n# jaeger_agent_endpoint = 'http://localhost:14268/api/traces'\\n# max_concurrent_exports = 2\\n# max_queue_size = 4096\\n\"), keys: [\"query\", \"query_sql_limit\"], span: Some(286..294) } } }" }
```
[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

[//]: # (Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.)

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

