### PR TITLE
refactor: use new Timeranges impl in 2.4.

### DIFF
--- a/tskv/src/reader/memcache_reader.rs
+++ b/tskv/src/reader/memcache_reader.rs
@@ -186,7 +186,7 @@ impl BatchReader for MemCacheReader {
             f,
             "MemCacheReader: series_id:{}, time_ranges:{:?}, batch_size:{}, columns_count:{}",
             self.series_data.read().series_id,
-            self.time_ranges.time_ranges(),
+            self.time_ranges.time_ranges().collect::<Vec<_>>(),
             self.batch_size,
             self.columns.len()
         )

--- a/tskv/src/vnode_store.rs
+++ b/tskv/src/vnode_store.rs
@@ -556,7 +556,7 @@ impl VnodeStorage {
 
         for time_range in time_ranges.time_ranges() {
             version
-                .add_tombstone(series_ids, &column_ids, time_range)
+                .add_tombstone(series_ids, &column_ids, &time_range)
                 .await?;
         }
 


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

https://github.com/cnosdb/cnosdb/commit/f4b518cdb081acfb233b4475a32bfb4eba0cd523
Migrate refactoring involving timerange from 2.3 to 2.4
Related #.

# Rationale for this change

[//]: # (Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.)

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

