### PR TITLE
Refactor(protos): prevent code of common/protos changed by the IDE-code checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clippy:
 	BUILD_PROTOS=1 cargo clippy --workspace  --all-targets --features coordinator_e2e_test --features meta_e2e_test --fix --allow-staged
 
 build:
-	BUILD_PROTOS=1 cargo build --workspace --bins
+	cargo build --workspace --bins
 
 build_release:
 	BUILD_PROTOS=1 cargo build --release --workspace --bins
@@ -37,6 +37,6 @@ clean:
 	cargo clean
 
 run:
-	BUILD_PROTOS=1 cargo run -- run
+	cargo run -- run
 
 .PHONY: docs_check docs fmt_check fmt clippy_check clippy build build_release build_trace test check clean run

--- a/Makefile
+++ b/Makefile
@@ -11,24 +11,25 @@ fmt:
 	cargo +nightly fmt --all
 
 clippy_check:
-	cargo clippy --workspace  --all-targets --features coordinator_e2e_test --features meta_e2e_test -- -D warnings
+	BUILD_PROTOS=1 cargo clippy --workspace  --all-targets --features coordinator_e2e_test --features meta_e2e_test -- -D warnings
 
 clippy:
-	cargo clippy --workspace  --all-targets --features coordinator_e2e_test --features meta_e2e_test --fix --allow-staged
+	BUILD_PROTOS=1 cargo clippy --workspace  --all-targets --features coordinator_e2e_test --features meta_e2e_test --fix --allow-staged
 
 build:
-	cargo build --workspace --bins
+	BUILD_PROTOS=1 cargo build --workspace --bins
 
 build_release:
-	cargo build --release --workspace --bins
+	BUILD_PROTOS=1 cargo build --release --workspace --bins
 
 build_trace:
 	cargo clean;
 	git stash;
-	export BACKTRACE=on; cargo build --workspace --bins --features backtrace;
+	export BACKTRACE=on; BUILD_PROTOS=1 cargo build --workspace --bins --features backtrace;
 	git reset --hard; git stash pop || true
+
 test:
-	cargo test --workspace --exclude e2e_test
+	BUILD_PROTOS=1 cargo test --workspace --exclude e2e_test
 
 check: fmt_check clippy_check build test docs_check
 
@@ -36,6 +37,6 @@ clean:
 	cargo clean
 
 run:
-	cargo run -- run
+	BUILD_PROTOS=1 cargo run -- run
 
-.PHONY: docs check fmt fmt_check clippy clippy_check build build_release build_trace test docs_check clean run
+.PHONY: docs_check docs fmt_check fmt clippy_check clippy build build_release build_trace test check clean run

--- a/common/protos/Cargo.toml
+++ b/common/protos/Cargo.toml
@@ -19,7 +19,6 @@ tower = { workspace = true }
 
 [features]
 default = []
-test = []
 backtrace = ["async-backtrace"]
 
 [build-dependencies]

