### PR TITLE
Feature(error_code): procedural macro  `ErrorCoder`  generates extra const-methods

### DIFF
--- a/common/error_code/src/test.rs
+++ b/common/error_code/src/test.rs
@@ -20,12 +20,14 @@ enum TestError1 {
 
 #[test]
 fn test1() {
-    let a = TestError1::A1;
-    let b = TestError1::B1;
-    let c = TestError1::C1;
-    assert_eq!(a.code(), "000001");
-    assert_eq!(b.code(), "000002");
-    assert_eq!(c.code(), "000003");
+    assert_eq!(TestError1::A1.code(), "000001");
+    assert_eq!(TestError1::code_a_1(), "000001");
+
+    assert_eq!(TestError1::B1.code(), "000002");
+    assert_eq!(TestError1::code_b_1(), "000002");
+
+    assert_eq!(TestError1::C1.code(), "000003");
+    assert_eq!(TestError1::code_c_1(), "000003");
 }
 
 #[derive(ErrorCoder, Snafu, Debug)]
@@ -39,6 +41,8 @@ enum TestError2 {
 fn test2() {
     let a = TestError2::A2;
     assert_eq!(a.code(), "xx0000");
+    let b = TestError2::B2;
+    assert_eq!(b.code(), "xx0000");
 }
 
 #[derive(ErrorCoder, Snafu, Debug)]
@@ -54,10 +58,12 @@ enum TestError3 {
 #[test]
 fn test3() {
     let a = TestError3::A3;
+    assert_eq!(a.code(), "000001");
+    assert_eq!(TestError3::code_a_3(), "000001");
+
     let b = TestError3::B3 {
         source: std::io::Error::new(std::io::ErrorKind::AddrInUse, "test"),
     };
-    assert_eq!(a.code(), "000001");
     assert_eq!(b.code(), "000000");
 }
 
@@ -72,9 +78,9 @@ enum TestError4 {
 
 #[test]
 fn test4() {
-    let a = TestError4::A4;
-    let b = TestError4::B4;
+    assert_eq!(TestError4::A4.code(), "000002");
+    assert_eq!(TestError4::code_a_4(), "000002");
 
-    println!("{}", a.code());
-    println!("{}", b.code());
+    assert_eq!(TestError4::B4.code(), "000001");
+    assert_eq!(TestError4::code_b_4(), "000001");
 }

--- a/common/macros/src/error_code/mod.rs
+++ b/common/macros/src/error_code/mod.rs
@@ -1,7 +1,7 @@
 mod parse;
 
 use parse::{parse_error_code_enum, EnumInfo, FieldContainer};
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{Data, Fields, LitStr};
 
@@ -21,26 +21,29 @@ impl<'a> ToTokens for ErrorCodeImpl<'a> {
         let enum_name = &self.0.name;
         let mod_code = &self.0.mod_code;
 
-        let arms: Vec<_> = self
-            .0
-            .variants
-            .iter()
-            .map(|variant| {
-                let variant_name = &variant.name;
-                let arm = ErrorCodeMatchArm {
-                    field_container: variant,
-                    mod_code,
-                    pattern_ident: &quote! {#enum_name::#variant_name},
-                };
-                quote! { #arm }
-            })
-            .collect();
+        let mut match_arms = Vec::with_capacity(self.0.variants.len());
+        let mut get_error_code_methods = Vec::with_capacity(self.0.variants.len());
+        for variant in self.0.variants.iter() {
+            let variant_name = &variant.name;
+            let arm = ErrorCodeMatchArm {
+                field_container: variant,
+                mod_code,
+                pattern_ident: &quote! {#enum_name::#variant_name},
+            };
+            match_arms.push(quote! { #arm });
+            if variant.code.is_some() {
+                // If variant has #[error_code(code = 0)]
+                let method =
+                    GetErrorCodeMethod::new(&variant_name.to_string(), arm.normalized_code());
+                get_error_code_methods.push(quote! { #method });
+            }
+        }
 
         let gen = quote! {
             impl ErrorCode for #enum_name {
                 fn code(&self) -> &'static str {
                     match self {
-                        #(#arms),*
+                        #(#match_arms),*
                     }
                 }
                 fn message(&self) -> String {
@@ -48,7 +51,16 @@ impl<'a> ToTokens for ErrorCodeImpl<'a> {
                 }
             }
         };
-        tokens.extend(gen)
+        tokens.extend(gen);
+
+        if !match_arms.is_empty() {
+            let gen = quote! {
+                impl #enum_name {
+                    #(#get_error_code_methods)*
+                }
+            };
+            tokens.extend(gen);
+        }
     }
 }
 
@@ -58,33 +70,33 @@ struct ErrorCodeMatchArm<'a> {
     pattern_ident: &'a dyn ToTokens,
 }
 
-impl ToTokens for ErrorCodeMatchArm<'_> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let Self {
-            mod_code,
-            field_container,
-            pattern_ident,
-        } = *self;
-        let mut mod_code = mod_code.value();
-        // let source_type = field_container.source_type.as_ref();
-        let default_code = mod_code.clone() + &format!("{:04}", default_code());
+impl ErrorCodeMatchArm<'_> {
+    fn normalized_code(&self) -> String {
+        use std::fmt::Write;
 
-        let code = match field_container.code.as_ref() {
+        match self.field_container.code.as_ref() {
             Some(c) => {
                 let code: u64 = c.code_num.base10_parse().unwrap();
                 assert!(code > 0 && code < 10_000);
 
-                mod_code.push_str(&format!("{:04}", code));
-                let code = LitStr::new(&mod_code, Span::call_site());
-                quote! {#code}
+                let mut mod_code = self.mod_code.value();
+                write!(&mut mod_code, "{:04}", code).unwrap();
+                mod_code
             }
-
             None => {
-                quote! { #default_code }
+                format!("{}{:04}", self.mod_code.value(), default_code())
             }
-        };
+        }
+    }
+}
 
-        let match_arm = match field_container.fields {
+impl ToTokens for ErrorCodeMatchArm<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let code = LitStr::new(&self.normalized_code(), Span::call_site());
+        let code = quote! {#code};
+        let pattern_ident = self.pattern_ident;
+
+        let match_arm = match self.field_container.fields {
             Fields::Unit => {
                 quote! {
                     #pattern_ident => #code
@@ -105,6 +117,38 @@ impl ToTokens for ErrorCodeMatchArm<'_> {
     }
 }
 
+struct GetErrorCodeMethod {
+    method_name: Ident,
+    method_return: LitStr,
+}
+
+impl GetErrorCodeMethod {
+    fn new(variant_name: &str, code: String) -> GetErrorCodeMethod {
+        let normalized_name = format!("code_{}", camel_to_snake(variant_name));
+        GetErrorCodeMethod {
+            method_name: Ident::new(&normalized_name, Span::mixed_site()),
+            method_return: LitStr::new(&code, Span::mixed_site()),
+        }
+    }
+}
+
+impl ToTokens for GetErrorCodeMethod {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self {
+            method_name: normalized_name,
+            method_return: normalized_code,
+        } = self;
+        let method_name = quote! { #normalized_name };
+        let method_return = quote! { #normalized_code };
+        let get_error_code_token = quote! {
+            pub const fn #method_name() -> &'static str {
+                #method_return
+            }
+        };
+        tokens.extend(get_error_code_token);
+    }
+}
+
 fn impl_error_code_macro(ast: syn::DeriveInput) -> proc_macro::TokenStream {
     let syn::DeriveInput {
         ident, data, attrs, ..
@@ -120,8 +164,45 @@ fn impl_error_code_macro(ast: syn::DeriveInput) -> proc_macro::TokenStream {
     gen.into()
 }
 
-// #[proc_macro_derive(ErrorCoder, attributes(error_code))]
 pub fn error_code_derive_inner(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
     impl_error_code_macro(ast)
+}
+
+fn camel_to_snake(camel_name: &str) -> String {
+    let mut buf = String::with_capacity(camel_name.len());
+    let mut prev_is_number = false;
+    for (i, c) in camel_name.chars().enumerate() {
+        if c.is_alphabetic() {
+            if prev_is_number || (i != 0 && c.is_uppercase()) {
+                buf.push('_');
+            }
+            prev_is_number = false;
+        }
+        if c.is_numeric() {
+            if !prev_is_number {
+                buf.push('_');
+            }
+            prev_is_number = true;
+        }
+        buf.push(c);
+    }
+    buf.to_lowercase()
+}
+
+#[test]
+fn test_camel_to_snake() {
+    assert_eq!(camel_to_snake("HelloWorld"), "hello_world");
+    assert_eq!(camel_to_snake("HelloWorld"), "hello_world");
+    assert_eq!(camel_to_snake("Hello11World1"), "hello_11_world_1");
+    assert_eq!(camel_to_snake("H11W1"), "h_11_w_1");
+    assert_eq!(camel_to_snake("HW"), "h_w");
+    assert_eq!(camel_to_snake("hw"), "hw");
+    assert_eq!(camel_to_snake("HW1"), "h_w_1");
+    assert_eq!(camel_to_snake("hw1"), "hw_1");
+    assert_eq!(camel_to_snake("H"), "h");
+    assert_eq!(camel_to_snake("h"), "h");
+    assert_eq!(camel_to_snake("1H"), "_1_h");
+    assert_eq!(camel_to_snake("1h"), "_1_h");
+    assert_eq!(camel_to_snake("1"), "_1");
 }

--- a/tskv/src/tsm/page.rs
+++ b/tskv/src/tsm/page.rs
@@ -9,7 +9,7 @@ use utils::bitset::ImmutBitSet;
 use super::statistics::ValueStatistics;
 use crate::byte_utils::{decode_be_u32, decode_be_u64};
 use crate::error::{
-    DecodeSnafu, EncodeSnafu, TSMPageFileHashCheckFailedSnafu, TskvResult, TsmPageSnafu,
+    DecodeSnafu, EncodeSnafu, TskvResult, TsmPageFileHashCheckFailedSnafu, TsmPageSnafu,
     UnsupportedDataTypeSnafu,
 };
 use crate::tsm::codec::{
@@ -55,7 +55,7 @@ impl Page {
         let data_crc_calculated = hasher.finalize();
         if data_crc != data_crc_calculated {
             // If crc not match, try to return error.
-            return Err(TSMPageFileHashCheckFailedSnafu {
+            return Err(TsmPageFileHashCheckFailedSnafu {
                 crc: data_crc,
                 crc_calculated: data_crc_calculated,
                 page: Page { bytes, meta },


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

[//]: # (Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.)

Generate some const methods to get error code.

```rust
#[derive(Debug, Snafu, ErrorCoder)]
#[error_code(mod_code = "03")]
enum MyError {
    #[error_code(code = 1)]
    SomethingFailed,

    Io {
        source: std::io::Error,
    },
}

#[test]
fn test_my_error() {
    let my_custom_error = MyError:: SomethingFailed;
    assert_eq!(my_custom_error.code(), "030001"); // Get error code from instance.
    assert_eq!(MyError::code_something_failed(), "030001"); // Get error code from const value.

    let my_io_error = MyError::Io {
        source: std::io::Error::new(std::io::ErrorKind::AddrInUse, "test"),
    };
    assert_eq!(my_io_error.code(), "030000");
    // assert_eq!(MyError::code_io(), "030000"); // Will not generate for MyError::Io because it has no `#[error_code]`.
}
```

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

