### PR TITLE
feat(query): allow exect_count with other aggregate functions

### DIFF
--- a/query_server/sqllogicaltests/cases/function/common/count.slt
+++ b/query_server/sqllogicaltests/cases/function/common/count.slt
@@ -131,8 +131,10 @@ select exact_count(pressure) from air;
 ----
 5
 
-query error Arrow error: Io error: Status \{ code: Internal, message: "Could not chunk result: .*", metadata: MetadataMap \{ headers: \{"content\-type": "application/grpc", "date": ".*", "content\-length": "0"\} \}, source: None \}
+query
 select exact_count(temperature),max(pressure) from air;
+----
+6 80.0
 
 statement ok
 drop table if exists air;


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

For SQL statement:

```sql
select exact_count(temperature),max(pressure) from air;
```

## Before

```plaintext
Arrow: Invalid argument error: number of columns(3) must match number of fields(2) in schema"
```

or

```plaintext
Datafusion: Internal error: Sum is not expected to receive the type Utf8. This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
```

## After

```csv
COUNT(air.temperature),MAX(air.pressure)
6,80.0
```

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

