### PR TITLE
refactor: Persistent sql is migrated from local to meta and watermark…

### DIFF
--- a/meta/src/model/meta_admin.rs
+++ b/meta/src/model/meta_admin.rs
@@ -791,4 +791,30 @@ impl AdminMeta {
     pub fn take_resourceinfo_rx(&self) -> Option<Receiver<MetaModifyType>> {
         self.resource_tx_rx.1.lock().take()
     }
+
+    pub async fn write_queryinfo(
+        &self,
+        node_id: NodeId,
+        query_id: u64,
+        query_info: Vec<u8>,
+    ) -> MetaResult<()> {
+        let req =
+            command::WriteCommand::WriteQueryInfo(self.cluster(), node_id, query_id, query_info);
+
+        self.client.write::<()>(&req).await?;
+
+        Ok(())
+    }
+
+    pub async fn read_queryinfos(&self, node_id: NodeId) -> MetaResult<Vec<Vec<u8>>> {
+        let req = command::ReadCommand::ReadQueryInfos(self.cluster(), node_id);
+
+        self.client.read::<Vec<Vec<u8>>>(&req).await
+    }
+
+    pub async fn remove_queryinfo(&self, node_id: NodeId, query_id: u64) -> MetaResult<()> {
+        let req = command::WriteCommand::RemoveQueryInfo(self.cluster(), node_id, query_id);
+
+        self.client.write::<()>(&req).await
+    }
 }

--- a/meta/src/store/command.rs
+++ b/meta/src/store/command.rs
@@ -140,6 +140,12 @@ pub enum WriteCommand {
     ResourceInfo(String, String, ResourceInfo),
     // cluster, node_id, is_lock
     ResourceInfosMark(String, NodeId, bool),
+
+    // cluster, node_id, query_id, query_info
+    WriteQueryInfo(String, NodeId, u64, Vec<u8>),
+
+    // cluster, node_id, query_id
+    RemoveQueryInfo(String, NodeId, u64),
 }
 
 /******************* read command *************************/
@@ -177,6 +183,9 @@ pub enum ReadCommand {
 
     // cluster, tenant, db, replication set id
     ReplicationSet(String, String, String, u32),
+
+    // cluster, node_id
+    ReadQueryInfos(String, NodeId),
 }
 
 pub const ENTRY_LOG_TYPE_SET: i32 = 1;

--- a/meta/src/store/key_path.rs
+++ b/meta/src/store/key_path.rs
@@ -1,3 +1,4 @@
+use models::meta_data::NodeId;
 use models::oid::Oid;
 
 // **    /cluster_name/users ->
@@ -138,5 +139,13 @@ impl KeyPath {
 
     pub fn resourceinfosmark(cluster: &str) -> String {
         format!("/{}/resourceinfosmark", cluster)
+    }
+
+    pub fn query(cluster: &str, node_id: NodeId, query_id: u64) -> String {
+        format!("/{}/{}/queries/{}", cluster, node_id, query_id)
+    }
+
+    pub fn queries(cluster: &str, node_id: NodeId) -> String {
+        format!("/{}/{}/queries", cluster, node_id)
     }
 }

