### PR TITLE
Feature(e2e_test):  new api of e2e executor; add case 'data lost after compaction and restart'

### DIFF
--- a/e2e_test/src/case/executor.rs
+++ b/e2e_test/src/case/executor.rs
@@ -1,19 +1,22 @@
-#![allow(dead_code)]
-
+use core::panic;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::runtime::Runtime;
 
+use super::step::Step;
+use super::{CaseFlowControl, CnosdbAuth};
 use crate::cluster_def::{CnosdbClusterDefinition, DataNodeDefinition};
-use crate::utils::{kill_all, run_cluster, run_singleton, Client, CnosdbDataTestHelper};
-use crate::{E2eError, E2eResult};
+use crate::utils::{
+    kill_all, run_cluster, run_singleton, Client, CnosdbDataTestHelper, CnosdbMetaTestHelper,
+};
+use crate::E2eResult;
 
 const WAIT_BEFORE_RESTART_SECONDS: u64 = 1;
 
-// TODO(zipper): This module also need test.
-// TODO(zipper): Test the following scenarios: 1. todo
+// TODO(zipper): This module also needs test.
 
 pub struct E2eExecutor {
     case_group: String,
@@ -68,50 +71,76 @@ impl E2eExecutor {
         )
     }
 
-    pub fn execute_steps(&self, steps: &[Step]) {
-        println!("Test begin: {}_{}", self.case_group, self.case_name);
-        if self.is_singleton {
-            self.execute_steps_in_singleton(steps);
-        } else {
-            self.execute_steps_in_cluster(steps);
-        }
-        println!("Test complete: {}.{}", self.case_group, self.case_name);
-    }
-
-    fn execute_steps_in_singleton(&self, steps: &[Step]) {
+    fn install_singleton(&self) -> CnosdbDataTestHelper {
         let _ = std::fs::remove_dir_all(&self.test_dir);
         std::fs::create_dir_all(&self.test_dir).unwrap();
 
         kill_all();
 
-        let mut data = run_singleton(
+        run_singleton(
             &self.test_dir,
             &self.cluster_definition.data_cluster_def[0],
             false,
             true,
-        );
-        self.execute_steps_inner(&mut data, steps);
+        )
     }
 
-    fn execute_steps_in_cluster(&self, steps: &[Step]) {
+    fn install_cluster(&self) -> (Option<CnosdbMetaTestHelper>, Option<CnosdbDataTestHelper>) {
         let _ = std::fs::remove_dir_all(&self.test_dir);
         std::fs::create_dir_all(&self.test_dir).unwrap();
 
         kill_all();
 
-        let (_meta, data) = run_cluster(
+        run_cluster(
             &self.test_dir,
             self.runtime.clone(),
             &self.cluster_definition,
             true,
             true,
-        );
-        let mut data = data.unwrap();
-        self.execute_steps_inner(&mut data, steps);
+        )
     }
 
-    fn execute_steps_inner(&self, data: &mut CnosdbDataTestHelper, steps: &[Step]) {
-        let fail_msg = |i: usize, step: &Step, result: &E2eResult<Vec<String>>| {
+    pub fn execute_steps(&self, steps: &[Box<dyn Step>]) {
+        println!("Test begin: {}_{}", self.case_group, self.case_name);
+
+        let mut context = E2eContext::from(self);
+        if self.is_singleton {
+            let data = self.install_singleton();
+            context.with_data(Some(data));
+        } else {
+            let (meta, data) = self.install_cluster();
+            context.with_meta(meta);
+            context.with_data(data);
+        }
+
+        for step in steps {
+            println!("- Executing step: [{}]-{}", step.id(), step.name());
+            match step.execute(&mut context) {
+                CaseFlowControl::Continue => continue,
+                CaseFlowControl::Break => break,
+            }
+        }
+
+        println!("Test complete: {}.{}", self.case_group, self.case_name);
+    }
+
+    #[deprecated]
+    pub fn execute_steps_legacy(&self, steps: &[StepLegacy]) {
+        println!("Test begin: {}_{}", self.case_group, self.case_name);
+        if self.is_singleton {
+            let mut data = self.install_singleton();
+            self.execute_steps_legacy_inner(&mut data, steps);
+        } else {
+            let (_meta, data) = self.install_cluster();
+            let mut data = data.unwrap();
+            self.execute_steps_legacy_inner(&mut data, steps);
+        }
+        println!("Test complete: {}.{}", self.case_group, self.case_name);
+    }
+
+    #[deprecated]
+    fn execute_steps_legacy_inner(&self, data: &mut CnosdbDataTestHelper, steps: &[StepLegacy]) {
+        let fail_msg = |i: usize, step: &StepLegacy, result: &E2eResult<Vec<String>>| {
             format!(
                 "[{}.{}] steps[{i}] [{step}], result: {result:?}",
                 &self.case_group, &self.case_name
@@ -120,8 +149,8 @@ impl E2eExecutor {
         for (i, step) in steps.iter().enumerate() {
             println!("- Executing step: {step}");
             match step {
-                Step::Log(msg) => println!("LOG: {}", msg),
-                Step::CnosdbRequest { req, auth } => {
+                StepLegacy::Log(msg) => println!("LOG: {}", msg),
+                StepLegacy::CnosdbRequest { req, auth } => {
                     let client = match auth {
                         Some(a) => {
                             Arc::new(Client::with_auth(a.username.clone(), a.password.clone()))
@@ -159,8 +188,9 @@ impl E2eExecutor {
                                         "{}",
                                         fail_msg(i, step, &result_resp)
                                     );
-                                    assert!(
-                                        compare_e2e_error(exp_err, &result_resp.unwrap_err()),
+                                    assert_eq!(
+                                        exp_err,
+                                        &result_resp.unwrap_err(),
                                         "{fail_message}"
                                     );
                                 }
@@ -173,8 +203,9 @@ impl E2eExecutor {
                                 Ok(_) => assert!(result_resp.is_ok(), "{fail_message}"),
                                 Err(exp_err) => {
                                     assert!(result_resp.is_err(), "{fail_message}");
-                                    assert!(
-                                        compare_e2e_error(exp_err, &result_resp.unwrap_err()),
+                                    assert_eq!(
+                                        exp_err,
+                                        &result_resp.unwrap_err(),
                                         "{fail_message}"
                                     );
                                 }
@@ -187,8 +218,9 @@ impl E2eExecutor {
                                 Ok(_) => assert!(result_resp.is_ok(), "{fail_message}"),
                                 Err(exp_err) => {
                                     assert!(result_resp.is_err(), "{fail_message}");
-                                    assert!(
-                                        compare_e2e_error(exp_err, &result_resp.unwrap_err()),
+                                    assert_eq!(
+                                        exp_err,
+                                        &result_resp.unwrap_err(),
                                         "{fail_message}"
                                     );
                                 }
@@ -201,8 +233,9 @@ impl E2eExecutor {
                                 Ok(_) => assert!(result_resp.is_ok(), "{fail_message}"),
                                 Err(exp_err) => {
                                     assert!(result_resp.is_err(), "{fail_message}");
-                                    assert!(
-                                        compare_e2e_error(exp_err, &result_resp.unwrap_err()),
+                                    assert_eq!(
+                                        exp_err,
+                                        &result_resp.unwrap_err(),
                                         "{fail_message}"
                                     );
                                 }
@@ -210,7 +243,7 @@ impl E2eExecutor {
                         }
                     }
                 }
-                Step::RestartDataNode(data_node_index) => {
+                StepLegacy::RestartDataNode(data_node_index) => {
                     if WAIT_BEFORE_RESTART_SECONDS > 0 {
                         // TODO(zipper): The test sometimes fail if we restart just after a DDL or Insert, why?
                         std::thread::sleep(Duration::from_secs(WAIT_BEFORE_RESTART_SECONDS));
@@ -218,15 +251,15 @@ impl E2eExecutor {
                     let data_node_def = data.data_node_definitions[*data_node_index].clone();
                     data.restart_one_node(&data_node_def);
                 }
-                Step::StartDataNode(data_node_index) => {
+                StepLegacy::StartDataNode(data_node_index) => {
                     let data_node_def = data.data_node_definitions[*data_node_index].clone();
                     data.start_one_node(&data_node_def);
                 }
-                Step::StopDataNode(data_node_index) => {
+                StepLegacy::StopDataNode(data_node_index) => {
                     let data_node_def = data.data_node_definitions[*data_node_index].clone();
                     data.stop_one_node(&data_node_def.config_file_name, false);
                 }
-                Step::RestartCluster => {
+                StepLegacy::RestartCluster => {
                     kill_all();
                     run_cluster(
                         &self.test_dir,
@@ -236,7 +269,7 @@ impl E2eExecutor {
                         false,
                     );
                 }
-                Step::Sleep(seconds) => {
+                StepLegacy::Sleep(seconds) => {
                     std::thread::sleep(Duration::from_secs(*seconds));
                 }
             }
@@ -244,9 +277,154 @@ impl E2eExecutor {
     }
 }
 
+pub struct E2eContext {
+    case_group: String,
+    case_name: String,
+    runtime: Arc<Runtime>,
+    cluster_definition: CnosdbClusterDefinition,
+
+    test_dir: PathBuf,
+    meta: Option<CnosdbMetaTestHelper>,
+    data: Option<CnosdbDataTestHelper>,
+    global_variables: HashMap<String, String>,
+    context_variables: HashMap<String, String>,
+    last_step_variables: HashMap<String, String>,
+}
+
+impl E2eContext {
+    pub fn case_group(&self) -> &str {
+        &self.case_group
+    }
+
+    pub fn case_name(&self) -> &str {
+        &self.case_name
+    }
+
+    pub fn runtime(&self) -> Arc<Runtime> {
+        self.runtime.clone()
+    }
+
+    pub fn cluster_definition(&self) -> &CnosdbClusterDefinition {
+        &self.cluster_definition
+    }
+
+    pub fn test_dir(&self) -> &PathBuf {
+        &self.test_dir
+    }
+
+    pub fn with_meta(&mut self, meta: Option<CnosdbMetaTestHelper>) {
+        self.meta = meta;
+    }
+
+    pub fn meta_opt(&self) -> Option<&CnosdbMetaTestHelper> {
+        self.meta.as_ref()
+    }
+
+    pub fn meta(&self) -> &CnosdbMetaTestHelper {
+        match self.meta_opt() {
+            Some(d) => d,
+            None => panic!("Cnosdb meta server is not in the e2e context"),
+        }
+    }
+
+    pub fn meta_mut(&mut self) -> &mut CnosdbMetaTestHelper {
+        match self.meta.as_mut() {
+            Some(d) => d,
+            None => panic!("Cnosdb meta server is not in the e2e context"),
+        }
+    }
+
+    pub fn with_data(&mut self, data: Option<CnosdbDataTestHelper>) {
+        self.data = data;
+    }
+
+    pub fn data_opt(&self) -> Option<&CnosdbDataTestHelper> {
+        self.data.as_ref()
+    }
+
+    pub fn data(&self) -> &CnosdbDataTestHelper {
+        match self.data_opt() {
+            Some(d) => d,
+            None => panic!("Cnosdb data server is not in the e2e context"),
+        }
+    }
+
+    pub fn data_mut(&mut self) -> &mut CnosdbDataTestHelper {
+        match self.data.as_mut() {
+            Some(d) => d,
+            None => panic!("Cnosdb data server is not in the e2e context"),
+        }
+    }
+
+    pub fn data_dir(&self, i: usize) -> PathBuf {
+        let config = match self.data().data_node_configs.get(i) {
+            Some(c) => c,
+            None => panic!("Data node config of index {i} not found"),
+        };
+        self.test_dir.join(&config.storage.path)
+    }
+
+    pub fn meta_client(&self) -> Arc<Client> {
+        self.meta().client.clone()
+    }
+
+    pub fn data_client(&self) -> Arc<Client> {
+        self.data().client.clone()
+    }
+
+    pub fn global_variables(&self) -> &HashMap<String, String> {
+        &self.global_variables
+    }
+
+    pub fn global_variables_mut(&mut self) -> &mut HashMap<String, String> {
+        &mut self.global_variables
+    }
+
+    pub fn context_variables(&self) -> &HashMap<String, String> {
+        &self.context_variables
+    }
+
+    pub fn context_variables_mut(&mut self) -> &mut HashMap<String, String> {
+        &mut self.context_variables
+    }
+
+    pub fn last_step_variables(&self) -> &HashMap<String, String> {
+        &self.last_step_variables
+    }
+
+    pub fn last_step_variables_mut(&mut self) -> &mut HashMap<String, String> {
+        &mut self.last_step_variables
+    }
+
+    pub fn add_context_variable(&mut self, key: &str, value: &str) {
+        self.last_step_variables
+            .insert(key.to_string(), value.to_string());
+        self.context_variables
+            .insert(key.to_string(), value.to_string());
+    }
+}
+
+impl From<&E2eExecutor> for E2eContext {
+    fn from(executor: &E2eExecutor) -> Self {
+        E2eContext {
+            case_group: executor.case_group.clone(),
+            case_name: executor.case_name.clone(),
+            runtime: executor.runtime.clone(),
+            cluster_definition: executor.cluster_definition.clone(),
+            test_dir: executor.test_dir.clone(),
+            data: None,
+            meta: None,
+            global_variables: HashMap::new(),
+            context_variables: HashMap::new(),
+            last_step_variables: HashMap::new(),
+        }
+    }
+}
+
 // TODO(zipper): Supports: 1. cli execution;
 #[derive(Debug)]
-pub enum Step {
+#[deprecated]
+pub enum StepLegacy {
     Log(String),
     CnosdbRequest {
         req: CnosdbRequest,
@@ -260,27 +438,28 @@ pub enum Step {
     Sleep(u64),
 }
 
-impl std::fmt::Display for Step {
+impl std::fmt::Display for StepLegacy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Step::Log(msg) => write!(f, "Log: {msg}"),
-            Step::CnosdbRequest { req, auth } => {
+            StepLegacy::Log(msg) => write!(f, "Log: {msg}"),
+            StepLegacy::CnosdbRequest { req, auth } => {
                 write!(f, "CnosdbRequest: {req}, ")?;
                 match auth {
                     Some(a) => write!(f, ", with auth: '{a}'"),
                     None => write!(f, "no auth"),
                 }
             }
-            Step::RestartDataNode(i) => write!(f, "RestartDataNode of data node {i}"),
-            Step::StartDataNode(i) => write!(f, "StartDataNode of data node {i}"),
-            Step::StopDataNode(i) => write!(f, "StopDataNode of data node {i}"),
-            Step::RestartCluster => write!(f, "RestartCluster"),
-            Step::Sleep(d) => write!(f, "Sleep for {d} seconds"),
+            StepLegacy::RestartDataNode(i) => write!(f, "RestartDataNode of data node {i}"),
+            StepLegacy::StartDataNode(i) => write!(f, "StartDataNode of data node {i}"),
+            StepLegacy::StopDataNode(i) => write!(f, "StopDataNode of data node {i}"),
+            StepLegacy::RestartCluster => write!(f, "RestartCluster"),
+            StepLegacy::Sleep(d) => write!(f, "Sleep for {d} seconds"),
         }
     }
 }
 
 #[derive(Debug)]
+#[deprecated]
 pub enum CnosdbRequest {
     Query {
         url: &'static str,
@@ -330,90 +509,5 @@ impl std::fmt::Display for CnosdbRequest {
                 write!(f, "DDL to '{url}', SQL: '{sql}' => {resp:?}")
             }
         }
-    }
-}
-
-#[derive(Debug)]
-pub struct CnosdbAuth {
-    pub username: String,
-    pub password: Option<String>,
-}
-
-impl std::fmt::Display for CnosdbAuth {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{username}", username = self.username)?;
-        if let Some(password) = &self.password {
-            write!(f, ":{password}")?;
-        }
-        Ok(())
-    }
-}
-
-fn compare_e2e_error(expected: &E2eError, actual: &E2eError) -> bool {
-    match (expected, actual) {
-        (E2eError::Connect(msg1), E2eError::Connect(msg2)) => msg1 == msg2,
-        (
-            E2eError::Http {
-                status: status1,
-                url: url1,
-                req: req1,
-                err: err1,
-            },
-            E2eError::Http {
-                status: status2,
-                url: url2,
-                req: req2,
-                err: err2,
-            },
-        ) => {
-            status1 == status2
-                && match (url1, url2) {
-                    (None, _) => true,
-                    (Some(u1), Some(u2)) => u1 == u2,
-                    (Some(_), None) => false,
-                }
-                && match (req1, req2) {
-                    (None, _) => true,
-                    (Some(r1), Some(r2)) => r1 == r2,
-                    (Some(_), None) => false,
-                }
-                && match (err1, err2) {
-                    (None, _) => true,
-                    (Some(e1), Some(e2)) => e1 == e2,
-                    (Some(_), None) => false,
-                }
-        }
-        (
-            E2eError::Api {
-                status: status1,
-                url: url1,
-                req: req1,
-                resp: resp1,
-            },
-            E2eError::Api {
-                status: status2,
-                url: url2,
-                req: req2,
-                resp: resp2,
-            },
-        ) => {
-            status1 == status2
-                && match (url1, url2) {
-                    (None, _) => true,
-                    (Some(u1), Some(u2)) => u1 == u2,
-                    (Some(_), None) => false,
-                }
-                && match (req1, req2) {
-                    (None, _) => true,
-                    (Some(r1), Some(r2)) => r1 == r2,
-                    (Some(_), None) => false,
-                }
-                && match (resp1, resp2) {
-                    (None, _) => true,
-                    (Some(r1), Some(r2)) => r1 == r2,
-                    (Some(_), None) => false,
-                }
-        }
-        _ => false,
     }
 }

--- a/e2e_test/src/case/mod.rs
+++ b/e2e_test/src/case/mod.rs
@@ -1,0 +1,27 @@
+#![allow(dead_code)]
+
+mod executor;
+pub mod step;
+
+pub use executor::*;
+
+pub enum CaseFlowControl {
+    Continue,
+    Break,
+}
+
+#[derive(Debug)]
+pub struct CnosdbAuth {
+    pub username: String,
+    pub password: Option<String>,
+}
+
+impl std::fmt::Display for CnosdbAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{username}", username = self.username)?;
+        if let Some(password) = &self.password {
+            write!(f, ":{password}")?;
+        }
+        Ok(())
+    }
+}

--- a/e2e_test/src/case/step.rs
+++ b/e2e_test/src/case/step.rs
@@ -1,0 +1,740 @@
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::{CaseFlowControl, CnosdbAuth, E2eContext};
+use crate::utils::{kill_all, run_cluster, Client};
+use crate::E2eResult;
+
+pub type StepResult = E2eResult<Vec<String>>;
+pub type FnStepResult = Box<dyn for<'a> Fn(&'a mut E2eContext) -> CaseFlowControl>;
+pub type FnString = Box<dyn for<'a> Fn(&'a E2eContext) -> String>;
+pub type FnStringVec = Box<dyn for<'a> Fn(&'a E2eContext) -> Vec<String>>;
+pub type FnCommand = Box<dyn for<'a> Fn(&'a E2eContext) -> Vec<Command>>;
+pub type FnGeneric<T> = Box<dyn for<'a> Fn(&'a E2eContext) -> T>;
+pub type FnVoid = Box<dyn for<'a> Fn(&'a E2eContext)>;
+pub type FnAfterRequestSucceed = Box<dyn for<'a> Fn(&'a mut E2eContext, &Vec<String>)>;
+
+pub trait Step: std::fmt::Display {
+    fn id(&self) -> usize;
+
+    fn name(&self) -> &str;
+
+    fn execute(&self, context: &mut E2eContext) -> CaseFlowControl;
+
+    fn build_fail_message(&self, context: &E2eContext, result: &StepResult) -> String {
+        format!(
+            "test[{}.{}] steps[{}-{}] [{self}], result: {result:?}",
+            context.case_group(),
+            context.case_name(),
+            self.id(),
+            self.name(),
+        )
+    }
+}
+
+pub enum StrValue {
+    Constant(String),
+    Function(FnString),
+}
+
+impl StrValue {
+    pub fn get(&self, context: &E2eContext) -> String {
+        match self {
+            StrValue::Constant(s) => s.clone(),
+            StrValue::Function(f) => f(context),
+        }
+    }
+}
+
+impl std::fmt::Display for StrValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StrValue::Constant(c) => write!(f, "{c}"),
+            StrValue::Function(_) => write!(f, "fn(&c) -> String"),
+        }
+    }
+}
+
+pub enum StrVecValue {
+    Constant(Vec<String>),
+    Function(FnStringVec),
+}
+
+impl StrVecValue {
+    pub fn get(&self, context: &E2eContext) -> Vec<String> {
+        match self {
+            StrVecValue::Constant(s) => s.clone(),
+            StrVecValue::Function(f) => f(context),
+        }
+    }
+}
+
+pub enum GenericValue<T> {
+    Constant(T),
+    Function(FnGeneric<T>),
+}
+
+impl<T: Clone> GenericValue<T> {
+    pub fn get(&self, context: &E2eContext) -> T {
+        match self {
+            Self::Constant(t) => t.clone(),
+            Self::Function(f) => f(context),
+        }
+    }
+}
+
+pub struct WrappedStep {
+    pub inner: Box<dyn Step>,
+    pub before_execute: Option<FnVoid>,
+    pub after_execute: Option<FnVoid>,
+}
+
+impl WrappedStep {
+    pub fn new(
+        inner: Box<dyn Step>,
+        before_execute: Option<FnVoid>,
+        after_execute: Option<FnVoid>,
+    ) -> Self {
+        Self {
+            inner,
+            before_execute,
+            after_execute,
+        }
+    }
+}
+
+impl Step for WrappedStep {
+    fn id(&self) -> usize {
+        self.inner.id()
+    }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn execute(&self, context: &mut E2eContext) -> CaseFlowControl {
+        if let Some(f) = &self.before_execute {
+            f(context);
+        }
+        let result = self.inner.execute(context);
+        if let Some(f) = &self.after_execute {
+            f(context);
+        }
+        result
+    }
+}
+
+impl std::fmt::Display for WrappedStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+pub struct FunctionStep {
+    id: usize,
+    name: String,
+    function: FnStepResult,
+}
+
+impl FunctionStep {
+    pub fn new(id: usize, name: String, function: FnStepResult) -> Self {
+        Self { id, name, function }
+    }
+}
+
+impl Step for FunctionStep {
+    fn id(&self) -> usize {
+        self.id
+    }
+
+    fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    fn execute(&self, context: &mut E2eContext) -> CaseFlowControl {
+        (self.function)(context)
+    }
+}
+
+impl std::fmt::Display for FunctionStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Step(function)[{}-{}]", self.id(), self.name())
+    }
+}
+
+pub struct LogStep {
+    inner: FunctionStep,
+}
+
+impl LogStep {
+    pub fn new(id: usize, msg: String) -> Self {
+        Self {
+            inner: FunctionStep::new(
+                id,
+                "Log".to_string(),
+                Box::new(move |_| {
+                    println!("LOG: {}", msg);
+                    CaseFlowControl::Continue
+                }),
+            ),
+        }
+    }
+
+    pub fn with_fn(id: usize, msg: FnString) -> Self {
+        Self {
+            inner: FunctionStep::new(
+                id,
+                "Log".to_string(),
+                Box::new(move |context| {
+                    println!("LOG: {}", msg(context));
+                    CaseFlowControl::Continue
+                }),
+            ),
+        }
+    }
+}
+
+impl Step for LogStep {
+    fn id(&self) -> usize {
+        self.inner.id()
+    }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn execute(&self, context: &mut E2eContext) -> CaseFlowControl {
+        self.inner.execute(context)
+    }
+}
+
+impl std::fmt::Display for LogStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Step(log)[{}-{}]", self.id(), self.name())
+    }
+}
+
+pub struct RequestStep {
+    id: usize,
+    name: String,
+    req: CnosdbRequest,
+    auth: Option<CnosdbAuth>,
+    after_request_succeed: Option<FnAfterRequestSucceed>,
+}
+
+impl RequestStep {
+    pub fn new<Name: ToString>(
+        id: usize,
+        name: Name,
+        req: CnosdbRequest,
+        auth: Option<CnosdbAuth>,
+        after_request_succeed: Option<FnAfterRequestSucceed>,
+    ) -> Self {
+        Self {
+            id,
+            name: name.to_string(),
+            req,
+            auth,
+            after_request_succeed,
+        }
+    }
+}
+
+impl Step for RequestStep {
+    fn id(&self) -> usize {
+        self.id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn execute(&self, context: &mut E2eContext) -> CaseFlowControl {
+        let client = match &self.auth {
+            Some(a) => Arc::new(Client::with_auth(a.username.clone(), a.password.clone())),
+            None => context.data_client(),
+        };
+        match &self.req {
+            CnosdbRequest::SqlQuery(s) => s.do_request(context, self, client.as_ref()),
+            CnosdbRequest::SqlInsert(s) => s.do_request(context, self, client.as_ref()),
+            CnosdbRequest::LineProtocol(l) => l.do_request(context, self, client.as_ref()),
+            CnosdbRequest::SqlDdl(s) => s.do_request(context, self, client.as_ref()),
+        }
+    }
+}
+
+impl std::fmt::Display for RequestStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Step(request)[{}-{}]:", self.id(), self.name())?;
+        if let Some(auth) = &self.auth {
+            write!(f, " auth:({auth}),")?;
+        } else {
+            write!(f, " auth(None),")?;
+        }
+        write!(f, " {}", self.req)
+    }
+}
+
+pub enum CnosdbRequest {
+    SqlQuery(SqlQuery),
+    SqlInsert(SqlInsert),
+    LineProtocol(LineProtocol),
+    SqlDdl(SqlDdl),
+}
+
+impl std::fmt::Display for CnosdbRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CnosdbRequest::SqlQuery(s) => write!(f, "{s}"),
+            CnosdbRequest::SqlInsert(s) => write!(f, "{s}"),
+            CnosdbRequest::LineProtocol(s) => write!(f, "{s}"),
+            CnosdbRequest::SqlDdl(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+pub struct SqlQuery {
+    pub url: StrValue,
+    pub sql: StrValue,
+    pub resp: E2eResult<StrVecValue>,
+    pub sorted: bool,
+}
+
+impl SqlQuery {
+    pub fn with_str<Url: ToString, Sql: ToString, Line: ToString>(
+        url: Url,
+        sql: Sql,
+        resp: E2eResult<Vec<Line>>,
+        sorted: bool,
+    ) -> CnosdbRequest {
+        CnosdbRequest::SqlQuery(Self {
+            url: StrValue::Constant(url.to_string()),
+            sql: StrValue::Constant(sql.to_string()),
+            resp: resp.map(|v| StrVecValue::Constant(v.iter().map(|l| l.to_string()).collect())),
+            sorted,
+        })
+    }
+
+    pub fn with_fn(
+        url: FnString,
+        sql: FnString,
+        resp: E2eResult<FnStringVec>,
+        sorted: bool,
+    ) -> CnosdbRequest {
+        CnosdbRequest::SqlQuery(Self {
+            url: StrValue::Function(url),
+            sql: StrValue::Function(sql),
+            resp: resp.map(|v| StrVecValue::Function(v)),
+            sorted,
+        })
+    }
+
+    fn do_request(
+        &self,
+        context: &mut E2eContext,
+        request: &RequestStep,
+        client: &Client,
+    ) -> CaseFlowControl {
+        let url = self.url.get(context);
+        let sql = self.sql.get(context);
+        let resp = self.resp.as_ref().map(|v| v.get(context));
+        let result_resp = client.api_v1_sql(url, &sql);
+        let fail_message = request.build_fail_message(context, &result_resp);
+        match resp {
+            Ok(exp_lines) => {
+                assert!(result_resp.is_ok(), "{fail_message}");
+                if let Ok(mut resp_lines) = result_resp {
+                    if self.sorted {
+                        resp_lines.sort_unstable();
+                    }
+                    assert_eq!(resp_lines, exp_lines.to_vec(), "{fail_message}");
+                    if let Some(f) = &request.after_request_succeed {
+                        f(context, &resp_lines);
+                    }
+                } else {
+                    assert!(result_resp.is_err(), "{fail_message}");
+                }
+            }
+            Err(exp_err) => {
+                assert!(
+                    result_resp.is_err(),
+                    "{}",
+                    request.build_fail_message(context, &result_resp)
+                );
+                assert_eq!(exp_err, &result_resp.unwrap_err(), "{fail_message}");
+            }
+        }
+        CaseFlowControl::Continue
+    }
+}
+
+impl std::fmt::Display for SqlQuery {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SQL Query: url: {}, sql: {}", self.url, self.sql)
+    }
+}
+
+pub struct SqlInsert {
+    pub url: StrValue,
+    pub sql: StrValue,
+    pub resp: E2eResult<()>,
+}
+
+impl SqlInsert {
+    pub fn with_str<Url: ToString, Sql: ToString>(
+        url: Url,
+        sql: Sql,
+        resp: E2eResult<()>,
+    ) -> CnosdbRequest {
+        CnosdbRequest::SqlInsert(Self {
+            url: StrValue::Constant(url.to_string()),
+            sql: StrValue::Constant(sql.to_string()),
+            resp,
+        })
+    }
+
+    pub fn with_fn(url: FnString, sql: FnString, resp: E2eResult<()>) -> CnosdbRequest {
+        CnosdbRequest::SqlInsert(Self {
+            url: StrValue::Function(url),
+            sql: StrValue::Function(sql),
+            resp,
+        })
+    }
+
+    fn do_request(
+        &self,
+        context: &mut E2eContext,
+        request: &RequestStep,
+        client: &Client,
+    ) -> CaseFlowControl {
+        let url = self.url.get(context);
+        let sql = self.sql.get(context);
+        let result_resp = client.api_v1_write(url, &sql);
+        let fail_message = request.build_fail_message(context, &result_resp);
+        match &self.resp {
+            Ok(_) => {
+                assert!(result_resp.is_ok(), "{fail_message}");
+                if let Some(f) = &request.after_request_succeed {
+                    f(context, &result_resp.unwrap());
+                }
+            }
+            Err(exp_err) => {
+                assert!(result_resp.is_err(), "{fail_message}");
+                assert_eq!(exp_err, &result_resp.unwrap_err(), "{fail_message}");
+            }
+        }
+        CaseFlowControl::Continue
+    }
+}
+
+impl std::fmt::Display for SqlInsert {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SQL Insert: url: {}, sql: {}", self.url, self.sql)
+    }
+}
+
+pub struct LineProtocol {
+    pub url: StrValue,
+    pub req: StrValue,
+    pub resp: E2eResult<()>,
+}
+
+impl LineProtocol {
+    pub fn with_str<Url: ToString, Req: ToString>(
+        url: Url,
+        req: Req,
+        resp: E2eResult<()>,
+    ) -> CnosdbRequest {
+        CnosdbRequest::LineProtocol(Self {
+            url: StrValue::Constant(url.to_string()),
+            req: StrValue::Constant(req.to_string()),
+            resp,
+        })
+    }
+
+    pub fn with_fn(url: FnString, req: FnString, resp: E2eResult<()>) -> CnosdbRequest {
+        CnosdbRequest::LineProtocol(Self {
+            url: StrValue::Function(url),
+            req: StrValue::Function(req),
+            resp,
+        })
+    }
+
+    fn do_request(
+        &self,
+        context: &mut E2eContext,
+        request: &RequestStep,
+        client: &Client,
+    ) -> CaseFlowControl {
+        let url = self.url.get(context);
+        let req = self.req.get(context);
+        let result_resp = client.api_v1_write(url, &req);
+        let fail_message = request.build_fail_message(context, &result_resp);
+        match &self.resp {
+            Ok(_) => {
+                assert!(result_resp.is_ok(), "{fail_message}");
+                if let Some(f) = &request.after_request_succeed {
+                    f(context, &result_resp.unwrap());
+                }
+            }
+            Err(exp_err) => {
+                assert!(result_resp.is_err(), "{fail_message}");
+                assert_eq!(exp_err, &result_resp.unwrap_err(), "{fail_message}");
+            }
+        }
+        CaseFlowControl::Continue
+    }
+}
+
+impl std::fmt::Display for LineProtocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Line Protocol: url: {}, req: {}", self.url, self.req)
+    }
+}
+
+pub struct SqlDdl {
+    url: StrValue,
+    sql: StrValue,
+    resp: E2eResult<()>,
+}
+
+impl SqlDdl {
+    pub fn with_str<Url: ToString, Sql: ToString>(
+        url: Url,
+        sql: Sql,
+        resp: E2eResult<()>,
+    ) -> CnosdbRequest {
+        CnosdbRequest::SqlDdl(Self {
+            url: StrValue::Constant(url.to_string()),
+            sql: StrValue::Constant(sql.to_string()),
+            resp,
+        })
+    }
+
+    pub fn with_fn(url: FnString, sql: FnString, resp: E2eResult<()>) -> CnosdbRequest {
+        CnosdbRequest::SqlDdl(Self {
+            url: StrValue::Function(url),
+            sql: StrValue::Function(sql),
+            resp,
+        })
+    }
+
+    fn do_request(
+        &self,
+        context: &mut E2eContext,
+        request: &RequestStep,
+        client: &Client,
+    ) -> CaseFlowControl {
+        let url = self.url.get(context);
+        let sql = self.sql.get(context);
+        let result_resp = client.api_v1_sql(url, &sql);
+        let fail_message = request.build_fail_message(context, &result_resp);
+        match &self.resp {
+            Ok(_) => {
+                assert!(result_resp.is_ok(), "{fail_message}");
+                if let Some(f) = &request.after_request_succeed {
+                    f(context, &result_resp.unwrap());
+                }
+            }
+            Err(exp_err) => {
+                assert!(result_resp.is_err(), "{fail_message}");
+                assert_eq!(exp_err, &result_resp.unwrap_err(), "{fail_message}");
+            }
+        }
+        CaseFlowControl::Continue
+    }
+}
+
+impl std::fmt::Display for SqlDdl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SQL DDL: url: {}, sql: {}", self.url, self.sql)
+    }
+}
+
+pub struct ControlStep {
+    id: usize,
+    name: String,
+    control: Control,
+}
+
+impl ControlStep {
+    pub fn new<Name: ToString>(id: usize, name: Name, control: Control) -> Self {
+        Self {
+            id,
+            name: name.to_string(),
+            control,
+        }
+    }
+}
+
+impl Step for ControlStep {
+    fn id(&self) -> usize {
+        self.id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn execute(&self, context: &mut E2eContext) -> CaseFlowControl {
+        self.control.do_control(context);
+        CaseFlowControl::Continue
+    }
+}
+
+impl std::fmt::Display for ControlStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Step(Control)[{}-{}]: {}",
+            self.id(),
+            self.name(),
+            self.control
+        )
+    }
+}
+
+pub enum Control {
+    RestartDataNode(usize),
+    StartDataNode(usize),
+    StopDataNode(usize),
+    RestartCluster,
+    /// Sleep current thread for a while(in seconds)
+    Sleep(u64),
+}
+
+impl Control {
+    const WAIT_BEFORE_RESTART_SECONDS: u64 = 1;
+
+    fn do_control(&self, context: &mut E2eContext) {
+        let data = context.data_mut();
+        match self {
+            Control::RestartDataNode(data_node_index) => {
+                if Self::WAIT_BEFORE_RESTART_SECONDS > 0 {
+                    // TODO(zipper): The test sometimes fail if we restart just after a DDL or Insert, why?
+                    std::thread::sleep(Duration::from_secs(Self::WAIT_BEFORE_RESTART_SECONDS));
+                }
+                let data_node_def = data.data_node_definitions[*data_node_index].clone();
+                data.restart_one_node(&data_node_def);
+            }
+            Control::StartDataNode(data_node_index) => {
+                let data_node_def = data.data_node_definitions[*data_node_index].clone();
+                data.start_one_node(&data_node_def);
+            }
+            Control::StopDataNode(data_node_index) => {
+                let data_node_def = data.data_node_definitions[*data_node_index].clone();
+                data.stop_one_node(&data_node_def.config_file_name, false);
+            }
+            Control::RestartCluster => {
+                kill_all();
+                run_cluster(
+                    context.test_dir(),
+                    context.runtime(),
+                    context.cluster_definition(),
+                    false,
+                    false,
+                );
+            }
+            Control::Sleep(seconds) => {
+                std::thread::sleep(Duration::from_secs(*seconds));
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for Control {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Control::RestartDataNode(id) => write!(f, "restart data node: {id}"),
+            Control::StartDataNode(id) => write!(f, "start data node: {id}"),
+            Control::StopDataNode(id) => write!(f, "stop data node: {id}"),
+            Control::RestartCluster => write!(f, "restart cluster"),
+            Control::Sleep(sec) => write!(f, "sleep {sec} seconds"),
+        }
+    }
+}
+pub struct ShellStep {
+    id: usize,
+    name: String,
+    command: FnGeneric<Command>,
+    terminate_on_fail: bool,
+    before_execution: Option<FnVoid>,
+    after_execute_succeed: Option<FnAfterRequestSucceed>,
+}
+
+impl ShellStep {
+    pub fn with_fn<Name: ToString>(
+        id: usize,
+        name: Name,
+        command: FnGeneric<Command>,
+        terminate_on_fail: bool,
+        before_execution: Option<FnVoid>,
+        after_execute_succeed: Option<FnAfterRequestSucceed>,
+    ) -> Self {
+        Self {
+            id,
+            name: name.to_string(),
+            command,
+            terminate_on_fail,
+            before_execution,
+            after_execute_succeed,
+        }
+    }
+
+    fn command_str(&self, context: &E2eContext) -> String {
+        let command = (self.command)(context);
+        Self::command_to_string(&command)
+    }
+
+    fn command_to_string(command: &Command) -> String {
+        let mut buf = command.get_program().to_string_lossy().to_string();
+        for arg in command.get_args() {
+            buf.push(' ');
+            buf.push_str(arg.to_string_lossy().as_ref());
+        }
+        buf
+    }
+}
+
+impl Step for ShellStep {
+    fn id(&self) -> usize {
+        self.id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn execute(&self, context: &mut E2eContext) -> CaseFlowControl {
+        if let Some(f) = &self.before_execution {
+            f(context);
+        }
+        let mut command = (self.command)(context);
+        let command_string = Self::command_to_string(&command);
+        let output = command
+            .output()
+            .unwrap_or_else(|e| panic!("failed to execute process '{command_string}': {e}"));
+        if output.status.success() {
+            if let Some(f) = &self.after_execute_succeed {
+                let stdout_utf8 = String::from_utf8_lossy(&output.stdout);
+                let lines: Vec<String> = stdout_utf8.lines().map(|l| l.to_string()).collect();
+                f(context, &lines);
+            }
+        } else if self.terminate_on_fail {
+            panic!("Execute shell command failed: {command_string}");
+        }
+        CaseFlowControl::Continue
+    }
+}
+
+impl std::fmt::Display for ShellStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Step(shell)[{}-{}]: fn(&c) -> Command",
+            self.id(),
+            self.name(),
+        )
+    }
+}

