### PR TITLE
fix: errors caused by sequential dependencies in CI

### DIFF
--- a/query_server/sqllogicaltests/cases/sys_table/usage_schema/http_metrics.slt
+++ b/query_server/sqllogicaltests/cases/sys_table/usage_schema/http_metrics.slt
@@ -1,7 +1,24 @@
 statement ok
+--#DATABASE=http_metrics_pre
+
+statement ok
+--#CHUNKED=true
+
+statement ok
+DROP DATABASE IF EXISTS http_metrics_pre;
+
+statement ok
+CREATE DATABASE http_metrics_pre WITH TTL '100000d';
+
+statement ok
+--#LP_BEGIN
+m0,t0=t0 f0=false,f1=0.0 0
+--#LP_END
+
+statement ok
 --#DATABASE = usage_schema
 
-sleep 100ms
+sleep 8000ms
 query 
 DESCRIBE DATABASE usage_schema;
 ----


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

The issue with http_metric was encountered when the test was converted to sqllogictest about 2 months ago. The problem is that http_metric has dependencies, but the order of executing sqllogictest in the query_server/sqllogicaltests/src/main.rs based on std::fs::read_dir depends on the operating system. While it runs stably on the local macOS environment, the CI system running on x86 architecture occasionally encounters issues.

To address this, http_metric has added the following:
```
--#LP_BEGIN
m0,t0=t0 f0=false,f1=0.0 0
--#LP_BEGIN
```
and increased the sleep time to ensure that it can run independently and pass the tests.[1]


# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