--- a/common/protos/build.rs
+++ b/common/protos/build.rs
@@ -1,182 +1,352 @@
-use core::panic;
-use std::{env, fs, io::Write, path::PathBuf, process::Command};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::{cmp, env, fs};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+type AnyError = Box<dyn std::error::Error>;
+
+const VERSION_PROTOBUF: Version = Version(27, 0, 0); // 27.0
+const VERSION_FLATBUFFERS: Version = Version(24, 3, 25); // 24.3.25
+
+/// The folder where the build script should place its output.
+/// https://doc.rust-lang.org/cargo/reference/environment-variables.html
+const ENV_OUT_DIR: &str = "OUT_DIR";
+
+/// Path of `flatc` binary.
+const ENV_FLATC_PATH: &str = "FLATC_PATH";
+
+/// Build protos if the major version of `flatc` or `protoc` is greater
+/// or lesser than the expected version.
+const ENV_BUILD_PROTOS: &str = "BUILD_PROTOS";
+
+fn main() -> Result<(), AnyError> {
+    println!("cargo:rerun-if-changed=proto");
+    println!("cargo:rerun-if-changed=prompb");
+
     let project_root_dir = env::current_dir()?;
-    let proto_files_dir = project_root_dir.join("proto");
-    let prompb_proto_files_dir = project_root_dir.join("prompb");
+    let proto_dir = project_root_dir.join("proto");
+    let prompb_dir = project_root_dir.join("prompb");
+    let rust_dir = env::current_dir().unwrap().join("src");
 
     // src/generated/mod.rs
     let generated_mod_rs_path = project_root_dir
         .join("src")
         .join("generated")
         .join("mod.rs");
-    let mut generated_mod_rs_file = fs::File::create(generated_mod_rs_path)?;
-    generated_mod_rs_file.write_all(
-        b"#![allow(unused_imports)]
-#![allow(clippy::all)]
-mod protobuf_generated;
-pub use protobuf_generated::*;
+    let mut generated_mod_rs = fs::File::create(generated_mod_rs_path)?;
+    writeln!(&mut generated_mod_rs, "#![allow(unused_imports)]")?;
+    writeln!(&mut generated_mod_rs, "#![allow(clippy::all)]")?;
+    generated_mod_rs.flush()?;
 
-mod flatbuffers_generated;
-",
+    // build proto/*.proto files to src/generated/protobuf_generated/
+    compile_protobuf_models(
+        &mut generated_mod_rs,
+        &proto_dir,
+        &rust_dir.join("generated").join("protobuf_generated"),
+        vec![
+            ("kv_service.proto", "kv_service"),
+            ("vector_event.proto", "vector"),
+            ("raft_service.proto", "raft_service"),
+            ("logproto.proto", "logproto"),
+        ],
     )?;
 
-    // build .proto files
-    {
-        let proto_file_paths = &[
-            proto_files_dir.join("kv_service.proto"),
-            proto_files_dir.join("vector_event.proto"),
-            proto_files_dir.join("raft_service.proto"),
-            proto_files_dir.join("logproto.proto"),
-        ];
-        let rust_mod_names = &[
-            "kv_service".to_string(),
-            "vector".to_string(),
-            "raft_service".to_string(),
-            "logproto".to_string(),
-        ];
+    let flatc_path = match env::var(ENV_FLATC_PATH) {
+        Ok(path) => {
+            println!("cargo:warning=Specified flatc path by environment {ENV_FLATC_PATH}={path}");
+            path
+        }
+        Err(_) => "flatc".to_string(),
+    };
 
-        // src/generated/protobuf_generated/
-        let output_dir_final = env::current_dir()
-            .unwrap()
-            .join("src")
-            .join("generated")
-            .join("protobuf_generated");
-        fs::create_dir_all(&output_dir_final)?;
-        let descriptor_set_path =
-            PathBuf::from(env::var("OUT_DIR").unwrap()).join("proto-descriptor.bin");
+    // build proto/*.fbs files to src/generated/flatbuffers_generated/
+    compile_flatbuffers_models(
+        &mut generated_mod_rs,
+        &flatc_path,
+        &proto_dir,
+        &rust_dir.join("generated").join("flatbuffers_generated"),
+        vec!["models"],
+    )?;
 
+    // build prompb/*.proto files to src/prompb/
+    compile_prometheus_models(&prompb_dir, &rust_dir.join("prompb"))?;
+
+    Ok(())
+}
+
+/// Compile *.proto files
+fn compile_protobuf_models<P: AsRef<Path>, S: AsRef<str>>(
+    generated_mod_rs: &mut fs::File,
+    in_proto_dir: P,
+    out_rust_dir: P,
+    proto_package_names: Vec<(S, S)>,
+) -> Result<(), AnyError> {
+    let version = protobuf_compiler_version()?;
+    let need_compile = match version.compare_ext(&VERSION_PROTOBUF) {
+        Ok(cmp::Ordering::Equal) => true,
+        Ok(_) => {
+            let version_err = Version::build_error_message(&version, &VERSION_PROTOBUF).unwrap();
+            println!("cargo:warning=Tool `protoc` {version_err}, skip compiling.");
+            false
+        }
+        Err(version_err) => {
+            return Err(format!("Tool `protoc` {version_err}, please update it.").into());
+        }
+    };
+
+    let proto_dir = in_proto_dir.as_ref();
+    let rust_dir = out_rust_dir.as_ref();
+    fs::create_dir_all(rust_dir)?;
+
+    let proto_file_paths = proto_package_names
+        .iter()
+        .map(|(proto, _package)| proto.as_ref().to_string())
+        .collect::<Vec<String>>();
+
+    let descriptor_set_path =
+        PathBuf::from(env::var(ENV_OUT_DIR).unwrap()).join("proto-descriptor.bin");
+
+    if need_compile {
         tonic_build::configure()
-            .out_dir(&output_dir_final)
+            .out_dir(rust_dir)
             .file_descriptor_set_path(descriptor_set_path)
             .protoc_arg("--experimental_allow_proto3_optional")
             .compile_well_known_types(true)
-            .compile(proto_file_paths, &[proto_files_dir.as_path()])
-            .expect("Failed to generate protobuf file {}.");
-        eprintln!("Generated protobuf files in {:?}", output_dir_final);
-
-        // src/generated/protobuf_generated/mod.rs
-        let mut protobuf_generated_mod_rs_file = fs::File::create(output_dir_final.join("mod.rs"))?;
-        for mod_name in rust_mod_names.iter() {
-            protobuf_generated_mod_rs_file.write_all(b"pub mod ")?;
-            protobuf_generated_mod_rs_file.write_all(mod_name.as_bytes())?;
-            protobuf_generated_mod_rs_file.write_all(b";\n")?;
-            protobuf_generated_mod_rs_file.flush()?;
-        }
+            .emit_rerun_if_changed(false)
+            .compile(&proto_file_paths, &[proto_dir])
+            .map_err(|e| format!("Failed to generate protobuf file: {e}."))?;
+        println!(
+            "cargo:warning=Generated protobuf files in {}",
+            rust_dir.display()
+        );
     }
 
-    // build prompb/**.proto files
-    {
-        let proto_file_paths = &[
-            prompb_proto_files_dir.join("types.proto"),
-            prompb_proto_files_dir.join("remote.proto"),
-        ];
-        let rust_mod_names = &["prometheus".to_string()];
-
-        // src/generated/protobuf_generated/
-        let output_dir_final = env::current_dir().unwrap().join("src").join("prompb");
-        fs::create_dir_all(&output_dir_final)?;
-        let descriptor_set_path =
-            PathBuf::from(env::var("OUT_DIR").unwrap()).join("proto-descriptor.bin");
-
-        tonic_build::configure()
-            .out_dir(&output_dir_final)
-            .file_descriptor_set_path(descriptor_set_path)
-            .compile_well_known_types(true)
-            .compile(proto_file_paths, &[prompb_proto_files_dir.as_path()])
-            .expect("Failed to generate protobuf file {}.");
-        eprintln!("Generated protobuf files in {:?}", output_dir_final);
-
-        // let output_file_path = output_dir_final.join("prometheus.rs");
-        // format_file(&output_file_path);
-
-        // src/prompb/mod.rs
-        let mut protobuf_generated_mod_rs_file = fs::File::create(output_dir_final.join("mod.rs"))?;
-        for mod_name in rust_mod_names.iter() {
-            protobuf_generated_mod_rs_file.write_all(b"pub mod ")?;
-            protobuf_generated_mod_rs_file.write_all(mod_name.as_bytes())?;
-            protobuf_generated_mod_rs_file.write_all(b";\n")?;
-            protobuf_generated_mod_rs_file.flush()?;
-        }
+    // $rust_dir/mod.rs
+    let mut sub_mod_rs = fs::File::create(rust_dir.join("mod.rs"))?;
+    for (_proto, package) in proto_package_names.iter() {
+        let mod_name = package.as_ref();
+        writeln!(&mut sub_mod_rs, "pub mod {mod_name};")?;
     }
+    sub_mod_rs.flush()?;
 
-    // build .fbs files
-    {
-        let fbs_file_paths = &[proto_files_dir.join("models.fbs")];
+    writeln!(generated_mod_rs)?;
+    writeln!(generated_mod_rs, "mod protobuf_generated;")?;
+    writeln!(generated_mod_rs, "pub use protobuf_generated::*;")?;
+    generated_mod_rs.flush()?;
 
-        // src/generated/flatbuffers_generated/
-        let output_dir_final = env::current_dir()
-            .unwrap()
-            .join("src")
-            .join("generated")
-            .join("flatbuffers_generated");
-        fs::create_dir_all(&output_dir_final)?;
+    Ok(())
+}
 
-        // src/generated/flatbuffers_generated/mod.rs
-        let mut flatbuffers_generated_mod_rs_file =
-            fs::File::create(output_dir_final.join("mod.rs"))?;
+/// Compile proto/**.fbs files.
+fn compile_flatbuffers_models<P: AsRef<Path>, S: AsRef<str>>(
+    generated_mod_rs: &mut fs::File,
+    flatc_path: &str,
+    in_fbs_dir: P,
+    out_rust_dir: P,
+    mod_names: Vec<S>,
+) -> Result<(), AnyError> {
+    let version = flatbuffers_compiler_version(flatc_path)?;
+    let need_compile = match version.compare_ext(&VERSION_FLATBUFFERS) {
+        Ok(cmp::Ordering::Equal) => true,
+        Ok(_) => {
+            let version_err = Version::build_error_message(&version, &VERSION_FLATBUFFERS).unwrap();
+            println!("cargo:warning=Tool `{flatc_path}` {version_err}, skip compiling.");
+            false
+        }
+        Err(version_err) => {
+            return Err(format!("Tool `{flatc_path}` {version_err}, please update it.").into());
+        }
+    };
 
-        // <flatbuffers_file_name>.fbs -> <flatbuffers_file_name>
-        for p in fbs_file_paths.iter() {
-            let output_rust_mod_name = p
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .split('.')
-                .collect::<Vec<&str>>()
-                .first()
-                .unwrap()
-                .to_string();
+    let fbs_dir = in_fbs_dir.as_ref();
+    let rust_dir = out_rust_dir.as_ref();
+    fs::create_dir_all(rust_dir)?;
 
-            // <flatbuffers_file_name> -> <flatbuffers_file_name>.rs
-            let output_file_name = output_rust_mod_name.clone() + ".rs";
+    // $rust_dir/mod.rs
+    let mut sub_mod_rs = fs::File::create(rust_dir.join("mod.rs"))?;
+    writeln!(generated_mod_rs)?;
+    writeln!(generated_mod_rs, "mod flatbuffers_generated;")?;
+    for mod_name in mod_names.iter() {
+        let mod_name = mod_name.as_ref();
+        writeln!(
+            generated_mod_rs,
+            "pub use flatbuffers_generated::{mod_name}::*;"
+        )?;
+        writeln!(&mut sub_mod_rs, "pub mod {mod_name};")?;
 
-            generated_mod_rs_file.write_all(b"pub use flatbuffers_generated::")?;
-            generated_mod_rs_file.write_all(output_rust_mod_name.as_bytes())?;
-            generated_mod_rs_file.write_all(b"::*;\n")?;
-            generated_mod_rs_file.flush()?;
-
-            flatbuffers_generated_mod_rs_file.write_all(b"pub mod ")?;
-            flatbuffers_generated_mod_rs_file.write_all(output_rust_mod_name.as_bytes())?;
-            flatbuffers_generated_mod_rs_file.write_all(b";\n")?;
-            flatbuffers_generated_mod_rs_file.flush()?;
-
-            let flatc_path = match env::var("FLATC_PATH") {
-                Ok(p) => {
-                    eprintln!(
-                        "Found specified flatc path in environment FLATC_PATH( {} )",
-                        &p
-                    );
-                    p
-                }
-                Err(_) => "flatc".to_string(),
-            };
-            let output = Command::new(&flatc_path)
+        if need_compile {
+            let fbs_file_path = fbs_dir.join(format!("{mod_name}.fbs"));
+            let output = Command::new(flatc_path)
                 .arg("-o")
-                .arg(&output_dir_final)
+                .arg(rust_dir)
                 .arg("--rust")
                 .arg("--gen-mutable")
                 .arg("--gen-onefile")
                 .arg("--gen-name-strings")
                 .arg("--filename-suffix")
                 .arg("")
-                .arg(p)
+                .arg(&fbs_file_path)
                 .output()
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "Failed to generate file '{}' by flatc(path: '{}'): {:?}.",
-                        output_file_name, flatc_path, e
-                    )
-                });
-
+                .map_err(|e| format!("Failed to execute process of flatc: {e}"))?;
             if !output.status.success() {
-                panic!("{}", String::from_utf8(output.stderr).unwrap());
+                return Err(format!(
+                    "Failed to generate file '{}' by flatc(path: '{flatc_path}'): {}.",
+                    fbs_file_path.display(),
+                    String::from_utf8_lossy(&output.stderr),
+                )
+                .into());
             }
-            eprintln!("Generated flatbuffers files in {:?}", output_dir_final);
+        }
+    }
+    println!(
+        "cargo:warning=Generated flatbuffers files in {}",
+        rust_dir.display()
+    );
+    generated_mod_rs.flush()?;
+    sub_mod_rs.flush()?;
+
+    Ok(())
+}
+
+/// Compile types.proto and remote.proto.
+fn compile_prometheus_models<P: AsRef<Path>>(
+    in_proto_dir: P,
+    out_rust_dir: P,
+) -> Result<(), AnyError> {
+    let proto_dir = in_proto_dir.as_ref();
+    let rust_dir = out_rust_dir.as_ref();
+    fs::create_dir_all(rust_dir)?;
+
+    let descriptor_set_path =
+        PathBuf::from(env::var(ENV_OUT_DIR).unwrap()).join("proto-descriptor.bin");
+
+    tonic_build::configure()
+        .out_dir(rust_dir)
+        .file_descriptor_set_path(descriptor_set_path)
+        .compile_well_known_types(true)
+        .emit_rerun_if_changed(false)
+        .compile(&["types.proto", "remote.proto"], &[proto_dir])
+        .map_err(|e| format!("Failed to generate protobuf file: {e}."))?;
+    println!(
+        "cargo:warning=Generated protobuf files in {}",
+        rust_dir.display()
+    );
+
+    // $rust_dir/mod.rs
+    let mut sub_mod_rs = fs::File::create(rust_dir.join("mod.rs"))?;
+    writeln!(&mut sub_mod_rs, "pub mod prometheus;")?;
+    sub_mod_rs.flush()?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Version(u32, u32, u32);
+
+impl Version {
+    fn try_get<F: FnOnce(&str) -> Result<String, String>>(
+        exe: String,
+        output_to_version_string: F,
+    ) -> Result<Self, String> {
+        let cmd = format!("{exe} --version");
+        let output = std::process::Command::new(exe)
+            .arg("--version")
+            .output()
+            .map_err(|e| format!("Failed to execute `{cmd}`: {e}",))?;
+        let output_utf8 = String::from_utf8(output.stdout).map_err(|e| {
+            let output_lossy = String::from_utf8_lossy(e.as_bytes());
+            format!("Command `{cmd}` returned invalid UTF-8('{output_lossy}'): {e}")
+        })?;
+        if output.status.success() {
+            let version_string = output_to_version_string(&output_utf8)?;
+            Ok(version_string.parse::<Self>()?)
+        } else {
+            Err(format!(
+                "Failed to get version by command `{cmd}`: {output_utf8}"
+            ))
         }
     }
 
-    Ok(())
+    fn build_error_message(version: &Self, expected: &Self) -> Option<String> {
+        match version.compare_major_version(expected) {
+            cmp::Ordering::Equal => None,
+            cmp::Ordering::Greater => Some(format!(
+                "version({version}) is greater than version({expected})"
+            )),
+            cmp::Ordering::Less => Some(format!(
+                "version({version}) is lesser than version({expected})"
+            )),
+        }
+    }
+
+    fn compare_ext(&self, expected_version: &Self) -> Result<cmp::Ordering, String> {
+        match env::var(ENV_BUILD_PROTOS) {
+            Ok(_build_protos) => match self.compare_major_version(expected_version) {
+                cmp::Ordering::Equal => Ok(cmp::Ordering::Equal),
+                _ => Err(Self::build_error_message(self, expected_version).unwrap()),
+            },
+            Err(_) => Ok(self.compare_major_version(expected_version)),
+        }
+    }
+
+    fn compare_major_version(&self, other: &Self) -> cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl std::str::FromStr for Version {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut version = [0_u32; 3];
+        for (i, v) in s.split('.').take(3).enumerate() {
+            version[i] = v
+                .parse()
+                .map_err(|e| format!("Failed to parse version string '{s}': {e}"))?;
+        }
+        Ok(Version(version[0], version[1], version[2]))
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.0, self.1, self.2)
+    }
+}
+
+/// Run command `flatc --version` to get the version of flatc.
+///
+/// ```ignore
+/// $ flatc --version
+/// flatc version 24.3.25
+/// ```
+fn flatbuffers_compiler_version(flatc_path: impl AsRef<Path>) -> Result<Version, String> {
+    let flatc_path = flatc_path.as_ref();
+    Version::try_get(format!("{}", flatc_path.display()), |output| {
+        const PREFIX_OF_VERSION: &str = "flatc version ";
+        let output = output.trim();
+        if let Some(version) = output.strip_prefix(PREFIX_OF_VERSION) {
+            Ok(version.to_string())
+        } else {
+            Err(format!("Failed to get flatc version: {output}"))
+        }
+    })
+}
+
+/// Run command `protoc --version` to get the version of flatc.
+///
+/// ```ignore
+/// $ protoc --version
+/// libprotoc 27.0
+/// ```
+fn protobuf_compiler_version() -> Result<Version, String> {
+    Version::try_get("protoc".to_string(), |output| {
+        const PREFIX_OF_VERSION: &str = "libprotoc ";
+        let output = output.trim();
+        if let Some(version) = output.strip_prefix(PREFIX_OF_VERSION) {
+            Ok(version.to_string())
+        } else {
+            Err(format!("Failed to get protoc version: {output}"))
+        }
+    })
 }

--- a/common/protos/rustfmt.toml
+++ b/common/protos/rustfmt.toml
@@ -1,7 +1,0 @@
-edition = "2021"
-
-# ignore dir
-ignore = [
-     "src/generated",
-     "src/prompb"
-]

--- a/common/protos/src/generated/mod.rs
+++ b/common/protos/src/generated/mod.rs
@@ -1,5 +1,6 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
+
 mod protobuf_generated;
 pub use protobuf_generated::*;
 

--- a/common/protos/src/lib.rs
+++ b/common/protos/src/lib.rs
@@ -9,13 +9,14 @@ use core::time;
 use std::fmt::{Display, Formatter};
 use std::time::Duration;
 
-use crate::kv_service::tskv_service_client::TskvServiceClient;
-use crate::models::{Column, Points, Table};
-use crate::raft_service::raft_service_client::RaftServiceClient;
 use flatbuffers::{ForwardsUOffset, Vector};
 use snafu::{Backtrace, Location, OptionExt, Snafu};
 use tonic::transport::{Channel, Endpoint};
 use tower::timeout::Timeout;
+
+use crate::kv_service::tskv_service_client::TskvServiceClient;
+use crate::models::{Column, Points, Table};
+use crate::raft_service::raft_service_client::RaftServiceClient;
 
 // Default 100 MB
 pub const DEFAULT_GRPC_SERVER_MESSAGE_LEN: usize = 100 * 1024 * 1024;
@@ -336,10 +337,11 @@ pub async fn tskv_service_ping(addr: &str) -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test"))]
 pub mod test {
-    use flatbuffers::FlatBufferBuilder;
     use std::collections::HashMap;
+
+    use flatbuffers::FlatBufferBuilder;
 
     use crate::models::{FieldType, Points};
     use crate::models_helper::create_const_points;

--- a/common/protos/src/lib.rs
+++ b/common/protos/src/lib.rs
@@ -337,7 +337,7 @@ pub async fn tskv_service_ping(addr: &str) -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(all(test, feature = "test"))]
+#[cfg(test)]
 pub mod test {
     use std::collections::HashMap;
 

--- a/common/protos/src/models_helper.rs
+++ b/common/protos/src/models_helper.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "test")]
 pub use test::*;
 
 pub fn print_points(points: crate::models::Points) {
@@ -42,8 +41,7 @@ where
     T::decode(bytes)
 }
 
-#[cfg(feature = "test")]
-pub mod test {
+mod test {
     use std::collections::HashMap;
 
     use chrono::prelude::*;

--- a/common/protos/src/models_helper.rs
+++ b/common/protos/src/models_helper.rs
@@ -44,9 +44,10 @@ where
 
 #[cfg(feature = "test")]
 pub mod test {
+    use std::collections::HashMap;
+
     use chrono::prelude::*;
     use flatbuffers::{self, WIPOffset};
-    use std::collections::HashMap;
     use utils::bitset::BitSet;
 
     use crate::models::*;

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -10,7 +10,7 @@ meta = { path = "../meta" }
 metrics = { path = "../common/metrics" }
 models = { path = "../common/models" }
 protocol_parser = { path = "../common/protocol_parser" }
-protos = { path = "../common/protos", features = ["test"] }
+protos = { path = "../common/protos" }
 replication = { path = "../replication" }
 trace = { path = "../common/trace" }
 tskv = { path = "../tskv" }

--- a/e2e_test/Cargo.toml
+++ b/e2e_test/Cargo.toml
@@ -11,8 +11,8 @@ http_protocol = { path = "../common/http_protocol", features = ["http_client"] }
 meta = { path = "../meta" }
 metrics = { path = "../common/metrics" }
 models = { path = "../common/models" }
+protos = { path = "../common/protos" }
 utils = { path = "../common/utils" }
-protos = { path = "../common/protos", features = ["test"] }
 
 arrow-flight = { workspace = true, features = ["flight-sql-experimental"] }
 arrow-schema = { workspace = true, optional = false }

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -15,7 +15,7 @@ error_code = { path = "../common/error_code" }
 limiter_bucket = { path = "../common/limiter_bucket" }
 metrics = { path = "../common/metrics" }
 models = { path = "../common/models" }
-protos = { path = "../common/protos", features = ["test"] }
+protos = { path = "../common/protos" }
 replication = { path = "../replication" }
 trace = { path = "../common/trace" }
 utils = { path = "../common/utils" }

--- a/replication/Cargo.toml
+++ b/replication/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [dependencies]
 config = { path = "../config" }
 models = { path = "../common/models" }
-protos = { path = "../common/protos", features = ["test"] }
+protos = { path = "../common/protos" }
 trace = { path = "../common/trace" }
 utils = { path = "../common/utils" }
 metrics = { path = "../common/metrics" }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,6 +3,8 @@ edition = "2021"
 # ignore dir
 ignore = [
      "docs",
+     "common/protos/src/generated",
+     "common/protos/src/prompb"
 ]
 
 group_imports = "StdExternalCrate"

--- a/tskv/Cargo.toml
+++ b/tskv/Cargo.toml
@@ -12,7 +12,7 @@ memory_pool = { path = "../common/memory_pool" }
 meta = { path = "../meta" }
 metrics = { path = "../common/metrics" }
 models = { path = "../common/models" }
-protos = { path = "../common/protos", features = ["test"] }
+protos = { path = "../common/protos" }
 replication = { path = "../replication" }
 trace = { path = "../common/trace" }
 utils = { path = "../common/utils" }


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

## Skip compiling protobuf&flatbuffers models if the protoc&flatc does not match expected version.

Only commands like `cargo check`, `cargo build` enabled this logical. But commands `make build`, `make build_release` is sensitive with the version of protoc&flatc.

## Only generated codes are ignored by rustfmt.

## Remove feature `test` from `common/protos`.

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

