### PR TITLE
[Feature(LTS/2.3] Add cache maps auth to User with LRU and TTL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,6 +2997,7 @@ dependencies = [
  "http_protocol",
  "lazy_static",
  "libc",
+ "lru",
  "memory_pool",
  "meta",
  "metrics",

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -46,6 +46,7 @@ fly-accept-encoding = { workspace = true }
 futures = { workspace = true, default-features = false, features = ["alloc"] }
 lazy_static = { workspace = true }
 libc = { workspace = true }
+lru = { workspace = true }
 moka = { workspace = true }
 num_cpus = { workspace = true }
 once_cell = { workspace = true, features = ["parking_lot"] }

--- a/main/src/http/auth_cache.rs
+++ b/main/src/http/auth_cache.rs
@@ -1,0 +1,103 @@
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+
+#[derive(Clone)]
+struct CacheEntry<V> {
+    value: V,
+    expires_at: Option<Instant>,
+}
+
+impl<V> CacheEntry<V> {
+    fn new(value: V, ttl: Option<Duration>) -> Self {
+        let expires_at = ttl.map(|ttl| Instant::now() + ttl);
+        CacheEntry { value, expires_at }
+    }
+
+    fn is_expired(&self) -> bool {
+        self.expires_at
+            .map(|expires_at| expires_at <= Instant::now())
+            .unwrap_or(false)
+    }
+}
+
+pub struct AuthCache<K, V> {
+    ttl: Option<Duration>,
+    cache: Arc<Mutex<lru::LruCache<K, CacheEntry<V>>>>,
+}
+
+impl<K, V> AuthCache<K, V>
+where
+    K: Eq + std::hash::Hash,
+{
+    pub fn new(capacity: usize, ttl: Option<Duration>) -> Self {
+        let cache_cap = unsafe { NonZeroUsize::new_unchecked(capacity) };
+        AuthCache {
+            ttl,
+            cache: Arc::new(Mutex::new(lru::LruCache::new(cache_cap))),
+        }
+    }
+
+    pub fn insert(&self, key: K, value: V) {
+        self.cache.lock().put(key, CacheEntry::new(value, self.ttl));
+    }
+
+    pub fn get<Q>(&self, key: &Q) -> Option<V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+        V: Clone,
+    {
+        let mut cache = self.cache.lock();
+        if let Some(entry) = cache.get(key) {
+            if !entry.is_expired() {
+                return Some(entry.value.clone());
+            }
+        }
+        None
+    }
+
+    pub fn remove<Q>(&self, key: &Q)
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        let mut cache = self.cache.lock();
+        cache.pop(key);
+    }
+
+    pub fn clear(&self) {
+        let mut cache = self.cache.lock();
+        cache.clear();
+    }
+}
+
+#[test]
+fn test() {
+    let cache: AuthCache<&str, &str> = AuthCache::new(2, Some(Duration::from_secs(5)));
+
+    cache.insert("k1", "v1");
+    cache.insert("k2", "v2");
+    assert_eq!("v1", cache.get(&"k1").unwrap());
+    assert_eq!("v2", cache.get(&"k2").unwrap());
+    cache.remove(&"k2");
+    assert!(cache.get(&"k2").is_none());
+    assert_eq!("v1", cache.get(&"k1").unwrap());
+
+    std::thread::sleep(Duration::from_secs(3));
+
+    assert_eq!("v1", cache.get(&"k1").unwrap());
+    assert!(cache.get(&"k2").is_none());
+
+    std::thread::sleep(Duration::from_secs(3));
+
+    assert!(cache.get(&"k1").is_none());
+    assert!(cache.get(&"k2").is_none());
+
+    cache.insert("k1", "v1");
+    assert_eq!("v1", cache.get(&"k1").unwrap());
+    cache.clear();
+    assert!(cache.get(&"k1").is_none());
+}

--- a/main/src/http/header.rs
+++ b/main/src/http/header.rs
@@ -57,20 +57,7 @@ impl Header {
         self.content_encoding.as_deref()
     }
 
-    pub fn try_get_basic_auth(&self) -> Result<UserInfo, HttpError> {
-        let private_key = self
-            .private_key
-            .as_ref()
-            .map(|e| {
-                let content = base64::decode(e).map_err(|_| HttpError::InvalidHeader {
-                    reason: format!("Can not parse private_key with base64: {}", e),
-                })?;
-                String::from_utf8(content).map_err(|err| HttpError::InvalidHeader {
-                    reason: err.to_string(),
-                })
-            })
-            .transpose()?;
-
+    pub fn try_get_raw_basic_auth(&self) -> Result<&str, HttpError> {
         let auth = &self.authorization;
 
         let get_err = || {
@@ -89,7 +76,24 @@ impl Header {
             return get_err();
         }
 
-        let content_in_auth = &auth[BASIC_PREFIX.len()..];
+        Ok(&auth[BASIC_PREFIX.len()..])
+    }
+
+    pub fn try_get_basic_auth(&self) -> Result<UserInfo, HttpError> {
+        let private_key = self
+            .private_key
+            .as_ref()
+            .map(|e| {
+                let content = base64::decode(e).map_err(|_| HttpError::InvalidHeader {
+                    reason: format!("Can not parse private_key with base64: {}", e),
+                })?;
+                String::from_utf8(content).map_err(|err| HttpError::InvalidHeader {
+                    reason: err.to_string(),
+                })
+            })
+            .transpose()?;
+
+        let content_in_auth = self.try_get_raw_basic_auth()?;
 
         if let Ok(content) = base64::decode(content_in_auth) {
             if let Ok(str) = String::from_utf8(content) {
@@ -103,7 +107,9 @@ impl Header {
             }
         }
 
-        get_err()
+        Err(HttpError::ParseAuth {
+            reason: self.authorization.to_string(),
+        })
     }
 }
 

--- a/main/src/http/mod.rs
+++ b/main/src/http/mod.rs
@@ -11,6 +11,7 @@ use warp::{reject, Rejection};
 use self::response::ResponseBuilder;
 
 mod api_type;
+mod auth_cache;
 mod encoding;
 pub mod header;
 pub mod http_service;

--- a/query_server/query/src/auth/auth_control.rs
+++ b/query_server/query/src/auth/auth_control.rs
@@ -26,6 +26,7 @@ impl AccessControl for AccessControlImpl {
         let user_options = user.desc().options();
         if let Some(password) = user_options.password() {
             if password.eq(user_info.password.as_str()) {
+                // If the stored password is not encrypted (the same as the input), update it.
                 let new_user_option = UserOptionsBuilder::default()
                     .password(bcrypt_hash(password)?)
                     .build()
@@ -59,6 +60,7 @@ impl AccessControl for AccessControlImpl {
     }
 }
 
+/// Get user info without checking authorization.
 #[derive(Clone)]
 pub struct AccessControlNoCheck {
     meta_manager: MetaRef,


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

[//]: # (Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.)

Add cache that maps basic auth to checked `User` to improve the performance of write APIs.

### Before

| info | rows/sec |
| --- | --- |
| auth_enabled=false | 469545 |
| auth_enabled=true, with bcrypt verify | 106682 |
| auth_enabled=true, no bcrypt verify | 463695 |

### After

| info | rows/sec |
| --- | --- |
| auth_enabled=false | 471272 |
| auth_enabled=true, with bcrypt verify | 461941 |
| auth_enabled=true, no bcrypt verify | 489147 |


# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

