### PR TITLE
Refactor(2.3): improve delta_compactions

### DIFF
--- a/tskv/src/compaction/mod.rs
+++ b/tskv/src/compaction/mod.rs
@@ -358,7 +358,7 @@ pub mod test {
     #[tokio::test]
     async fn test_generate_version() {
         let dir = "/tmp/test/compaction/test_generate_version";
-        let storage_opt = create_options(dir.to_string(), true).storage.clone();
+        let storage_opt = create_options(dir.to_string(), 1).storage.clone();
         let vnode_sketch = VersionSketch::new(dir, Arc::new("dba".to_string()), 1)
             .add(0, FileSketch(6, (1, 10), 50, false))
             .add(0, FileSketch(7, (790, 800), 50, false))
@@ -430,7 +430,7 @@ pub mod test {
     async fn test_compact_req_methods_delta_compaction() {
         // This case doesn't need directory to exist.
         let dir = "/tmp/test/compaction/test_compact_req_methods_delta_compaction";
-        let opt = create_options(dir.to_string(), true);
+        let opt = create_options(dir.to_string(), 1);
 
         {
             // Merge delta files to level-1.
@@ -659,7 +659,7 @@ pub mod test {
     async fn test_compact_req_methods_normal_compaction() {
         // This case doesn't need directory to exist.
         let dir = "/tmp/test/compaction/test_compact_req_methods_normal_compaction";
-        let opt = create_options(dir.to_string(), true);
+        let opt = create_options(dir.to_string(), 1);
 
         {
             // Merge level files to next level.


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.
# Rationale for this change

[//]: # (Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.)

## Some improvements of  delta_compactions

### Picker

Pick `compact_trigger_file_num` lv0 files until there are no more lv0 files that contain the newest data numbered consecutively and, then pick the first lv0 file that overlaps with lv1_4.

### Job

Do not trigger normal compaction after delta compaction.

### Others

Improve logs, with more debug information.

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

