### PR TITLE
refactor: Error code serialization supports cross-node transmission.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4392,6 +4392,8 @@ dependencies = [
  "prost-build",
  "protobuf 3.2.0",
  "rand",
+ "serde",
+ "serde_json",
  "snafu",
  "tonic 0.9.2",
  "tonic-build",

--- a/common/protos/Cargo.toml
+++ b/common/protos/Cargo.toml
@@ -12,6 +12,8 @@ flatbuffers = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
 snafu = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tonic = { workspace = true, features = ["transport", "tls"] }
 tower = { workspace = true }
 protobuf = { workspace = true }

--- a/common/protos/src/lib.rs
+++ b/common/protos/src/lib.rs
@@ -1,5 +1,6 @@
 mod generated;
 pub use generated::*;
+use serde::{Deserialize, Serialize};
 use tonic::codec::CompressionEncoding;
 pub mod models_helper;
 pub mod prompb;
@@ -21,7 +22,7 @@ pub const DEFAULT_GRPC_SERVER_MESSAGE_LEN: usize = 100 * 1024 * 1024;
 
 type PointsResult<T> = Result<T, PointsError>;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, Snafu, Serialize, Deserialize)]
 #[snafu(visibility(pub))]
 pub enum PointsError {
     #[snafu(display("{}", msg))]

--- a/coordinator/src/raft/writer.rs
+++ b/coordinator/src/raft/writer.rs
@@ -34,11 +34,11 @@ impl TskvRaftWriter {
                 raft_write_command::Command::WriteData(request) => {
                     let fb_points = flatbuffers::root::<protos::models::Points>(&request.data)
                         .map_err(|err| CoordinatorError::TskvError {
-                            source: tskv::TskvError::InvalidFlatbuffer { source: err },
+                            msg: err.to_string(),
                         })?;
 
                     let _ = fb_points.tables().ok_or(CoordinatorError::TskvError {
-                        source: tskv::TskvError::InvalidPointTable,
+                        msg: "Table name can't be empty".to_string(),
                     })?;
 
                     if request.data.len()
@@ -47,7 +47,7 @@ impl TskvRaftWriter {
                             .saturating_sub(self.memory_pool.reserved())
                     {
                         return Err(CoordinatorError::TskvError {
-                            source: tskv::TskvError::MemoryExhausted,
+                            msg: "Memory Exhausted Retry Later".to_string(),
                         });
                     }
                 }

--- a/coordinator/src/reader/deserialize.rs
+++ b/coordinator/src/reader/deserialize.rs
@@ -29,7 +29,7 @@ impl Stream for TonicRecordBatchDecoder {
                 Err(err) => Poll::Ready(Some(Err(err.into()))),
             },
             Some(Err(err)) => Poll::Ready(Some(Err(CoordinatorError::TskvError {
-                source: err.into(),
+                msg: err.to_string(),
             }))),
             None => Poll::Ready(None),
         }

--- a/coordinator/src/service.rs
+++ b/coordinator/src/service.rs
@@ -513,7 +513,7 @@ impl CoordService {
         let data = self.admin_command_on_node(node_id, request).await?;
         match record_batch_decode(&data) {
             Ok(r) => Ok(r),
-            Err(e) => Err(CoordinatorError::ArrowError { source: e }),
+            Err(e) => Err(CoordinatorError::ArrowError { msg: e.to_string() }),
         }
     }
 
@@ -839,7 +839,7 @@ impl Coordinator for CoordService {
 
             if !has_fileds {
                 return Err(CoordinatorError::TskvError {
-                    source: TskvError::FieldsIsEmpty,
+                    msg: "Fields can't be empty".to_string(),
                 });
             }
 

--- a/replication/src/errors.rs
+++ b/replication/src/errors.rs
@@ -68,6 +68,12 @@ pub enum ReplicationError {
     AlreadyShutdown { id: ReplicationSetId },
 }
 
+impl ReplicationError {
+    pub fn error_code(&self) -> &dyn ErrorCode {
+        self
+    }
+}
+
 impl From<std::io::Error> for ReplicationError {
     fn from(err: std::io::Error) -> Self {
         ReplicationError::StorageErr {


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

**Error code serialization supports cross-node transmission, and tries to avoid losing error types as much as possible.**
To directly serialize the error codes, we need to recursively serialize the nested errors and add the serialized data to the error's drive field. For third-party errors that are not supported, we directly convert the error message to a String type in the CoordinateError object. Then we serialize the entire structure directly into the data field of the BatchBytesResponse."
# Rationale for this change

[//]: # (Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.)

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