--- a/query_server/query/src/dispatcher/manager.rs
+++ b/query_server/query/src/dispatcher/manager.rs
@@ -64,6 +64,7 @@ impl QueryDispatcher for SimpleQueryDispatcher {
             let ctx = ContextBuilder::new(user)
                 .with_tenant(Some(tenant_name.to_owned()))
                 .with_database(Some(database_name.to_owned()))
+                .with_is_old(Some(true))
                 .build();
             let query = Query::new(ctx, sql.to_owned());
             match self
@@ -236,7 +237,8 @@ impl SimpleQueryDispatcher {
     ) -> QueryResult<Output> {
         let execution = self
             .query_execution_factory
-            .create_query_execution(logical_plan, query_state_machine.clone())?;
+            .create_query_execution(logical_plan, query_state_machine.clone())
+            .await?;
 
         // TrackedQuery.drop() is called implicitly when the value goes out of scope,
         self.query_tracker

--- a/query_server/query/src/dispatcher/persister.rs
+++ b/query_server/query/src/dispatcher/persister.rs
@@ -1,65 +1,36 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use snafu::{IntoError, ResultExt};
+use meta::model::meta_admin::AdminMeta;
+use snafu::ResultExt;
 use spi::query::dispatcher::QueryInfo;
 use spi::service::protocol::QueryId;
-use spi::{BincodeSerializeSnafu, PersistQuerySnafu, QueryError, StdIoSnafu};
-use tokio::fs::{self, File};
-use tokio::io::AsyncWriteExt;
+use spi::{MetaSnafu, PersistQuerySnafu, QueryError};
 use trace::{debug, warn};
 
 use super::QueryPersister;
 
 pub type QueryPersisterRef = Arc<dyn QueryPersister + Send + Sync>;
 
-const QUERY_INFO_FILE_NAME: &str = "query_info";
-
-pub struct LocalQueryPersister {
-    path: PathBuf,
+pub struct MetaQueryPersister {
+    admin_meta: Arc<AdminMeta>,
 }
 
-impl LocalQueryPersister {
-    pub fn try_new(path: impl Into<PathBuf>) -> Result<Self, QueryError> {
-        let path: PathBuf = path.into();
-        std::fs::create_dir_all(path.as_path()).context(StdIoSnafu)?;
-
-        Ok(Self { path })
-    }
-
-    fn file_path(&self, query_id: &QueryId) -> PathBuf {
-        let mut path = PathBuf::from(self.path.as_path());
-        path.push(&format!("{}", query_id));
-        path.push(QUERY_INFO_FILE_NAME);
-        path
-    }
-
-    fn query_dir(&self, query_id: &QueryId) -> PathBuf {
-        let mut path = PathBuf::from(self.path.as_path());
-        path.push(&format!("{}", query_id));
-        path
-    }
-
-    fn root_dir(&self) -> PathBuf {
-        PathBuf::from(self.path.as_path())
+impl MetaQueryPersister {
+    pub fn new(admin_meta: Arc<AdminMeta>) -> Self {
+        Self { admin_meta }
     }
 }
 
 #[async_trait]
-impl QueryPersister for LocalQueryPersister {
+impl QueryPersister for MetaQueryPersister {
     fn remove(&self, query_id: &QueryId) -> Result<(), QueryError> {
-        let path = self.query_dir(query_id);
+        let admin_meta = self.admin_meta.clone();
+        let query_id = query_id.get();
 
-        debug!("Remove query dir: {:?}", path.as_path());
-
-        // Asynchronously delete the metadata file of the query.
-        // note:
-        //   Since deleting folders is asynchronous,
-        //   the system crashes before deleting files,
-        //   and the query still exists when restarting.
-        tokio::spawn(async {
-            let _ = fs::remove_dir_all(path)
+        tokio::spawn(async move {
+            let _ = admin_meta
+                .remove_queryinfo(admin_meta.node_id(), query_id)
                 .await
                 .map_err(|err| warn!("Remove query dir failed: {:?}", err));
         });
@@ -70,53 +41,46 @@ impl QueryPersister for LocalQueryPersister {
     async fn save(&self, query_id: QueryId, query: QueryInfo) -> Result<(), QueryError> {
         debug!("Save query: {}, {:?}", query_id, query);
 
-        let path = self.file_path(&query_id);
-        let mut file = File::create(path).await.map_err(|err| {
+        let body = serde_json::to_vec(&query).map_err(|err| {
+            trace::error!("Failed to serialize query info: {}", err);
             PersistQuerySnafu {
-                reason: format!(
-                    "Failed to create query info file at {}: {}",
-                    self.path.display(),
-                    err
-                ),
+                reason: format!("Failed to serialize query info: {}", err),
             }
             .build()
         })?;
 
-        let body = serde_json::to_vec(&query)
-            .map_err(|e| BincodeSerializeSnafu.into_error(Box::new(e)))?;
-
-        file.write_all(&body).await.map_err(|err| {
-            PersistQuerySnafu {
-                reason: format!(
-                    "Failed to save query info into file at {}: {:?}",
-                    self.path.display(),
-                    err
-                ),
-            }
-            .build()
-        })?;
+        self.admin_meta
+            .write_queryinfo(self.admin_meta.node_id(), query_id.get(), body)
+            .await
+            .map_err(|err| {
+                PersistQuerySnafu {
+                    reason: format!(
+                        "Failed to save query info into file at {}: {:?}",
+                        self.admin_meta.node_id(),
+                        err
+                    ),
+                }
+                .build()
+            })?;
 
         Ok(())
     }
 
     async fn queries(&self) -> Result<Vec<QueryInfo>, QueryError> {
-        let mut result = vec![];
+        let query_infos = self
+            .admin_meta
+            .read_queryinfos(self.admin_meta.node_id())
+            .await
+            .context(MetaSnafu)?;
 
-        let mut entries = fs::read_dir(self.root_dir()).await.context(StdIoSnafu)?;
-        while let Some(entry) = entries.next_entry().await.context(StdIoSnafu)? {
-            let bytes = fs::read(entry.path().join(QUERY_INFO_FILE_NAME))
-                .await
-                .context(StdIoSnafu)?;
-            match serde_json::from_slice::<QueryInfo>(&bytes) {
+        let mut result = vec![];
+        for query_info in query_infos {
+            match serde_json::from_slice::<QueryInfo>(&query_info) {
                 Ok(query_info) => {
                     result.push(query_info);
                 }
                 Err(err) => {
-                    trace::warn!(
-                        "Failed to deserialize query info from file: {:?}, error: {}",
-                        entry.path(),
-                        err,
-                    );
+                    trace::warn!("Failed to deserialize query, error: {}", err,);
                 }
             }
         }

--- a/query_server/query/src/dispatcher/query_tracker.rs
+++ b/query_server/query/src/dispatcher/query_tracker.rs
@@ -348,6 +348,7 @@ mod tests {
     use coordinator::service_mock::MockCoordinator;
     use datafusion::arrow::datatypes::Schema;
     use datafusion::physical_plan::EmptyRecordBatchStream;
+    use meta::model::meta_admin::AdminMeta;
     use models::auth::user::{User, UserDesc, UserOptions};
     use spi::query::dispatcher::{QueryInfo, QueryStatus};
     use spi::query::execution::{Output, QueryExecution, QueryState, RUNNING};
@@ -355,7 +356,7 @@ mod tests {
     use spi::QueryError;
 
     use super::QueryTracker;
-    use crate::dispatcher::persister::LocalQueryPersister;
+    use crate::dispatcher::persister::MetaQueryPersister;
 
     struct QueryExecutionMock {}
 
@@ -393,7 +394,7 @@ mod tests {
     fn new_query_tracker(limit: usize) -> QueryTracker {
         QueryTracker::new(
             limit,
-            Arc::new(LocalQueryPersister::try_new("/tmp/cnosdb/query").unwrap()),
+            Arc::new(MetaQueryPersister::new(Arc::new(AdminMeta::mock()))),
             Arc::new(MockCoordinator {}),
         )
     }

--- a/query_server/query/src/execution/factory.rs
+++ b/query_server/query/src/execution/factory.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use datafusion::logical_expr::{Extension, LogicalPlan};
 use models::runtime::executor::DedicatedExecutor;
 use spi::query::datasource::stream::checker::StreamCheckerManagerRef;
@@ -65,8 +66,9 @@ impl SqlQueryExecutionFactory {
 
 pub type QueryExecutionFactoryRef = Arc<dyn QueryExecutionFactory + Send + Sync>;
 
+#[async_trait]
 impl QueryExecutionFactory for SqlQueryExecutionFactory {
-    fn create_query_execution(
+    async fn create_query_execution(
         &self,
         plan: Plan,
         state_machine: QueryStateMachineRef,
@@ -103,7 +105,8 @@ impl QueryExecutionFactory for SqlQueryExecutionFactory {
                                 self.scheduler.clone(),
                                 self.trigger_executor_factory.clone(),
                                 self.runtime.clone(),
-                            )?;
+                            )
+                            .await?;
 
                         Ok(Arc::new(exec))
                     }

--- a/query_server/query/src/instance.rs
+++ b/query_server/query/src/instance.rs
@@ -27,7 +27,7 @@ use crate::auth::auth_control::{AccessControlImpl, AccessControlNoCheck};
 use crate::data_source::split::SplitManager;
 use crate::data_source::stream::tskv::factory::{TskvStreamProviderFactory, TSKV_STREAM_PROVIDER};
 use crate::dispatcher::manager::SimpleQueryDispatcherBuilder;
-use crate::dispatcher::persister::LocalQueryPersister;
+use crate::dispatcher::persister::MetaQueryPersister;
 use crate::dispatcher::query_tracker::QueryTracker;
 use crate::execution::factory::SqlQueryExecutionFactory;
 use crate::execution::scheduler::local::LocalScheduler;
@@ -210,9 +210,7 @@ pub async fn make_cnosdbms(
     stream_checker_manager
         .register_stream_checker(TSKV_STREAM_PROVIDER, tskv_stream_provider_factory)?;
 
-    let query_persister = Arc::new(LocalQueryPersister::try_new(
-        query_dedicated_hidden_dir.clone(),
-    )?);
+    let query_persister = Arc::new(MetaQueryPersister::new(coord.meta_manager()));
     let query_tracker = Arc::new(QueryTracker::new(
         options.query.max_server_connections as usize,
         query_persister,

--- a/query_server/query/src/stream/watermark_tracker.rs
+++ b/query_server/query/src/stream/watermark_tracker.rs
@@ -1,55 +1,161 @@
-use std::path::PathBuf;
+use std::borrow::Cow;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 
+use coordinator::Coordinator;
+use datafusion::arrow::array::{Array, StringArray, TimestampNanosecondArray};
+use datafusion::arrow::record_batch::RecordBatch;
+use futures::TryStreamExt;
+use models::arrow::TimeUnit;
+use models::predicate::domain::Predicate;
+use models::schema::{
+    ColumnType, Precision, TableColumn, TskvTableSchema, CLUSTER_SCHEMA, DEFAULT_CATALOG,
+};
+use models::utils::now_timestamp_nanos;
+use models::ValueType;
+use protocol_parser::Line;
+use protos::FieldValue;
 use snafu::ResultExt;
+use spi::query::session::SessionCtx;
 use spi::service::protocol::QueryId;
-use spi::{QueryError, StdIoSnafu};
-use tokio::fs;
+use spi::{CoordinatorSnafu, ModelsSnafu, PersistQuerySnafu, QueryError};
+use trace::debug;
+use tskv::reader::QueryOption;
+
+use crate::data_source::split::tskv::TableLayoutHandle;
+use crate::data_source::split::SplitManager;
 
 pub type WatermarkTrackerRef = Arc<WatermarkTracker>;
 
-const WATERMARK_FILE_NAME: &str = "watermark";
+const PERSISTER_SQL_TABLE: &str = "sql_watermark_persister";
 
 /// Real-time tracking of watermark during query running, which can be recovered after system restart.
-/// Information is logged to a local file.
+/// Information is logged to table.
 #[derive(Default, Debug)]
 pub struct WatermarkTracker {
     global_watermark_ns: AtomicI64,
-    file_path: PathBuf,
+    query_id: QueryId,
+    timestamp: i64,
 }
 
 impl WatermarkTracker {
-    pub fn try_new(query_id: QueryId, path: impl Into<PathBuf>) -> Result<Self, QueryError> {
-        let mut path: PathBuf = path.into();
-        path.push(&format!("{}", query_id));
-        path.push(WATERMARK_FILE_NAME);
+    pub async fn try_new(
+        query_id: QueryId,
+        coord: Arc<dyn Coordinator>,
+        session: SessionCtx,
+        is_old: bool,
+    ) -> Result<Self, QueryError> {
+        let mut watermark_ns = i64::MIN;
+        let mut timestamp = now_timestamp_nanos();
 
-        let watermark_ns = if std::path::Path::new(path.as_path()).exists() {
-            let mut buf: [u8; 8] = [0; 8];
-            let bytes = std::fs::read(path.as_path()).context(StdIoSnafu)?;
-            if bytes.len() != 8 {
-                return Err(QueryError::Internal {
-                    reason: format!(
-                        "Invalid watermark file: {:?}, content: {:?}",
-                        path.as_path(),
-                        bytes
-                    ),
-                });
+        if is_old {
+            let table_columns = vec![
+                TableColumn::new_time_column(0, TimeUnit::Nanosecond),
+                TableColumn::new(
+                    1,
+                    "query_id".to_string(),
+                    ColumnType::Field(ValueType::String),
+                    Default::default(),
+                ),
+                TableColumn::new(
+                    2,
+                    "watermark".to_string(),
+                    ColumnType::Field(ValueType::String),
+                    Default::default(),
+                ),
+            ];
+            let tskv_table_schame = Arc::new(TskvTableSchema::new(
+                DEFAULT_CATALOG.to_string(),
+                CLUSTER_SCHEMA.to_string(),
+                PERSISTER_SQL_TABLE.to_string(),
+                table_columns,
+            ));
+            let schema = tskv_table_schame.to_arrow_schema();
+            let table_layout = TableLayoutHandle {
+                table: tskv_table_schame.clone(),
+                predicate: Arc::new(
+                    Predicate::push_down_filter(
+                        None,
+                        &*tskv_table_schame.to_df_schema()?,
+                        &schema,
+                        None,
+                    )
+                    .context(ModelsSnafu)?,
+                ),
+            };
+            let split_manager = SplitManager::new(coord.clone());
+            let splits = split_manager.splits(session.inner(), table_layout).await?;
+
+            let mut record_batch_vec: Vec<RecordBatch> = Vec::new();
+            for split in splits {
+                let query_opt = QueryOption::new(
+                    100_usize,
+                    split.clone(),
+                    None,
+                    schema.clone(),
+                    tskv_table_schame.clone(),
+                );
+                let mut iter = coord
+                    .table_scan(query_opt, session.get_span_ctx())
+                    .context(CoordinatorSnafu)?;
+                while let Some(record_batch) = iter
+                    .try_next()
+                    .await
+                    .map_err(|source| QueryError::Coordinator { source })?
+                {
+                    record_batch_vec.push(record_batch);
+                }
             }
-            buf.copy_from_slice(&bytes[..8]);
 
-            i64::from_be_bytes(buf)
-        } else {
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent).context(StdIoSnafu)?;
+            'outer: for batch in record_batch_vec {
+                let column = batch
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .ok_or(
+                        PersistQuerySnafu {
+                            reason: "column 1 is not StringArray".to_string(),
+                        }
+                        .build(),
+                    )?;
+                for i in 0..column.len() {
+                    if query_id.get().to_string().eq(column.value(i)) {
+                        let column = batch
+                            .column(0)
+                            .as_any()
+                            .downcast_ref::<TimestampNanosecondArray>()
+                            .ok_or(
+                                PersistQuerySnafu {
+                                    reason: "column 0 is not TimestampNanosecondArray".to_string(),
+                                }
+                                .build(),
+                            )?;
+                        timestamp = column.value(i);
+                        let column = batch
+                            .column(2)
+                            .as_any()
+                            .downcast_ref::<StringArray>()
+                            .ok_or(
+                                PersistQuerySnafu {
+                                    reason: "column 2 is not StringArray".to_string(),
+                                }
+                                .build(),
+                            )?;
+                        watermark_ns = column.value(i).parse().expect("Not a valid number");
+                        break 'outer;
+                    }
+                }
             }
-            i64::MIN
-        };
+        }
 
+        debug!(
+            "timestamp: {}, query_id: {}, watermark_ns: {}",
+            timestamp, query_id, watermark_ns
+        );
         Ok(Self {
             global_watermark_ns: AtomicI64::new(watermark_ns),
-            file_path: path,
+            query_id,
+            timestamp,
         })
     }
 
@@ -65,20 +171,53 @@ impl WatermarkTracker {
             .store(event_time, Ordering::Relaxed);
     }
 
-    /// Persist watermark to local file.
+    /// Persist watermark to table.
     /// The purpose is to not output duplicate data after the system restarts.
-    pub async fn commit(&self, _batch_id: i64) -> Result<(), QueryError> {
-        let contents = self
-            .global_watermark_ns
-            .load(Ordering::Relaxed)
-            .to_be_bytes();
-        fs::write(&self.file_path, contents)
+    pub async fn commit(
+        &self,
+        _batch_id: i64,
+        coord: Arc<dyn Coordinator>,
+    ) -> Result<(), QueryError> {
+        let line = Line {
+            hash_id: 0,
+            table: Cow::Owned(PERSISTER_SQL_TABLE.to_string()),
+            tags: vec![],
+            fields: vec![
+                (
+                    Cow::Owned("query_id".to_string()),
+                    FieldValue::Str(self.query_id.to_string().as_bytes().to_owned()),
+                ),
+                (
+                    Cow::Owned("watermark".to_string()),
+                    FieldValue::Str(
+                        self.global_watermark_ns
+                            .load(Ordering::Relaxed)
+                            .to_string()
+                            .as_bytes()
+                            .to_owned(),
+                    ),
+                ),
+            ],
+            timestamp: self.timestamp,
+        };
+
+        coord
+            .write_lines(
+                DEFAULT_CATALOG,
+                CLUSTER_SCHEMA,
+                Precision::NS,
+                vec![line],
+                None,
+            )
             .await
-            .map_err(|err| {
-                trace::error!("Commit streaming query watermark, error: {:?}", err);
-                err
-            })
-            .context(StdIoSnafu)?;
+            .map_err(|source| QueryError::Coordinator { source })?;
+
+        debug!(
+            "timestamp: {}, query_id: {}, watermark_ns: {}",
+            self.timestamp,
+            self.query_id,
+            self.global_watermark_ns.load(Ordering::Relaxed)
+        );
 
         Ok(())
     }

--- a/query_server/spi/src/query/execution.rs
+++ b/query_server/spi/src/query/execution.rs
@@ -173,8 +173,9 @@ impl Stream for Output {
 //     }
 // }
 
+#[async_trait]
 pub trait QueryExecutionFactory {
-    fn create_query_execution(
+    async fn create_query_execution(
         &self,
         plan: Plan,
         query_state_machine: QueryStateMachineRef,

--- a/query_server/spi/src/service/protocol.rs
+++ b/query_server/spi/src/service/protocol.rs
@@ -9,7 +9,7 @@ use crate::query::config::StreamTriggerInterval;
 use crate::query::execution::Output;
 use crate::query::session::CnosSessionConfig;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct QueryId(u64);
 
 impl QueryId {
@@ -72,6 +72,7 @@ pub struct Context {
     precision: String,
     chunked: bool,
     session_config: CnosSessionConfig,
+    is_old: bool,
 }
 
 impl Context {
@@ -97,6 +98,9 @@ impl Context {
     pub fn chunked(&self) -> bool {
         self.chunked
     }
+    pub fn is_old(&self) -> bool {
+        self.is_old
+    }
 }
 
 pub struct ContextBuilder {
@@ -106,6 +110,7 @@ pub struct ContextBuilder {
     precision: String,
     chunked: bool,
     session_config: CnosSessionConfig,
+    is_old: bool,
 }
 
 impl ContextBuilder {
@@ -117,6 +122,7 @@ impl ContextBuilder {
             database: DEFAULT_DATABASE.to_string(),
             chunked: Default::default(),
             session_config: Default::default(),
+            is_old: Default::default(),
         }
     }
 
@@ -164,6 +170,13 @@ impl ContextBuilder {
         self
     }
 
+    pub fn with_is_old(mut self, is_old: Option<bool>) -> Self {
+        if let Some(is_old) = is_old {
+            self.is_old = is_old;
+        }
+        self
+    }
+
     pub fn build(self) -> Context {
         Context {
             user: self.user,
@@ -172,6 +185,7 @@ impl ContextBuilder {
             precision: self.precision,
             chunked: self.chunked,
             session_config: self.session_config,
+            is_old: self.is_old,
         }
     }
 }


### PR DESCRIPTION
… is migrated from local to system table

Store the persistent sql (currently, streaming sql) in meta
Store the watermark for streaming sql in cluster_schema.sql_watermark_persister table
 

