### PR TITLE
Fix: build docker image for memcheck failed

### DIFF
--- a/.github/workflows/community-tag_docker_build_and_push.yml
+++ b/.github/workflows/community-tag_docker_build_and_push.yml
@@ -81,11 +81,13 @@ jobs:
             mv ./target/aarch64-unknown-linux-gnu/release/cnosdb-meta ./linux/arm64/cnosdb-meta
             mv ./target/x86_64-unknown-linux-gnu/release/cnosdb-meta ./linux/amd64/cnosdb-meta
           elif [[ "${{ matrix.version }}" = "memcheck" ]] && [[ "${{ matrix.image }}" = "cnosdb" ]]; then
-            RUSTFLAGS=-Zsanitizer=address cargo build --package main --package client --profile test-ci --target x86_64-unknown-linux-gnu
+            rustup toolchain install nightly-x86_64-unknown-linux-gnu
+            RUSTFLAGS=-Zsanitizer=address cargo +nightly build --package main --package client --profile test-ci --target x86_64-unknown-linux-gnu
             mv ./target/x86_64-unknown-linux-gnu/test-ci/cnosdb ./linux/amd64/cnosdb
             mv ./target/x86_64-unknown-linux-gnu/test-ci/cnosdb-cli ./linux/amd64/cnosdb-cli
           elif [[ "${{ matrix.version }}" = "memcheck" ]] && [[ "${{ matrix.image }}" = "cnosdb-meta" ]]; then
-            RUSTFLAGS=-Zsanitizer=address cargo build --package meta --profile test-ci --target x86_64-unknown-linux-gnu
+            rustup toolchain install nightly-x86_64-unknown-linux-gnu
+            RUSTFLAGS=-Zsanitizer=address cargo +nightly build --package meta --profile test-ci --target x86_64-unknown-linux-gnu
             mv ./target/x86_64-unknown-linux-gnu/test-ci/cnosdb-meta ./linux/amd64/cnosdb-meta
           fi
           make clean

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3808,6 +3808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6162,13 +6168,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
  "libc",
+ "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
@@ -6184,10 +6191,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 


### PR DESCRIPTION
# Required checklist
- [ ] Sample config files updated (`config`,`meta/config` and `default config`) 
- [ ] If there are user-facing changes, the documentation needs to be updated prior to approving the PR( [Link]() )
- [ ] If there are any breaking changes to public APIs, please add the `api change` label.
- [ ] Signed [CLA](https://cla-assistant.io/cnosdb/cnosdb) (if not already signed)

# Which issue does this PR close?

[//]: # (We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For -- example `Closes #123` indicates that this PR will close issue #123.)

Related #.

# Rationale for this change

Fix build failure of docker **memcheck**:

```log
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `/home/runner/.rustup/toolchains/1.76-x86_64-unknown-linux-gnu/bin/rustc - --crate-name ___ --print=file-names -Zsanitizer=address --target x86_64-unknown-linux-gnu --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg` (exit status: 1)
  --- stderr
  error: the option `Z` is only accepted on the nightly compiler

  help: consider switching to a nightly toolchain: `rustup default nightly`

  note: selecting a toolchain with `+toolchain` arguments require a rustup proxy; see <https://rust-lang.github.io/rustup/concepts/index.html>

  note: for more information about Rust's stability policy, see <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features>

  error: 1 nightly option were parsed
```

# Are there any user-facing changes?

[//]: # (There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.)

 