--- a/e2e_test/src/independent/api_router_tests.rs
+++ b/e2e_test/src/independent/api_router_tests.rs
@@ -3,7 +3,8 @@
 use reqwest::StatusCode;
 use serial_test::serial;
 
-use crate::case::{CnosdbRequest, E2eExecutor, Step};
+use crate::case::step::{LineProtocol, RequestStep, SqlQuery, Step, StepResult};
+use crate::case::E2eExecutor;
 use crate::{cluster_def, E2eError};
 
 #[test]
@@ -14,50 +15,63 @@ fn api_router() {
         "api_router",
         cluster_def::one_meta_two_data_separated(),
     );
-    executor.execute_steps(&[
-        Step::CnosdbRequest {
-            req: CnosdbRequest::Write {
-                url: "http://127.0.0.1:8902/api/v1/write?db=public",
-                req: "api_router,ta=a fa=1 1",
-                resp: Err(E2eError::Api {
+    let steps: Vec<Box<dyn Step>> = vec![
+        Box::new(RequestStep::new(
+            1,
+            "write data to invalid node",
+            LineProtocol::with_str(
+                "http://127.0.0.1:8902/api/v1/write?db=public",
+                "api_router,ta=a fa=1 1",
+                Err(E2eError::Api {
                     status: StatusCode::NOT_FOUND,
                     url: None,
                     req: None,
                     resp: None,
                 }),
-            },
-            auth: None,
-        },
-        Step::CnosdbRequest {
-            req: CnosdbRequest::Write {
-                url: "http://127.0.0.1:8912/api/v1/write?db=public",
-                req: "api_router,ta=a fa=1 1",
-                resp: Ok(()),
-            },
-            auth: None,
-        },
-        Step::CnosdbRequest {
-            req: CnosdbRequest::Query {
-                url: "http://127.0.0.1:8902/api/v1/sql?db=public",
-                sql: "select * from api_router",
-                resp: Err(E2eError::Api {
+            ),
+            None,
+            None,
+        )),
+        Box::new(RequestStep::new(
+            1,
+            "write data",
+            LineProtocol::with_str(
+                "http://127.0.0.1:8912/api/v1/write?db=public",
+                "api_router,ta=a fa=1 1",
+                Ok(()),
+            ),
+            None,
+            None,
+        )),
+        Box::new(RequestStep::new(
+            1,
+            "query data from invalid node",
+            SqlQuery::with_str(
+                "http://127.0.0.1:8902/api/v1/sql?db=public",
+                "select * from api_router",
+                StepResult::Err(E2eError::Api {
                     status: StatusCode::NOT_FOUND,
                     url: None,
                     req: None,
                     resp: None,
                 }),
-                sorted: false,
-            },
-            auth: None,
-        },
-        Step::CnosdbRequest {
-            req: CnosdbRequest::Query {
-                url: "http://127.0.0.1:8912/api/v1/sql?db=public",
-                sql: "select* from api_router",
-                resp: Ok(vec!["time,ta,fa", "1970-01-01T00:00:00.000000001,a,1.0"]),
-                sorted: false,
-            },
-            auth: None,
-        },
-    ]);
+                false,
+            ),
+            None,
+            None,
+        )),
+        Box::new(RequestStep::new(
+            1,
+            "query data",
+            SqlQuery::with_str(
+                "http://127.0.0.1:8912/api/v1/sql?db=public",
+                "select* from api_router",
+                Ok(vec!["time,ta,fa", "1970-01-01T00:00:00.000000001,a,1.0"]),
+                false,
+            ),
+            None,
+            None,
+        )),
+    ];
+    executor.execute_steps(&steps);
 }

--- a/e2e_test/src/independent/restart_tests.rs
+++ b/e2e_test/src/independent/restart_tests.rs
@@ -693,7 +693,7 @@ fn case6() {
             "select table air",
             SqlQuery::with_str(
                 url_cnosdb_public,
-                "SELECT time, station, visibility, temperature, pressure FROM air ORDER BY time",
+                "SELECT * FROM air ORDER BY time",
                 Ok(vec![
                     "time,station,visibility,temperature,pressure",
                     "2023-01-01T01:10:00.000000000,XiaoMaiDao,79.0,80.0,63.0",
@@ -737,7 +737,7 @@ fn case6() {
             "select table air",
             SqlQuery::with_str(
                 url_cnosdb_public,
-                "SELECT time, station, visibility, temperature, pressure FROM air ORDER BY time",
+                "SELECT * FROM air ORDER BY time",
                 Ok(vec![
                     "time,station,visibility,temperature,pressure",
                     "2023-01-01T01:10:00.000000000,XiaoMaiDao,79.0,80.0,63.0",

--- a/e2e_test/src/lib.rs
+++ b/e2e_test/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 mod case;
 mod cluster_def;
 mod independent;
@@ -71,5 +73,76 @@ impl std::fmt::Display for E2eError {
 }
 
 impl std::error::Error for E2eError {}
+
+impl PartialEq for E2eError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (E2eError::Connect(msg1), E2eError::Connect(msg2)) => msg1 == msg2,
+            (
+                E2eError::Http {
+                    status: status1,
+                    url: url1,
+                    req: req1,
+                    err: err1,
+                },
+                E2eError::Http {
+                    status: status2,
+                    url: url2,
+                    req: req2,
+                    err: err2,
+                },
+            ) => {
+                status1 == status2
+                    && match (url1, url2) {
+                        (None, _) => true,
+                        (Some(u1), Some(u2)) => u1 == u2,
+                        (Some(_), None) => false,
+                    }
+                    && match (req1, req2) {
+                        (None, _) => true,
+                        (Some(r1), Some(r2)) => r1 == r2,
+                        (Some(_), None) => false,
+                    }
+                    && match (err1, err2) {
+                        (None, _) => true,
+                        (Some(e1), Some(e2)) => e1 == e2,
+                        (Some(_), None) => false,
+                    }
+            }
+            (
+                E2eError::Api {
+                    status: status1,
+                    url: url1,
+                    req: req1,
+                    resp: resp1,
+                },
+                E2eError::Api {
+                    status: status2,
+                    url: url2,
+                    req: req2,
+                    resp: resp2,
+                },
+            ) => {
+                status1 == status2
+                    && match (url1, url2) {
+                        (None, _) => true,
+                        (Some(u1), Some(u2)) => u1 == u2,
+                        (Some(_), None) => false,
+                    }
+                    && match (req1, req2) {
+                        (None, _) => true,
+                        (Some(r1), Some(r2)) => r1 == r2,
+                        (Some(_), None) => false,
+                    }
+                    && match (resp1, resp2) {
+                        (None, _) => true,
+                        (Some(r1), Some(r2)) => r1 == r2,
+                        (Some(_), None) => false,
+                    }
+            }
+            _ => false,
+        }
+    }
+}
 
 pub type E2eResult<T> = std::result::Result<T, E2eError>;


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

- Make old API of e2e test case executor deprecated, move `Step` to `StepLegacy`, `execute_steps()` to `execute_steps_legacy()`.
- Add new API for e2e test case executor, add trait `Step`, struct `E2eContext`, add step `ShellStep` to execute shell commands.
   - Some implementations of `Step` have fields that can lazy init their values using a reference of `E2eContext`, or can even modify context variables in `E2eContext` before or after their execution.  
   - `CnosdbMetaTestHelper` and `CnosdbDataTestHelper` now store configs of cnosdb meta nodes (`meta::store::config::Opt`) and data nodes (`config::Config`).
- Add restart test `case_6` to test whether cnosdb will lost data after a compaction and restart.

[//]: # (Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.)

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

