### PR TITLE
feat(sqllogicaltests): add request type: HTTP for case http_metrics

### DIFF
--- a/query_server/sqllogicaltests/cases/sys_table/usage_schema/http_metrics.slt
+++ b/query_server/sqllogicaltests/cases/sys_table/usage_schema/http_metrics.slt
@@ -19,11 +19,15 @@ statement ok
 --#DATABASE = usage_schema
 
 sleep 8000ms
+
 query 
+--#HTTP
 DESCRIBE DATABASE usage_schema;
 ----
-"INF" 1 "1year" 1 "NS" "2 MiB" 16 "1 GiB" false false 32
+"ttl" "shard" "vnode_duration" "replica" "precision" "max_memcache_size" "memcache_partitions" "wal_max_file_size" "wal_sync" "strict_write" "max_cache_readers"
+"INF" "1" "1year" "1" "NS" "2 MiB" "16" "1 GiB" "false" "false" "32"
 
+sleep 10s
 
 query 
 select column_name, column_type, data_type from information_schema.columns
@@ -48,6 +52,13 @@ and database_name = 'usage_schema'
 and table_name = 'http_data_out'
 order by column_name;
 ----
+"api" "TAG" "STRING"
+"host" "TAG" "STRING"
+"node_id" "TAG" "STRING"
+"tenant" "TAG" "STRING"
+"time" "TIME" "TIMESTAMP(NANOSECOND)"
+"user" "TAG" "STRING"
+"value" "FIELD" "BIGINT UNSIGNED"
 
 
 query 
@@ -57,6 +68,13 @@ and database_name = 'usage_schema'
 and table_name = 'http_queries'
 order by column_name;
 ----
+"api" "TAG" "STRING"
+"host" "TAG" "STRING"
+"node_id" "TAG" "STRING"
+"tenant" "TAG" "STRING"
+"time" "TIME" "TIMESTAMP(NANOSECOND)"
+"user" "TAG" "STRING"
+"value" "FIELD" "BIGINT UNSIGNED"
 
 
 query 

--- a/query_server/sqllogicaltests/src/db_request.rs
+++ b/query_server/sqllogicaltests/src/db_request.rs
@@ -1,8 +1,6 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use arrow::datatypes::Schema;
-use arrow::record_batch::RecordBatch;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, tag_no_case};
 use nom::character::complete::{alpha1, alphanumeric1, none_of, space0};
@@ -13,14 +11,31 @@ use nom::IResult;
 
 use crate::error::SqlError;
 use crate::instance::{
-    run_lp_write, run_open_tsdb_json_write, run_open_tsdb_write, run_query, CreateOptions,
-    SqlClientOptions,
+    run_http_api_v1_sql, run_lp_write, run_open_tsdb_json_write, run_open_tsdb_write, run_query,
+    CnosDBColumnType, CreateOptions, SqlClientOptions,
 };
+use crate::utils::normalize;
 
 type Result<T, E = SqlError> = std::result::Result<T, E>;
 
+pub struct DBRequest {
+    protocol: Protocol,
+    body: RequestBody,
+}
+
+impl DBRequest {
+    pub fn new(protocol: Protocol, body: RequestBody) -> Self {
+        Self { protocol, body }
+    }
+}
+
+pub enum Protocol {
+    Default,
+    Http,
+}
+
 #[derive(Clone, Debug)]
