### PR TITLE
Feature(2.3): metrics of delta_compactions; some improvements

### DIFF
--- a/common/models/src/meta_data.rs
+++ b/common/models/src/meta_data.rs
@@ -108,6 +108,16 @@ pub enum VnodeStatus {
     Broken,
 }
 
+impl std::fmt::Display for VnodeStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VnodeStatus::Running => write!(f, "running"),
+            VnodeStatus::Copying => write!(f, "copying"),
+            VnodeStatus::Broken => write!(f, "broken"),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct VnodeAllInfo {
     pub vnode_id: VnodeId,

--- a/config/config_8902.toml
+++ b/config/config_8902.toml
@@ -32,6 +32,7 @@ compact_trigger_file_num = 4
 compact_trigger_cold_duration = "1h"
 max_compact_size = "2G" # 2147483648
 max_concurrent_compaction = 4
+collect_compaction_metrics = false
 strict_write = false
 reserve_space = "0"
 copyinto_trigger_flush_size = "128M" # 134217728

--- a/config/config_8912.toml
+++ b/config/config_8912.toml
@@ -27,10 +27,12 @@ max_summary_size = "128M" # 134217728
 base_file_size = "16M" # 16777216
 flush_req_channel_cap = 16
 max_cached_readers = 32
+enable_compaction = true
 compact_trigger_file_num = 4
 compact_trigger_cold_duration = "1h"
 max_compact_size = "2G" # 2147483648
 max_concurrent_compaction = 4
+collect_compaction_metrics = false
 strict_write = false
 reserve_space = "0"
 copyinto_trigger_flush_size = "128M" # 134217728
@@ -47,7 +49,7 @@ sync_interval = "0"
 [cache]
 max_buffer_size = "128M" # 134217728
 max_immutable_number = 4
-partition = 16          # default memcache partition number
+partition = 16           # default memcache partition number
 
 [log]
 level = 'info'
@@ -69,7 +71,7 @@ tcp_listen_port = 8915
 vector_listen_port = 8916
 
 [node_basic]
-node_id = 2001 
+node_id = 2001
 store_metrics = true
 
 [heartbeat]

--- a/config/src/storage_config.rs
+++ b/config/src/storage_config.rs
@@ -50,6 +50,9 @@ pub struct StorageConfig {
     #[serde(default = "StorageConfig::default_max_concurrent_compaction")]
     pub max_concurrent_compaction: u16,
 
+    #[serde(default = "StorageConfig::default_collect_compaction_metrics")]
+    pub collect_compaction_metrics: bool,
+
     #[serde(default = "StorageConfig::default_strict_write")]
     pub strict_write: bool,
 
@@ -108,6 +111,10 @@ impl StorageConfig {
         4
     }
 
+    fn default_collect_compaction_metrics() -> bool {
+        false
+    }
+
     fn default_reserve_space() -> u64 {
         0
     }
@@ -133,6 +140,12 @@ impl StorageConfig {
         if let Ok(size) = std::env::var("CNOSDB_FLUSH_REQ_CHANNEL_CAP") {
             self.flush_req_channel_cap = size.parse::<usize>().unwrap();
         }
+        if let Ok(size) = std::env::var("CNOSDB_STORAGE_MAX_CACHED_READERS") {
+            self.max_cached_readers = size.parse::<usize>().unwrap();
+        }
+        if let Ok(flag) = std::env::var("CNOSDB_STORAGE_ENABLE_COMPACTION") {
+            self.enable_compaction = flag.parse::<bool>().unwrap();
+        }
         if let Ok(size) = std::env::var("CNOSDB_STORAGE_MAX_LEVEL") {
             self.max_level = size.parse::<u16>().unwrap();
         }
@@ -147,6 +160,9 @@ impl StorageConfig {
         }
         if let Ok(size) = std::env::var("CNOSDB_STORAGE_MAX_CONCURRENT_COMPACTION") {
             self.max_concurrent_compaction = size.parse::<u16>().unwrap();
+        }
+        if let Ok(flag) = std::env::var("CNOSDB_STORAGE_COLLECT_COMPACTION_METRICS") {
+            self.collect_compaction_metrics = flag.parse::<bool>().unwrap();
         }
         if let Ok(size) = std::env::var("CNOSDB_STORAGE_STRICT_WRITE") {
             self.strict_write = size.parse::<bool>().unwrap();
@@ -179,6 +195,7 @@ impl Default for StorageConfig {
             compact_trigger_cold_duration: Self::default_compact_trigger_cold_duration(),
             max_compact_size: Self::default_max_compact_size(),
             max_concurrent_compaction: Self::default_max_concurrent_compaction(),
+            collect_compaction_metrics: Self::default_collect_compaction_metrics(),
             strict_write: Self::default_strict_write(),
             reserve_space: Self::default_reserve_space(),
             copyinto_trigger_flush_size: Self::default_copyinto_trigger_flush_size(),

--- a/tskv/src/compaction/picker.rs
+++ b/tskv/src/compaction/picker.rs
@@ -70,7 +70,7 @@ impl LevelCompactionPicker {
             in_level = start_lvl;
             out_level = out_lvl;
         } else {
-            info!("Picker(level): picked no level");
+            debug!("Picker(level): picked no level");
             return None;
         }
 
@@ -83,7 +83,7 @@ impl LevelCompactionPicker {
         files.sort_by(Self::compare_column_file);
         let picking_files: Vec<Arc<ColumnFile>> =
             Self::pick_files(files, storage_opt.max_compact_size).await;
-        info!(
+        debug!(
             "Picker(level): Picked files: [ {} ]",
             ColumnFiles(&picking_files)
         );

--- a/tskv/src/compaction/picker.rs
+++ b/tskv/src/compaction/picker.rs
@@ -26,11 +26,6 @@ pub async fn pick_compaction(
                 .pick_compaction(compact_task, version)
                 .await
         }
-        CompactTask::Cold(_) => {
-            LevelCompactionPicker
-                .pick_compaction(compact_task, version)
-                .await
-        }
         CompactTask::Manual(_) => {
             DeltaCompactionPicker::new()
                 .pick_compaction(compact_task, version)
@@ -346,7 +341,7 @@ impl DeltaCompactionPicker {
         let mut not_picked_l0_file: Option<(
             Arc<ColumnFile>,        // l0_file
             LevelId,                // adviced_out_level
-            TimeRange,              // l0_file_remained_tr_last
+            TimeRange,              // l0_file_remained_tr
             RwLockWriteGuard<bool>, // l0_file_compacting
         )> = Option::None;
         for l0_file in lv0.files.iter() {
@@ -361,7 +356,7 @@ impl DeltaCompactionPicker {
                 continue;
             }
 
-            let l0_file_remained_tr_last =
+            let l0_file_remained_tr_first =
                 match self.delta_file_first_remained_time_range(l0_file).await {
                     Ok(trs) => trs,
                     Err(_) => {
@@ -370,17 +365,17 @@ impl DeltaCompactionPicker {
                 };
 
             let advised_out_level =
-                advise_out_level(&l0_file_remained_tr_last, version.levels_info());
+                advise_out_level(&l0_file_remained_tr_first, version.levels_info());
             if picked_time_range.is_none() {
                 // First cycle to pick l0_file
-                picked_time_range = l0_file_remained_tr_last;
+                picked_time_range = l0_file_remained_tr_first;
             }
             // For well ordered lv0-files, merged to level 1
             if 0 == advised_out_level {
                 *l0_file_compacting = true;
                 picked_l0_compacting_wlocks.push(l0_file_compacting);
                 picked_l0_files.push(l0_file.clone());
-                picked_time_range.merge(&l0_file_remained_tr_last);
+                picked_time_range.merge(&l0_file_remained_tr_first);
                 if picked_l0_files.len() >= version.storage_opt.compact_trigger_file_num as usize {
                     info!(
                         "Picker(delta) [{}]: picked level_0 files({}) to level: 1",
@@ -410,7 +405,7 @@ impl DeltaCompactionPicker {
                     not_picked_l0_file = Some((
                         l0_file.clone(),
                         advised_out_level,
-                        l0_file_remained_tr_last,
+                        l0_file_remained_tr_first,
                         l0_file_compacting,
                     ));
                 } else {

--- a/tskv/src/database.rs
+++ b/tskv/src/database.rs
@@ -87,13 +87,18 @@ impl Database {
             ver.clone(),
             self.opt.cache.clone(),
             self.opt.storage.clone(),
-            flush_task_sender,
+            flush_task_sender.clone(),
             compact_task_sender.clone(),
             self.memory_pool.clone(),
             &self.metrics_register,
         );
         let tf_ref = Arc::new(RwLock::new(tf));
-        schedule_vnode_compaction(self.runtime.clone(), tf_ref.clone(), compact_task_sender);
+        schedule_vnode_compaction(
+            self.runtime.clone(),
+            tf_ref.clone(),
+            flush_task_sender,
+            compact_task_sender,
+        );
 
         self.ts_families.insert(ver.tf_id(), tf_ref);
     }
@@ -179,7 +184,7 @@ impl Database {
             ver,
             self.opt.cache.clone(),
             self.opt.storage.clone(),
-            flush_task_sender,
+            flush_task_sender.clone(),
             compact_task_sender.clone(),
             self.memory_pool.clone(),
             &self.metrics_register,
@@ -189,7 +194,12 @@ impl Database {
         if let Some(tsf) = self.ts_families.get(&tsf_id) {
             return Ok(tsf.clone());
         }
-        schedule_vnode_compaction(self.runtime.clone(), tf.clone(), compact_task_sender);
+        schedule_vnode_compaction(
+            self.runtime.clone(),
+            tf.clone(),
+            flush_task_sender,
+            compact_task_sender,
+        );
         self.ts_families.insert(tsf_id, tf.clone());
 
         let (task_state_sender, _task_state_receiver) = oneshot::channel();

--- a/tskv/src/kv_option.rs
+++ b/tskv/src/kv_option.rs
@@ -45,6 +45,7 @@ pub struct StorageOptions {
     pub enable_compaction: bool,
     pub compact_trigger_file_num: u32,
     pub compact_trigger_cold_duration: Duration,
+    pub collect_compaction_metrics: bool,
     pub max_compact_size: u64,
     pub max_concurrent_compaction: u16,
     pub strict_write: bool,
@@ -126,6 +127,7 @@ impl From<&Config> for StorageOptions {
             compact_trigger_cold_duration: config.storage.compact_trigger_cold_duration,
             max_compact_size: config.storage.max_compact_size,
             max_concurrent_compaction: config.storage.max_concurrent_compaction,
+            collect_compaction_metrics: config.storage.collect_compaction_metrics,
             strict_write: config.storage.strict_write,
         }
     }

--- a/tskv/src/tsm/block.rs
+++ b/tskv/src/tsm/block.rs
@@ -612,84 +612,84 @@ impl DataBlock {
         }
     }
 
-    /// Merges one or many `DataBlock`s into some `DataBlock` with fixed length,
-    /// sorted by timestamp, if many (timestamp, value) conflict with the same
-    /// timestamp, use the last value.
-    pub fn merge_blocks_and_split(mut blocks: Vec<Self>, max_block_size: u32) -> Vec<Self> {
-        if blocks.len() == 1 {
-            return vec![blocks.remove(0)];
-        }
-        let (capacity, field_type) = match blocks.first() {
-            None => {
-                // blocks.len() == 0
-                return vec![];
-            }
-            Some(v) => (v.len(), v.field_type()),
-        };
-        // (data_block, data_index, data_block_len)
-        let mut buf: Vec<(DataBlock, DataType, usize, usize)> = Vec::with_capacity(blocks.len());
-        for blk in blocks {
-            if let Some(dt) = blk.get(0) {
-                let blk_len = blk.len();
-                buf.push((blk, dt, 0, blk_len));
-            }
-        }
+    // /// Merges one or many `DataBlock`s into some `DataBlock` with fixed length,
+    // /// sorted by timestamp, if many (timestamp, value) conflict with the same
+    // /// timestamp, use the last value.
+    // pub fn merge_blocks_and_split(mut blocks: Vec<Self>, max_block_size: u32) -> Vec<Self> {
+    //     if blocks.len() == 1 {
+    //         return vec![blocks.remove(0)];
+    //     }
+    //     let (capacity, field_type) = match blocks.first() {
+    //         None => {
+    //             // blocks.len() == 0
+    //             return vec![];
+    //         }
+    //         Some(v) => (v.len(), v.field_type()),
+    //     };
+    //     // (data_block, data_index, data_block_len)
+    //     let mut buf: Vec<(DataBlock, DataType, usize, usize)> = Vec::with_capacity(blocks.len());
+    //     for blk in blocks {
+    //         if let Some(dt) = blk.get(0) {
+    //             let blk_len = blk.len();
+    //             buf.push((blk, dt, 0, blk_len));
+    //         }
+    //     }
 
-        let mut blk = Self::new(capacity, field_type);
-        let mut res = vec![];
-        loop {
-            match Self::next_min(&mut buf) {
-                Some(it) => {
-                    blk.insert(it);
-                    if max_block_size != 0 && blk.len() >= max_block_size as usize {
-                        res.push(blk);
-                        blk = Self::new(capacity, field_type);
-                    }
-                }
-                None => {
-                    if !blk.is_empty() {
-                        res.push(blk);
-                    }
-                    return res;
-                }
-            }
-        }
-    }
+    //     let mut blk = Self::new(capacity, field_type);
+    //     let mut res = vec![];
+    //     loop {
+    //         match Self::next_min(&mut buf) {
+    //             Some(it) => {
+    //                 blk.insert(it);
+    //                 if max_block_size != 0 && blk.len() >= max_block_size as usize {
+    //                     res.push(blk);
+    //                     blk = Self::new(capacity, field_type);
+    //                 }
+    //             }
+    //             None => {
+    //                 if !blk.is_empty() {
+    //                     res.push(blk);
+    //                 }
+    //                 return res;
+    //             }
+    //         }
+    //     }
+    // }
 
-    pub fn merge_blocks(mut blocks: Vec<Self>) -> Option<Self> {
-        if blocks.len() == 1 {
-            return Some(blocks.remove(0));
-        }
-        let mut blk = match blocks.first() {
-            None => {
-                // blocks.len() == 0
-                return None;
-            }
-            Some(v) => {
-                let capacity = v.len();
-                let field_type = v.field_type();
-                Self::new(capacity, field_type)
-            }
-        };
-        // (data_block, data_index, data_block_len)
-        let mut buf: Vec<(DataBlock, DataType, usize, usize)> = Vec::with_capacity(blocks.len());
-        for blk in blocks {
-            if let Some(dt) = blk.get(0) {
-                let blk_len = blk.len();
-                buf.push((blk, dt, 0, blk_len));
-            }
-        }
-        loop {
-            match Self::next_min(&mut buf) {
-                Some(data) => {
-                    blk.insert(data);
-                }
-                None => {
-                    return Some(blk);
-                }
-            }
-        }
-    }
+    // pub fn merge_blocks(mut blocks: Vec<Self>) -> Option<Self> {
+    //     if blocks.len() == 1 {
+    //         return Some(blocks.remove(0));
+    //     }
+    //     let mut blk = match blocks.first() {
+    //         None => {
+    //             // blocks.len() == 0
+    //             return None;
+    //         }
+    //         Some(v) => {
+    //             let capacity = v.len();
+    //             let field_type = v.field_type();
+    //             Self::new(capacity, field_type)
+    //         }
+    //     };
+    //     // (data_block, data_index, data_block_len)
+    //     let mut buf: Vec<(DataBlock, DataType, usize, usize)> = Vec::with_capacity(blocks.len());
+    //     for blk in blocks {
+    //         if let Some(dt) = blk.get(0) {
+    //             let blk_len = blk.len();
+    //             buf.push((blk, dt, 0, blk_len));
+    //         }
+    //     }
+    //     loop {
+    //         match Self::next_min(&mut buf) {
+    //             Some(data) => {
+    //                 blk.insert(data);
+    //             }
+    //             None => {
+    //                 return Some(blk);
+    //             }
+    //         }
+    //     }
+    // }
 
     /// Extract `DataBlock`s to `DataType`s,
     /// returns the minimum timestamp in a series of `DataBlock`s
@@ -1286,54 +1286,54 @@ pub mod test {
         }
     }
 
-    #[test]
-    #[rustfmt::skip]
-    fn test_merge_multiple_blocks() {
-        let res = DataBlock::merge_blocks_and_split(
-            vec![
-                DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 12, 13, 14, 15], enc: DataBlockEncoding::default() },
-                DataBlock::U64 { ts: vec![2, 3, 4], val: vec![22, 23, 24], enc: DataBlockEncoding::default() },
-            ],
-            0,
-        );
-        assert_eq!(res, vec![
-            DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 22, 23, 24, 15], enc: DataBlockEncoding::default() },
-        ]);
+    // #[test]
+    // #[rustfmt::skip]
+    // fn test_merge_multiple_blocks() {
+    //     let res = DataBlock::merge_blocks_and_split(
+    //         vec![
+    //             DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 12, 13, 14, 15], enc: DataBlockEncoding::default() },
+    //             DataBlock::U64 { ts: vec![2, 3, 4], val: vec![22, 23, 24], enc: DataBlockEncoding::default() },
+    //         ],
+    //         0,
+    //     );
+    //     assert_eq!(res, vec![
+    //         DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 22, 23, 24, 15], enc: DataBlockEncoding::default() },
+    //     ]);
 
-        let res = DataBlock::merge_blocks_and_split(
-            vec![
-                DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 12, 13, 14, 15], enc: DataBlockEncoding::default() },
-                DataBlock::U64 { ts: vec![2, 3, 4], val: vec![22, 23, 24], enc: DataBlockEncoding::default() },
-            ],
-            3,
-        );
-        assert_eq!(res, vec![
-            DataBlock::U64 { ts: vec![1, 2, 3], val: vec![11, 22, 23], enc: DataBlockEncoding::default() },
-            DataBlock::U64 { ts: vec![4, 5], val: vec![24, 15], enc: DataBlockEncoding::default() },
-        ]);
+    //     let res = DataBlock::merge_blocks_and_split(
+    //         vec![
+    //             DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 12, 13, 14, 15], enc: DataBlockEncoding::default() },
+    //             DataBlock::U64 { ts: vec![2, 3, 4], val: vec![22, 23, 24], enc: DataBlockEncoding::default() },
+    //         ],
+    //         3,
+    //     );
+    //     assert_eq!(res, vec![
+    //         DataBlock::U64 { ts: vec![1, 2, 3], val: vec![11, 22, 23], enc: DataBlockEncoding::default() },
+    //         DataBlock::U64 { ts: vec![4, 5], val: vec![24, 15], enc: DataBlockEncoding::default() },
+    //     ]);
 
-        let blk = DataBlock::merge_blocks(
-            vec![
-                DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 12, 13, 14, 15], enc: DataBlockEncoding::default() },
-                DataBlock::U64 { ts: vec![2, 3, 4], val: vec![22, 23, 24], enc: DataBlockEncoding::default() },
-            ],
-        );
-        assert_eq!(
-            blk.unwrap(),
-            DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 22, 23, 24, 15], enc: DataBlockEncoding::default() },
-        );
+    //     let blk = DataBlock::merge_blocks(
+    //         vec![
+    //             DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 12, 13, 14, 15], enc: DataBlockEncoding::default() },
+    //             DataBlock::U64 { ts: vec![2, 3, 4], val: vec![22, 23, 24], enc: DataBlockEncoding::default() },
+    //         ],
+    //     );
+    //     assert_eq!(
+    //         blk.unwrap(),
+    //         DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 22, 23, 24, 15], enc: DataBlockEncoding::default() },
+    //     );
 
-        let blk = DataBlock::merge_blocks(
-            vec![
-                DataBlock::U64 { ts: vec![1, 3, 5, 7], val: vec![11, 13, 15, 17], enc: DataBlockEncoding::default() },
-                DataBlock::U64 { ts: vec![2, 4, 6], val: vec![22, 24, 26], enc: DataBlockEncoding::default() },
-            ],
-        );
-        assert_eq!(
-            blk.unwrap(),
-            DataBlock::U64 { ts: vec![1, 2, 3, 4, 5, 6, 7], val: vec![11, 22, 13, 24, 15, 26, 17], enc: DataBlockEncoding::default() },
-        );
-    }
+    //     let blk = DataBlock::merge_blocks(
+    //         vec![
+    //             DataBlock::U64 { ts: vec![1, 3, 5, 7], val: vec![11, 13, 15, 17], enc: DataBlockEncoding::default() },
+    //             DataBlock::U64 { ts: vec![2, 4, 6], val: vec![22, 24, 26], enc: DataBlockEncoding::default() },
+    //         ],
+    //     );
+    //     assert_eq!(
+    //         blk.unwrap(),
+    //         DataBlock::U64 { ts: vec![1, 2, 3, 4, 5, 6, 7], val: vec![11, 22, 13, 24, 15, 26, 17], enc: DataBlockEncoding::default() },
+    //     );
+    // }
 
     #[test]
     fn test_merge_blocks() {

--- a/tskv/src/tsm/block.rs
+++ b/tskv/src/tsm/block.rs
@@ -5,7 +5,6 @@ use std::fmt::{Debug, Display, Formatter};
 use minivec::MiniVec;
 use models::predicate::domain::{TimeRange, TimeRanges};
 use models::{Timestamp, ValueType};
-use trace::error;
 
 use crate::memcache::DataType;
 use crate::tsm::codec::{
@@ -389,6 +388,8 @@ impl DataBlock {
 
     /// Extend self with a range of timestamps and vlaues in the other.
     fn extend_slice(&mut self, other: &Self, range: std::ops::Range<usize>) {
+        let old_len = self.len();
+        let new_len = old_len + (range.end - range.start);
         match (self, other) {
             (
                 DataBlock::U64 {
@@ -398,8 +399,10 @@ impl DataBlock {
                     ts: tb, val: vb, ..
                 },
             ) => {
-                ta.extend_from_slice(&tb[range.start..range.end]);
-                va.extend_from_slice(&vb[range.start..range.end]);
+                ta.resize(new_len, 0);
+                va.resize(new_len, 0);
+                ta[old_len..].copy_from_slice(&tb[range.start..range.end]);
+                va[old_len..].copy_from_slice(&vb[range.start..range.end]);
             }
             (
                 DataBlock::I64 {
@@ -409,8 +412,10 @@ impl DataBlock {
                     ts: tb, val: vb, ..
                 },
             ) => {
-                ta.extend_from_slice(&tb[range.start..range.end]);
-                va.extend_from_slice(&vb[range.start..range.end]);
+                ta.resize(new_len, 0);
+                va.resize(new_len, 0);
+                ta[old_len..].copy_from_slice(&tb[range.start..range.end]);
+                va[old_len..].copy_from_slice(&vb[range.start..range.end]);
             }
             (
                 DataBlock::Str {
@@ -420,7 +425,9 @@ impl DataBlock {
                     ts: tb, val: vb, ..
                 },
             ) => {
-                ta.extend_from_slice(&tb[range.start..range.end]);
+                ta.resize(new_len, 0);
+                va.reserve(new_len);
+                ta[old_len..].copy_from_slice(&tb[range.start..range.end]);
                 va.extend_from_slice(&vb[range.start..range.end]);
             }
             (
@@ -431,8 +438,10 @@ impl DataBlock {
                     ts: tb, val: vb, ..
                 },
             ) => {
-                ta.extend_from_slice(&tb[range.start..range.end]);
-                va.extend_from_slice(&vb[range.start..range.end]);
+                ta.resize(new_len, 0);
+                va.resize(new_len, 0.0);
+                ta[old_len..].copy_from_slice(&tb[range.start..range.end]);
+                va[old_len..].copy_from_slice(&vb[range.start..range.end]);
             }
             (
                 DataBlock::Bool {
@@ -442,8 +451,10 @@ impl DataBlock {
                     ts: tb, val: vb, ..
                 },
             ) => {
-                ta.extend_from_slice(&tb[range.start..range.end]);
-                va.extend_from_slice(&vb[range.start..range.end]);
+                ta.resize(new_len, 0);
+                va.resize(new_len, false);
+                ta[old_len..].copy_from_slice(&tb[range.start..range.end]);
+                va[old_len..].copy_from_slice(&vb[range.start..range.end]);
             }
             _ => {}
         }
@@ -605,43 +616,34 @@ impl DataBlock {
     /// sorted by timestamp, if many (timestamp, value) conflict with the same
     /// timestamp, use the last value.
     pub fn merge_blocks_and_split(mut blocks: Vec<Self>, max_block_size: u32) -> Vec<Self> {
-        if blocks.is_empty() {
-            return vec![];
-        }
         if blocks.len() == 1 {
             return vec![blocks.remove(0)];
         }
-        let data_blocks = match blocks.first() {
+        let (capacity, field_type) = match blocks.first() {
             None => {
-                error!("failed to get data block");
+                // blocks.len() == 0
                 return vec![];
             }
-            Some(v) => v,
+            Some(v) => (v.len(), v.field_type()),
         };
-        let capacity = data_blocks.len();
-        let field_type = data_blocks.field_type();
+        // (data_block, data_index, data_block_len)
+        let mut buf: Vec<(DataBlock, DataType, usize, usize)> = Vec::with_capacity(blocks.len());
+        for blk in blocks {
+            if let Some(dt) = blk.get(0) {
+                let blk_len = blk.len();
+                buf.push((blk, dt, 0, blk_len));
+            }
+        }
 
-        let mut res = vec![];
         let mut blk = Self::new(capacity, field_type);
-        let mut buf = vec![None; blocks.len()];
-        let mut offsets = vec![0_usize; blocks.len()];
+        let mut res = vec![];
         loop {
-            match Self::next_min(&mut blocks, &mut buf, &mut offsets) {
-                Some(min) => {
-                    let mut data = None;
-                    for item in &mut buf {
-                        if let Some(it) = item {
-                            if it.timestamp() == min {
-                                data = item.take();
-                            }
-                        }
-                    }
-                    if let Some(it) = data {
-                        blk.insert(it);
-                        if max_block_size != 0 && blk.len() >= max_block_size as usize {
-                            res.push(blk);
-                            blk = Self::new(capacity, field_type);
-                        }
+            match Self::next_min(&mut buf) {
+                Some(it) => {
+                    blk.insert(it);
+                    if max_block_size != 0 && blk.len() >= max_block_size as usize {
+                        res.push(blk);
+                        blk = Self::new(capacity, field_type);
                     }
                 }
                 None => {
@@ -655,38 +657,32 @@ impl DataBlock {
     }
 
     pub fn merge_blocks(mut blocks: Vec<Self>) -> Option<Self> {
-        if blocks.is_empty() {
-            return None;
-        }
         if blocks.len() == 1 {
             return Some(blocks.remove(0));
         }
-        let data_blocks = match blocks.first() {
+        let mut blk = match blocks.first() {
             None => {
+                // blocks.len() == 0
                 return None;
             }
-            Some(v) => v,
+            Some(v) => {
+                let capacity = v.len();
+                let field_type = v.field_type();
+                Self::new(capacity, field_type)
+            }
         };
-        let capacity = data_blocks.len();
-        let field_type = data_blocks.field_type();
-
-        let mut blk = Self::new(capacity, field_type);
-        let mut buf = vec![None; blocks.len()];
-        let mut offsets = vec![0_usize; blocks.len()];
+        // (data_block, data_index, data_block_len)
+        let mut buf: Vec<(DataBlock, DataType, usize, usize)> = Vec::with_capacity(blocks.len());
+        for blk in blocks {
+            if let Some(dt) = blk.get(0) {
+                let blk_len = blk.len();
+                buf.push((blk, dt, 0, blk_len));
+            }
+        }
         loop {
-            match Self::next_min(&mut blocks, &mut buf, &mut offsets) {
-                Some(min) => {
-                    let mut data = None;
-                    for item in &mut buf {
-                        if let Some(it) = item {
-                            if it.timestamp() == min {
-                                data = item.take();
-                            }
-                        }
-                    }
-                    if let Some(it) = data {
-                        blk.insert(it);
-                    }
+            match Self::next_min(&mut buf) {
+                Some(data) => {
+                    blk.insert(data);
                 }
                 None => {
                     return Some(blk);
@@ -697,25 +693,41 @@ impl DataBlock {
 
     /// Extract `DataBlock`s to `DataType`s,
     /// returns the minimum timestamp in a series of `DataBlock`s
-    fn next_min(
-        blocks: &mut [Self],
-        dst: &mut [Option<DataType>],
-        offsets: &mut [usize],
-    ) -> Option<Timestamp> {
-        let mut min_ts = None;
-        for (i, (block, dst)) in blocks.iter_mut().zip(dst).enumerate() {
-            if dst.is_none() {
-                *dst = block.get(offsets[i]);
-                offsets[i] += 1;
+    fn next_min(buffers: &mut [(DataBlock, DataType, usize, usize)]) -> Option<DataType> {
+        let (mut exists_min_ts, mut min_buf_idx, mut min_ts) = (false, 0_usize, i64::MAX);
+        for (i, (_, blk_data, blk_idx, blk_len)) in buffers.iter_mut().enumerate() {
+            if blk_idx >= blk_len {
+                continue;
             }
-
-            if let Some(pair) = dst {
-                min_ts = min_ts
-                    .map(|ts| min(pair.timestamp(), ts))
-                    .or_else(|| Some(pair.timestamp()));
-            };
+            let ts = blk_data.timestamp();
+            if min_ts >= ts {
+                exists_min_ts = true;
+                min_buf_idx = i;
+                min_ts = ts;
+            }
         }
-        min_ts
+        if exists_min_ts {
+            if min_buf_idx > 0 {
+                for (blk, blk_data, blk_idx, _) in &mut buffers[..min_buf_idx] {
+                    if blk_data.timestamp() == min_ts {
+                        *blk_idx += 1;
+                        if let Some(d) = blk.get(*blk_idx) {
+                            *blk_data = d;
+                        }
+                    }
+                }
+            }
+            let (blk, blk_data, blk_idx, _) = &mut buffers[min_buf_idx];
+            *blk_idx += 1;
+            let mut other_data_type = blk
+                .get(*blk_idx)
+                .unwrap_or_else(|| DataType::Bool(0, false));
+            std::mem::swap(blk_data, &mut other_data_type);
+
+            Some(other_data_type)
+        } else {
+            None
+        }
     }
 
     /// Remove (ts, val) in this `DatBlock` where index is greater equal than `min`
@@ -1275,45 +1287,51 @@ pub mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_merge_multiple_blocks() {
-        #[rustfmt::skip]
         let res = DataBlock::merge_blocks_and_split(
             vec![
-                DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![10, 20, 30, 40, 50], enc: DataBlockEncoding::default() },
-                DataBlock::U64 { ts: vec![2, 3, 4], val: vec![12, 13, 15], enc: DataBlockEncoding::default() },
+                DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 12, 13, 14, 15], enc: DataBlockEncoding::default() },
+                DataBlock::U64 { ts: vec![2, 3, 4], val: vec![22, 23, 24], enc: DataBlockEncoding::default() },
             ],
             0,
         );
-        #[rustfmt::skip]
         assert_eq!(res, vec![
-            DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![10, 12, 13, 15, 50], enc: DataBlockEncoding::default() },
+            DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 22, 23, 24, 15], enc: DataBlockEncoding::default() },
         ]);
 
-        #[rustfmt::skip]
         let res = DataBlock::merge_blocks_and_split(
             vec![
-                DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![10, 20, 30, 40, 50], enc: DataBlockEncoding::default() },
-                DataBlock::U64 { ts: vec![2, 3, 4], val: vec![12, 13, 15], enc: DataBlockEncoding::default() },
+                DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 12, 13, 14, 15], enc: DataBlockEncoding::default() },
+                DataBlock::U64 { ts: vec![2, 3, 4], val: vec![22, 23, 24], enc: DataBlockEncoding::default() },
             ],
             3,
         );
-        #[rustfmt::skip]
         assert_eq!(res, vec![
-            DataBlock::U64 { ts: vec![1, 2, 3], val: vec![10, 12, 13], enc: DataBlockEncoding::default() },
-            DataBlock::U64 { ts: vec![4, 5], val: vec![15, 50], enc: DataBlockEncoding::default() },
+            DataBlock::U64 { ts: vec![1, 2, 3], val: vec![11, 22, 23], enc: DataBlockEncoding::default() },
+            DataBlock::U64 { ts: vec![4, 5], val: vec![24, 15], enc: DataBlockEncoding::default() },
         ]);
 
-        #[rustfmt::skip]
         let blk = DataBlock::merge_blocks(
             vec![
-                DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![10, 20, 30, 40, 50], enc: DataBlockEncoding::default() },
-                DataBlock::U64 { ts: vec![2, 3, 4], val: vec![12, 13, 15], enc: DataBlockEncoding::default() },
+                DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 12, 13, 14, 15], enc: DataBlockEncoding::default() },
+                DataBlock::U64 { ts: vec![2, 3, 4], val: vec![22, 23, 24], enc: DataBlockEncoding::default() },
             ],
         );
-        #[rustfmt::skip]
         assert_eq!(
             blk.unwrap(),
-            DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![10, 12, 13, 15, 50], enc: DataBlockEncoding::default() },
+            DataBlock::U64 { ts: vec![1, 2, 3, 4, 5], val: vec![11, 22, 23, 24, 15], enc: DataBlockEncoding::default() },
+        );
+
+        let blk = DataBlock::merge_blocks(
+            vec![
+                DataBlock::U64 { ts: vec![1, 3, 5, 7], val: vec![11, 13, 15, 17], enc: DataBlockEncoding::default() },
+                DataBlock::U64 { ts: vec![2, 4, 6], val: vec![22, 24, 26], enc: DataBlockEncoding::default() },
+            ],
+        );
+        assert_eq!(
+            blk.unwrap(),
+            DataBlock::U64 { ts: vec![1, 2, 3, 4, 5, 6, 7], val: vec![11, 22, 13, 24, 15, 26, 17], enc: DataBlockEncoding::default() },
         );
     }
 


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

[//]: # (Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.)

## Compaction

Add metrics for delta compactions, to enable set config `storage.collect_compaction_metrics = true`.

## Job

Fix the concurrent compactions sometimes less than config `storage.max_concurrent_compaction`.

## Schedule

- Do not trigger normal compaction after delta_compaction.
- If a vnode has fewer delta files to trigger delta_compaction, run normal compaction on the vnode.

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

