### PR TITLE
fix: when both null and negative values are present, approx_percentil…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,7 +1708,7 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 [[package]]
 name = "datafusion"
 version = "27.0.0"
-source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#32a8decff7bac2a527eaf3eef829d85b988e9c0d"
+source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#6434749ffe55251f9f4415f2e96bbd64a1207802"
 dependencies = [
  "ahash 0.8.7",
  "arrow",
@@ -1756,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "27.0.0"
-source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#32a8decff7bac2a527eaf3eef829d85b988e9c0d"
+source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#6434749ffe55251f9f4415f2e96bbd64a1207802"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1771,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "27.0.0"
-source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#32a8decff7bac2a527eaf3eef829d85b988e9c0d"
+source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#6434749ffe55251f9f4415f2e96bbd64a1207802"
 dependencies = [
  "dashmap",
  "datafusion-common",
@@ -1788,7 +1788,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "27.0.0"
-source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#32a8decff7bac2a527eaf3eef829d85b988e9c0d"
+source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#6434749ffe55251f9f4415f2e96bbd64a1207802"
 dependencies = [
  "ahash 0.8.7",
  "arrow",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "27.0.0"
-source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#32a8decff7bac2a527eaf3eef829d85b988e9c0d"
+source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#6434749ffe55251f9f4415f2e96bbd64a1207802"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "27.0.0"
-source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#32a8decff7bac2a527eaf3eef829d85b988e9c0d"
+source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#6434749ffe55251f9f4415f2e96bbd64a1207802"
 dependencies = [
  "ahash 0.8.7",
  "arrow",
@@ -1851,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "27.0.0"
-source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#32a8decff7bac2a527eaf3eef829d85b988e9c0d"
+source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#6434749ffe55251f9f4415f2e96bbd64a1207802"
 dependencies = [
  "arrow",
  "chrono",
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-row"
 version = "27.0.0"
-source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#32a8decff7bac2a527eaf3eef829d85b988e9c0d"
+source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#6434749ffe55251f9f4415f2e96bbd64a1207802"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "27.0.0"
-source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#32a8decff7bac2a527eaf3eef829d85b988e9c0d"
+source = "git+https://github.com/cnosdb/arrow-datafusion.git?branch=27.0.0#6434749ffe55251f9f4415f2e96bbd64a1207802"
 dependencies = [
  "arrow",
  "arrow-schema",

--- a/query_server/sqllogicaltests/cases/function/common/approx_agg/approx_percentile_cont_with_weight.slt
+++ b/query_server/sqllogicaltests/cases/function/common/approx_agg/approx_percentile_cont_with_weight.slt
@@ -71,3 +71,24 @@ SELECT approx_percentile_cont_with_weight(temperature, -1.0, 0.5) AS approx_inva
 
 query error Arrow error: Io error: Status \{ code: Internal, message: "Build logical plan: Datafusion: Error during planning: The function ApproxPercentileContWithWeight does not accept 1 function arguments\.", metadata: MetadataMap \{ headers: \{"content\-type": "application/grpc", "date": "[^"]+", "content\-length": "0"\} \}, source: None \}
 select approx_percentile_cont_with_weight(null);
+
+statement ok
+drop table if exists air;
+
+statement ok
+CREATE TABLE air (
+id bigint,
+temperature double
+);
+
+statement ok
+INSERT INTO air (TIME, id, temperature) VALUES
+('1999-12-31 00:00:00.005', 6, NULL),
+('1999-12-31 00:00:00.006', 7, -5.0),
+('1999-12-31 00:00:00.007', 8, -10.0),
+('1999-12-31 00:00:00.008', 9, -2.5);
+
+query R
+SELECT approx_percentile_cont(temperature, 0.1, 100) AS approx_10th_percentile FROM air;
+----
+-10.0


### PR DESCRIPTION
…e_cont throws an error

# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #2259

# Rationale for this change

[//]: # (Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.)
cnosdb just submitted the test cases and the actual code changes are in https://github.com/cnosdb/arrow-datafusion/tree/27.0.0

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