-pub enum DBRequest {
+pub enum RequestBody {
     Sql(String),
     LineProtocol(String),
     OpenTSDBProtocol(String),
@@ -86,23 +101,23 @@ impl DBRequest {
             .filter(|l| !l.trim().is_empty())
             .collect::<Vec<_>>();
         let mut sql = vec![];
+        let mut protocol = Protocol::Default;
         for (i, line) in lines.iter().enumerate() {
             let line = *line;
             if instruction_match("LP_BEGIN", line) {
-                return Ok(DBRequest::LineProtocol(parse_block(
-                    &lines[i + 1..],
-                    "LP_END",
-                )?));
+                let block = parse_block(&lines[i + 1..], "LP_END")?;
+                return Ok(DBRequest::new(protocol, RequestBody::LineProtocol(block)));
             } else if instruction_match("OPENTSDB_BEGIN", line) {
-                return Ok(DBRequest::OpenTSDBProtocol(parse_block(
-                    &lines[i + 1..],
-                    "OPENTSDB_END",
-                )?));
+                let block = parse_block(&lines[i + 1..], "OPENTSDB_END")?;
+                return Ok(DBRequest::new(
+                    protocol,
+                    RequestBody::OpenTSDBProtocol(block),
+                ));
             } else if instruction_match("OPENTSDB_JSON_BEGIN", line) {
-                return Ok(DBRequest::OpenTSDBJson(parse_block(
-                    &lines[i + 1..],
-                    "OPENTSDB_JSON_END",
-                )?));
+                let block = parse_block(&lines[i + 1..], "OPENTSDB_JSON_END")?;
+                return Ok(DBRequest::new(protocol, RequestBody::OpenTSDBJson(block)));
+            } else if instruction_match("HTTP", line) {
+                protocol = Protocol::Http;
             } else if instruction_match("", line) {
                 options.parse_and_change(line)
             } else {
@@ -110,9 +125,9 @@ impl DBRequest {
             }
         }
         if sql.is_empty() {
-            Ok(DBRequest::Nothing)
+            Ok(DBRequest::new(protocol, RequestBody::Nothing))
         } else {
-            Ok(DBRequest::Sql(sql.join("\n")))
+            Ok(DBRequest::new(protocol, RequestBody::Sql(sql.join("\n"))))
         }
     }
 
@@ -121,40 +136,69 @@ impl DBRequest {
         options: &SqlClientOptions,
         create_option: &CreateOptions,
         path: &Path,
-    ) -> Result<(Schema, Vec<RecordBatch>)> {
-        match self {
-            DBRequest::Sql(sql) => {
-                println!("[{}] Execute Sql: \"{}\"", path.display(), sql);
-                Ok(run_query(options, create_option, sql).await?)
-            }
-            DBRequest::LineProtocol(lp) => {
+    ) -> Result<(Vec<CnosDBColumnType>, Vec<Vec<String>>)> {
+        match &self.body {
+            RequestBody::Sql(sql) => match self.protocol {
+                Protocol::Default => {
+                    self.execute_record_batch(options, create_option, path, sql)
+                        .await
+                }
+                Protocol::Http => self.execute_http(options, path, sql).await,
+            },
+            RequestBody::LineProtocol(lp) => {
                 println!("[{}] Execute LineProtocol: \"{}\"", path.display(), lp);
                 run_lp_write(options, lp).await?;
-                Ok((Schema::empty(), vec![]))
+                Ok((vec![], vec![]))
             }
-            DBRequest::OpenTSDBProtocol(open_tsdb) => {
+            RequestBody::OpenTSDBProtocol(open_tsdb) => {
                 println!(
                     "[{}] Execute OpenTSDBProtocol: \"{}\"",
                     path.display(),
                     open_tsdb
                 );
                 run_open_tsdb_write(options, open_tsdb).await?;
-                Ok((Schema::empty(), vec![]))
+                Ok((vec![], vec![]))
             }
-            DBRequest::OpenTSDBJson(open_tsdb_json) => {
+            RequestBody::OpenTSDBJson(open_tsdb_json) => {
                 println!(
                     "[{}] Execute OpenTSDBJsonProtocol: \"{}\"",
                     path.display(),
                     open_tsdb_json
                 );
                 run_open_tsdb_json_write(options, open_tsdb_json).await?;
-                Ok((Schema::empty(), vec![]))
+                Ok((vec![], vec![]))
             }
-            DBRequest::Nothing => {
+            RequestBody::Nothing => {
                 println!("[{}] Execute Nothing", path.display());
-                Ok((Schema::empty(), vec![]))
+                Ok((vec![], vec![]))
             }
         }
+    }
+
+    async fn execute_record_batch(
+        &self,
+        options: &SqlClientOptions,
+        create_option: &CreateOptions,
+        path: &Path,
+        sql: &str,
+    ) -> Result<(Vec<CnosDBColumnType>, Vec<Vec<String>>)> {
+        println!("[{}] Execute Sql (flight): \"{}\"", path.display(), sql);
+        let (schema, batches) = run_query(options, create_option, sql).await?;
+        let types = normalize::convert_schema_to_types(schema.fields());
+        let rows = normalize::convert_batches(batches)?;
+        Ok((types, rows))
+    }
+
+    async fn execute_http(
+        &self,
+        options: &SqlClientOptions,
+        path: &Path,
+        sql: &str,
+    ) -> Result<(Vec<CnosDBColumnType>, Vec<Vec<String>>)> {
+        println!("[{}] Execute Sql (http): \"{}\"", path.display(), sql);
+        let rows = run_http_api_v1_sql(options, sql).await?;
+        let cols_num = rows.first().map(|c| c.len()).unwrap_or(0);
+        Ok((vec![CnosDBColumnType::Text; cols_num], rows))
     }
 }
 


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

## What changed

Add instruction `--#HTTP` for query.

## Why do change

This commit aims to make sure the `sqllogicaltests/cases/sys_table/usage_schema/http_metrics.slt` always pass.

In a SQL logical test case, the **query** type communicates with the __Apache-Flight__ service of CnosDB server, while there are some test expect result sets that depend on serial past interactions with __HTTP__ service, such as:

```sql
query 
select column_name, column_type, data_type from information_schema.columns
where column_name != 'database'
and database_name = 'usage_schema'
and table_name = 'http_queries'
order by column_name;
 ----
"api" "TAG" "STRING"
"host" "TAG" "STRING"
"node_id" "TAG" "STRING"
"tenant" "TAG" "STRING"
"time" "TIME" "TIMESTAMP(NANOSECOND)"
"user" "TAG" "STRING"
"value" "FIELD" "BIGINT UNSIGNED"
```

## Example

### Query the HTTP service

HTTP API responses CSV format, the first line is the title. 

```sql
query 
--#HTTP
DESCRIBE DATABASE usage_schema;
----
"ttl" "shard" "vnode_duration" "replica" "precision" "max_memcache_size" "memcache_partitions" "wal_max_file_size" "wal_sync" "strict_write" "max_cache_readers"
"INF" "1" "1year" "1" "NS" "2 MiB" "16" "1 GiB" "false" "false" "32"
```

### Query the Apache-Flight service

Apache-Flight API responses RecordBatch format, There are not column-name in the expected results.

```sql
query 
DESCRIBE DATABASE usage_schema;
----
"INF" 1 "1year" 1 "NS" "2 MiB" 16 "1 GiB" false false 32
```

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

